### PR TITLE
Update odroidxu4-current to 6.6.155

### DIFF
--- a/patch/kernel/archive/odroidxu4-6.6/patch-6.6.151-152.patch
+++ b/patch/kernel/archive/odroidxu4-6.6/patch-6.6.151-152.patch
@@ -1,0 +1,7212 @@
+diff --git a/Documentation/devicetree/bindings/crypto/qcom,inline-crypto-engine.yaml b/Documentation/devicetree/bindings/crypto/qcom,inline-crypto-engine.yaml
+index 7da9aa82d8374e..69731ff62c6530 100644
+--- a/Documentation/devicetree/bindings/crypto/qcom,inline-crypto-engine.yaml
++++ b/Documentation/devicetree/bindings/crypto/qcom,inline-crypto-engine.yaml
+@@ -21,6 +21,16 @@ properties:
+     maxItems: 1
+ 
+   clocks:
++    minItems: 1
++    maxItems: 2
++
++  clock-names:
++    minItems: 1
++    items:
++      - const: core
++      - const: iface
++
++  power-domains:
+     maxItems: 1
+ 
+ required:
+@@ -38,6 +48,10 @@ examples:
+       compatible = "qcom,sm8550-inline-crypto-engine",
+                    "qcom,inline-crypto-engine";
+       reg = <0x01d88000 0x8000>;
+-      clocks = <&gcc GCC_UFS_PHY_ICE_CORE_CLK>;
++      clocks = <&gcc GCC_UFS_PHY_ICE_CORE_CLK>,
++               <&gcc GCC_UFS_PHY_AHB_CLK>;
++      clock-names = "core",
++                    "iface";
++      power-domains = <&gcc UFS_PHY_GDSC>;
+     };
+ ...
+diff --git a/Documentation/driver-api/driver-model/devres.rst b/Documentation/driver-api/driver-model/devres.rst
+index 8be086b3f8297a..3fe1711dd587c2 100644
+--- a/Documentation/driver-api/driver-model/devres.rst
++++ b/Documentation/driver-api/driver-model/devres.rst
+@@ -426,6 +426,7 @@ REGULATOR
+   devm_regulator_bulk_put()
+   devm_regulator_get()
+   devm_regulator_get_enable()
++  devm_regulator_get_enable_read_voltage()
+   devm_regulator_get_enable_optional()
+   devm_regulator_get_exclusive()
+   devm_regulator_get_optional()
+diff --git a/Makefile b/Makefile
+index 05c17f548757ae..13d82f5eefd264 100644
+--- a/Makefile
++++ b/Makefile
+@@ -1,7 +1,7 @@
+ # SPDX-License-Identifier: GPL-2.0
+ VERSION = 6
+ PATCHLEVEL = 6
+-SUBLEVEL = 151
++SUBLEVEL = 152
+ EXTRAVERSION =
+ NAME = Pinguïn Aangedreven
+ 
+diff --git a/arch/arm/boot/dts/broadcom/bcm-ns.dtsi b/arch/arm/boot/dts/broadcom/bcm-ns.dtsi
+index 88fda18af1f8e6..06acd72f9835a5 100644
+--- a/arch/arm/boot/dts/broadcom/bcm-ns.dtsi
++++ b/arch/arm/boot/dts/broadcom/bcm-ns.dtsi
+@@ -131,7 +131,7 @@
+ 
+ 			/* PCIe Controller 2 */
+ 			<0x00014000 0 &gic GIC_SPI 138 IRQ_TYPE_LEVEL_HIGH>,
+-			<0x00014000 1 &gic GIC_SPI 138 IRQ_TYPE_LEVEL_HIGH>,
++			<0x00014000 1 &gic GIC_SPI 139 IRQ_TYPE_LEVEL_HIGH>,
+ 			<0x00014000 2 &gic GIC_SPI 140 IRQ_TYPE_LEVEL_HIGH>,
+ 			<0x00014000 3 &gic GIC_SPI 141 IRQ_TYPE_LEVEL_HIGH>,
+ 			<0x00014000 4 &gic GIC_SPI 142 IRQ_TYPE_LEVEL_HIGH>,
+diff --git a/arch/arm/mach-npcm/platsmp.c b/arch/arm/mach-npcm/platsmp.c
+index 41891d3aa1247d..4c1fc9983746ce 100644
+--- a/arch/arm/mach-npcm/platsmp.c
++++ b/arch/arm/mach-npcm/platsmp.c
+@@ -32,6 +32,7 @@ static int npcm7xx_smp_boot_secondary(unsigned int cpu,
+ 		goto out;
+ 	}
+ 	gcr_base = of_iomap(gcr_np, 0);
++	of_node_put(gcr_np);
+ 	if (!gcr_base) {
+ 		pr_err("could not iomap gcr");
+ 		ret = -ENOMEM;
+@@ -60,6 +61,7 @@ static void __init npcm7xx_smp_prepare_cpus(unsigned int max_cpus)
+ 		return;
+ 	}
+ 	scu_base = of_iomap(scu_np, 0);
++	of_node_put(scu_np);
+ 	if (!scu_base) {
+ 		pr_err("could not iomap scu");
+ 		return;
+diff --git a/arch/s390/kvm/pci.c b/arch/s390/kvm/pci.c
+index 17fedfc7bb9904..d9fcbf41025e0c 100644
+--- a/arch/s390/kvm/pci.c
++++ b/arch/s390/kvm/pci.c
+@@ -167,7 +167,7 @@ static int kvm_zpci_set_airq(struct zpci_dev *zdev)
+ 	fib.fmt0.noi = airq_iv_end(zdev->aibv);
+ 	fib.fmt0.aibv = virt_to_phys(zdev->aibv->vector);
+ 	fib.fmt0.aibvo = 0;
+-	fib.fmt0.aisb = virt_to_phys(aift->sbv->vector + (zdev->aisb / 64) * 8);
++	fib.fmt0.aisb = virt_to_phys(aift->sbv->vector) + (zdev->aisb / 64) * 8;
+ 	fib.fmt0.aisbo = zdev->aisb & 63;
+ 	fib.gd = zdev->gisa;
+ 
+@@ -191,34 +191,54 @@ static int kvm_zpci_clear_airq(struct zpci_dev *zdev)
+ 	return cc ? -EIO : 0;
+ }
+ 
+-static inline void unaccount_mem(unsigned long nr_pages)
++static inline void unaccount_mem(struct kvm_zdev *kzdev, unsigned long nr_pages)
+ {
+-	struct user_struct *user = get_uid(current_user());
++	struct user_struct *user = kzdev->user_account;
++	struct mm_struct *mm_account = kzdev->mm_account;
+ 
+-	if (user)
++	if (user) {
+ 		atomic_long_sub(nr_pages, &user->locked_vm);
+-	if (current->mm)
+-		atomic64_sub(nr_pages, &current->mm->pinned_vm);
++		free_uid(user);
++		kzdev->user_account = NULL;
++	}
++
++	if (mm_account) {
++		atomic64_sub(nr_pages, &mm_account->pinned_vm);
++		mmdrop(mm_account);
++		kzdev->mm_account = NULL;
++	}
+ }
+ 
+-static inline int account_mem(unsigned long nr_pages)
++static inline int account_mem(struct kvm_zdev *kzdev, unsigned long nr_pages)
+ {
+ 	struct user_struct *user = get_uid(current_user());
+ 	unsigned long page_limit, cur_pages, new_pages;
++	int rc = 0;
+ 
+ 	page_limit = rlimit(RLIMIT_MEMLOCK) >> PAGE_SHIFT;
+ 
++	cur_pages = atomic_long_read(&user->locked_vm);
+ 	do {
+-		cur_pages = atomic_long_read(&user->locked_vm);
+ 		new_pages = cur_pages + nr_pages;
+-		if (new_pages > page_limit)
+-			return -ENOMEM;
+-	} while (atomic_long_cmpxchg(&user->locked_vm, cur_pages,
+-					new_pages) != cur_pages);
++		if (new_pages > page_limit) {
++			rc = -ENOMEM;
++			goto out;
++		}
++	} while (!atomic_long_try_cmpxchg(&user->locked_vm, &cur_pages, new_pages));
+ 
+-	atomic64_add(nr_pages, &current->mm->pinned_vm);
++	if (current->mm) {
++		mmgrab(current->mm);
++		atomic64_add(nr_pages, &current->mm->pinned_vm);
++	}
++
++	kzdev->user_account = user;
++	kzdev->mm_account = current->mm;
+ 
+ 	return 0;
++
++out:
++	free_uid(user);
++	return rc;
+ }
+ 
+ static int kvm_s390_pci_aif_enable(struct zpci_dev *zdev, struct zpci_fib *fib,
+@@ -295,14 +315,17 @@ static int kvm_s390_pci_aif_enable(struct zpci_dev *zdev, struct zpci_fib *fib,
+ 	}
+ 
+ 	/* Account for pinned pages, roll back on failure */
+-	if (account_mem(pcount))
++	rc = account_mem(zdev->kzdev, pcount);
++	if (rc)
+ 		goto unpin2;
+ 
+ 	/* AISB must be allocated before we can fill in GAITE */
+ 	mutex_lock(&aift->aift_lock);
+ 	bit = airq_iv_alloc_bit(aift->sbv);
+-	if (bit == -1UL)
++	if (bit == -1UL) {
++		rc = -ENOMEM;
+ 		goto unlock;
++	}
+ 	zdev->aisb = bit; /* store the summary bit number */
+ 	zdev->aibv = airq_iv_create(msi_vecs, AIRQ_IV_DATA |
+ 				    AIRQ_IV_BITLOCK |
+@@ -336,24 +359,39 @@ static int kvm_s390_pci_aif_enable(struct zpci_dev *zdev, struct zpci_fib *fib,
+ 	aift->kzdev[zdev->aisb] = zdev->kzdev;
+ 	spin_unlock_irq(&aift->gait_lock);
+ 
+-	/* Update guest FIB for re-issue */
+-	fib->fmt0.aisbo = zdev->aisb & 63;
+-	fib->fmt0.aisb = virt_to_phys(aift->sbv->vector + (zdev->aisb / 64) * 8);
+-	fib->fmt0.isc = gisc;
+-
+ 	/* Save some guest fib values in the host for later use */
+-	zdev->kzdev->fib.fmt0.isc = fib->fmt0.isc;
++	zdev->kzdev->fib.fmt0.isc = gisc;
+ 	zdev->kzdev->fib.fmt0.aibv = fib->fmt0.aibv;
+-	mutex_unlock(&aift->aift_lock);
+ 
+ 	/* Issue the clp to setup the irq now */
+ 	rc = kvm_zpci_set_airq(zdev);
+-	return rc;
++	if (!rc) {
++		mutex_unlock(&aift->aift_lock);
++		return rc;
++	}
++
++	/* Start cleanup */
++	zdev->kzdev->fib.fmt0.isc = 0;
++	zdev->kzdev->fib.fmt0.aibv = 0;
++
++	spin_lock_irq(&aift->gait_lock);
++	gaite->count--;
++	gaite->aisb = 0;
++	gaite->gisc = 0;
++	gaite->aisbo = 0;
++	gaite->gisa = 0;
++	aift->kzdev[zdev->aisb] = NULL;
++	spin_unlock_irq(&aift->gait_lock);
++
++	airq_iv_release(zdev->aibv);
++	zdev->aibv = NULL;
+ 
+ free_aisb:
+ 	airq_iv_free_bit(aift->sbv, zdev->aisb);
+ 	zdev->aisb = 0;
+ unlock:
++	if (pcount > 0)
++		unaccount_mem(zdev->kzdev, pcount);
+ 	mutex_unlock(&aift->aift_lock);
+ unpin2:
+ 	if (fib->fmt0.sum == 1)
+@@ -424,7 +462,7 @@ static int kvm_s390_pci_aif_disable(struct zpci_dev *zdev, bool force)
+ 		pcount++;
+ 	}
+ 	if (pcount > 0)
+-		unaccount_mem(pcount);
++		unaccount_mem(kzdev, pcount);
+ out:
+ 	mutex_unlock(&aift->aift_lock);
+ 
+diff --git a/arch/s390/kvm/pci.h b/arch/s390/kvm/pci.h
+index ff0972dd5e71dc..fdf8c7bf4ed082 100644
+--- a/arch/s390/kvm/pci.h
++++ b/arch/s390/kvm/pci.h
+@@ -22,6 +22,8 @@ struct kvm_zdev {
+ 	struct kvm *kvm;
+ 	struct zpci_fib fib;
+ 	struct list_head entry;
++	struct user_struct *user_account;
++	struct mm_struct *mm_account;
+ };
+ 
+ struct zpci_gaite {
+diff --git a/arch/x86/kvm/mmu/mmu.c b/arch/x86/kvm/mmu/mmu.c
+index 6c4b588d557fcf..50a8c5701084f1 100644
+--- a/arch/x86/kvm/mmu/mmu.c
++++ b/arch/x86/kvm/mmu/mmu.c
+@@ -2299,6 +2299,9 @@ static union kvm_mmu_page_role kvm_mmu_child_role(u64 *sptep, bool direct,
+ 	role.direct = direct;
+ 	role.passthrough = 0;
+ 
++	WARN_ON_ONCE(role.invalid);
++	role.invalid = 0;
++
+ 	/*
+ 	 * If the guest has 4-byte PTEs then that means it's using 32-bit,
+ 	 * 2-level, non-PAE paging. KVM shadows such guests with PAE paging
+diff --git a/drivers/ata/pata_sl82c105.c b/drivers/ata/pata_sl82c105.c
+index 93882e976ede45..2a5ce46af5a0ac 100644
+--- a/drivers/ata/pata_sl82c105.c
++++ b/drivers/ata/pata_sl82c105.c
+@@ -264,6 +264,7 @@ static struct ata_port_operations sl82c105_port_ops = {
+ static int sl82c105_bridge_revision(struct pci_dev *pdev)
+ {
+ 	struct pci_dev *bridge;
++	u8 revision;
+ 
+ 	/*
+ 	 * The bridge should be part of the same device, but function 0.
+@@ -285,8 +286,9 @@ static int sl82c105_bridge_revision(struct pci_dev *pdev)
+ 	/*
+ 	 * We need to find function 0's revision, not function 1
+ 	 */
++	revision = bridge->revision;
+ 	pci_dev_put(bridge);
+-	return bridge->revision;
++	return revision;
+ }
+ 
+ static void sl82c105_fixup(struct pci_dev *pdev)
+diff --git a/drivers/counter/microchip-tcb-capture.c b/drivers/counter/microchip-tcb-capture.c
+index 461f57f66631c3..fbd1afe178a366 100644
+--- a/drivers/counter/microchip-tcb-capture.c
++++ b/drivers/counter/microchip-tcb-capture.c
+@@ -309,7 +309,7 @@ static int mchp_tc_probe(struct platform_device *pdev)
+ 	char clk_name[7];
+ 	struct regmap *regmap;
+ 	struct clk *clk[3];
+-	int channel;
++	u32 channel;
+ 	int ret, i;
+ 
+ 	counter = devm_counter_alloc(&pdev->dev, sizeof(*priv));
+@@ -343,7 +343,7 @@ static int mchp_tc_probe(struct platform_device *pdev)
+ 
+ 		priv->channel[i] = channel;
+ 
+-		snprintf(clk_name, sizeof(clk_name), "t%d_clk", channel);
++		snprintf(clk_name, sizeof(clk_name), "t%u_clk", channel);
+ 
+ 		clk[i] = of_clk_get_by_name(np->parent, clk_name);
+ 		if (IS_ERR(clk[i])) {
+diff --git a/drivers/gpu/drm/amd/amdgpu/amdgpu_device.c b/drivers/gpu/drm/amd/amdgpu/amdgpu_device.c
+index 5eea14076a9292..8672838fb67cad 100644
+--- a/drivers/gpu/drm/amd/amdgpu/amdgpu_device.c
++++ b/drivers/gpu/drm/amd/amdgpu/amdgpu_device.c
+@@ -3977,6 +3977,8 @@ static void amdgpu_device_unmap_mmio(struct amdgpu_device *adev)
+ 
+ 	iounmap(adev->rmmio);
+ 	adev->rmmio = NULL;
++	if (adev->mman.aper_base_kaddr)
++		iounmap(adev->mman.aper_base_kaddr);
+ 	adev->mman.aper_base_kaddr = NULL;
+ 
+ 	/* Memory manager related */
+diff --git a/drivers/gpu/drm/amd/amdgpu/amdgpu_ttm.c b/drivers/gpu/drm/amd/amdgpu/amdgpu_ttm.c
+index 1499638182bc24..df23a77a07d639 100644
+--- a/drivers/gpu/drm/amd/amdgpu/amdgpu_ttm.c
++++ b/drivers/gpu/drm/amd/amdgpu/amdgpu_ttm.c
+@@ -1887,23 +1887,17 @@ int amdgpu_ttm_init(struct amdgpu_device *adev)
+ 	/* Change the size here instead of the init above so only lpfn is affected */
+ 	amdgpu_ttm_set_buffer_funcs_status(adev, false);
+ #ifdef CONFIG_64BIT
+-	if (adev->gmc.xgmi.connected_to_cpu) {
+-		void *kaddr = devm_memremap(adev->dev, adev->gmc.aper_base,
+-					    adev->gmc.visible_vram_size,
+-					    MEMREMAP_WB);
+-		if (IS_ERR(kaddr))
+-			return PTR_ERR(kaddr);
+-		adev->mman.aper_base_kaddr = (__force void __iomem *)kaddr;
+-	} else if (adev->gmc.is_app_apu) {
++#ifdef CONFIG_X86
++	if (adev->gmc.xgmi.connected_to_cpu)
++		adev->mman.aper_base_kaddr = ioremap_cache(adev->gmc.aper_base,
++				adev->gmc.visible_vram_size);
++	else if (adev->gmc.is_app_apu)
+ 		DRM_DEBUG_DRIVER(
+ 			"No need to ioremap when real vram size is 0\n");
+-	} else {
+-		adev->mman.aper_base_kaddr = devm_ioremap_wc(adev->dev,
+-							     adev->gmc.aper_base,
+-							     adev->gmc.visible_vram_size);
+-		if (!adev->mman.aper_base_kaddr)
+-			return -ENOMEM;
+-	}
++	else
++#endif
++		adev->mman.aper_base_kaddr = ioremap_wc(adev->gmc.aper_base,
++				adev->gmc.visible_vram_size);
+ #endif
+ 
+ 	/*
+@@ -2050,6 +2044,8 @@ int amdgpu_ttm_init(struct amdgpu_device *adev)
+  */
+ void amdgpu_ttm_fini(struct amdgpu_device *adev)
+ {
++	int idx;
++
+ 	if (!adev->mman.initialized)
+ 		return;
+ 
+@@ -2072,7 +2068,14 @@ void amdgpu_ttm_fini(struct amdgpu_device *adev)
+ 	amdgpu_ttm_fw_reserve_vram_fini(adev);
+ 	amdgpu_ttm_drv_reserve_vram_fini(adev);
+ 
+-	adev->mman.aper_base_kaddr = NULL;
++	if (drm_dev_enter(adev_to_drm(adev), &idx)) {
++
++		if (adev->mman.aper_base_kaddr)
++			iounmap(adev->mman.aper_base_kaddr);
++		adev->mman.aper_base_kaddr = NULL;
++
++		drm_dev_exit(idx);
++	}
+ 
+ 	amdgpu_vram_mgr_fini(adev);
+ 	amdgpu_gtt_mgr_fini(adev);
+diff --git a/drivers/gpu/drm/bridge/parade-ps8640.c b/drivers/gpu/drm/bridge/parade-ps8640.c
+index 14d4dcf239da83..61ea855e55d879 100644
+--- a/drivers/gpu/drm/bridge/parade-ps8640.c
++++ b/drivers/gpu/drm/bridge/parade-ps8640.c
+@@ -258,8 +258,14 @@ static ssize_t ps8640_aux_transfer_msg(struct drm_dp_aux *aux,
+ 	addr_len[PAGE0_SWAUX_LENGTH - base] = (len == 0) ? SWAUX_NO_PAYLOAD :
+ 					      ((len - 1) & SWAUX_LENGTH_MASK);
+ 
+-	regmap_bulk_write(map, PAGE0_SWAUX_ADDR_7_0, addr_len,
+-			  ARRAY_SIZE(addr_len));
++	ret = regmap_bulk_write(map, PAGE0_SWAUX_ADDR_7_0, addr_len,
++				ARRAY_SIZE(addr_len));
++	if (ret) {
++		DRM_DEV_ERROR(dev,
++			      "failed to write AUX address %#x, len %zu: %d\n",
++			      msg->address, len, ret);
++		return ret;
++	}
+ 
+ 	if (len && (request == DP_AUX_NATIVE_WRITE ||
+ 		    request == DP_AUX_I2C_WRITE)) {
+@@ -275,13 +281,22 @@ static ssize_t ps8640_aux_transfer_msg(struct drm_dp_aux *aux,
+ 		}
+ 	}
+ 
+-	regmap_write(map, PAGE0_SWAUX_CTRL, SWAUX_SEND);
++	ret = regmap_write(map, PAGE0_SWAUX_CTRL, SWAUX_SEND);
++	if (ret) {
++		DRM_DEV_ERROR(dev, "failed to start AUX transfer: %d\n", ret);
++		return ret;
++	}
+ 
+ 	/* Zero delay loop because i2c transactions are slow already */
+-	regmap_read_poll_timeout(map, PAGE0_SWAUX_CTRL, data,
+-				 !(data & SWAUX_SEND), 0, 50 * 1000);
++	ret = regmap_read_poll_timeout(map, PAGE0_SWAUX_CTRL, data,
++				       !(data & SWAUX_SEND), 0, 50 * 1000);
++	if (ret) {
++		DRM_DEV_ERROR(dev, "failed to complete AUX transfer: %d\n",
++			      ret);
++		return ret;
++	}
+ 
+-	regmap_read(map, PAGE0_SWAUX_STATUS, &data);
++	ret = regmap_read(map, PAGE0_SWAUX_STATUS, &data);
+ 	if (ret) {
+ 		DRM_DEV_ERROR(dev, "failed to read PAGE0_SWAUX_STATUS: %d\n",
+ 			      ret);
+diff --git a/drivers/hwmon/ads7828.c b/drivers/hwmon/ads7828.c
+index 809e830f52a6bf..b9ed146a24cc1a 100644
+--- a/drivers/hwmon/ads7828.c
++++ b/drivers/hwmon/ads7828.c
+@@ -108,12 +108,11 @@ static int ads7828_probe(struct i2c_client *client)
+ 	struct ads7828_data *data;
+ 	struct device *hwmon_dev;
+ 	unsigned int vref_mv = ADS7828_INT_VREF_MV;
+-	unsigned int vref_uv;
++	int vref_uv;
+ 	bool diff_input = false;
+ 	bool ext_vref = false;
+ 	unsigned int regval;
+ 	enum ads7828_chips chip;
+-	struct regulator *reg;
+ 
+ 	data = devm_kzalloc(dev, sizeof(struct ads7828_data), GFP_KERNEL);
+ 	if (!data)
+@@ -127,9 +126,11 @@ static int ads7828_probe(struct i2c_client *client)
+ 	} else if (dev->of_node) {
+ 		diff_input = of_property_read_bool(dev->of_node,
+ 						   "ti,differential-input");
+-		reg = devm_regulator_get_optional(dev, "vref");
+-		if (!IS_ERR(reg)) {
+-			vref_uv = regulator_get_voltage(reg);
++		vref_uv = devm_regulator_get_enable_read_voltage(dev, "vref");
++		if (vref_uv < 0) {
++			if (vref_uv != -ENODEV)
++				return vref_uv;
++		} else {
+ 			vref_mv = DIV_ROUND_CLOSEST(vref_uv, 1000);
+ 			if (vref_mv < ADS7828_EXT_VREF_MV_MIN ||
+ 			    vref_mv > ADS7828_EXT_VREF_MV_MAX)
+diff --git a/drivers/hwmon/corsair-psu.c b/drivers/hwmon/corsair-psu.c
+index 4ab73bcef1d125..61d1b22bc63ecb 100644
+--- a/drivers/hwmon/corsair-psu.c
++++ b/drivers/hwmon/corsair-psu.c
+@@ -709,7 +709,7 @@ static int vendor_show(struct seq_file *seqf, void *unused)
+ {
+ 	struct corsairpsu_data *priv = seqf->private;
+ 
+-	seq_printf(seqf, "%s\n", priv->vendor);
++	seq_printf(seqf, "%.*s\n", REPLY_SIZE, priv->vendor);
+ 
+ 	return 0;
+ }
+@@ -719,7 +719,7 @@ static int product_show(struct seq_file *seqf, void *unused)
+ {
+ 	struct corsairpsu_data *priv = seqf->private;
+ 
+-	seq_printf(seqf, "%s\n", priv->product);
++	seq_printf(seqf, "%.*s\n", REPLY_SIZE, priv->product);
+ 
+ 	return 0;
+ }
+diff --git a/drivers/hwmon/nzxt-smart2.c b/drivers/hwmon/nzxt-smart2.c
+index 5bbe6f3f8af48c..00c8d3bc3e3441 100644
+--- a/drivers/hwmon/nzxt-smart2.c
++++ b/drivers/hwmon/nzxt-smart2.c
+@@ -760,7 +760,11 @@ static int nzxt_smart2_hid_probe(struct hid_device *hdev,
+ 
+ 	hid_device_io_start(hdev);
+ 
+-	init_device(drvdata, UPDATE_INTERVAL_DEFAULT_MS);
++	ret = init_device(drvdata, UPDATE_INTERVAL_DEFAULT_MS);
++	if (ret) {
++		dev_err(&hdev->dev, "init_device failed: %d\n", ret);
++		goto out_hw_close;
++	}
+ 
+ 	drvdata->hwmon =
+ 		hwmon_device_register_with_info(&hdev->dev, "nzxtsmart2", drvdata,
+diff --git a/drivers/hwmon/pmbus/lm25066.c b/drivers/hwmon/pmbus/lm25066.c
+index 929fa6d34efdc5..8a94c4cfb5d197 100644
+--- a/drivers/hwmon/pmbus/lm25066.c
++++ b/drivers/hwmon/pmbus/lm25066.c
+@@ -14,10 +14,11 @@
+ #include <linux/slab.h>
+ #include <linux/i2c.h>
+ #include <linux/log2.h>
+-#include <linux/of_device.h>
++#include <linux/math.h>
++#include <linux/of.h>
+ #include "pmbus.h"
+ 
+-enum chips { lm25056, lm25066, lm5064, lm5066, lm5066i };
++enum chips { lm25056 = 1, lm25066, lm5064, lm5066, lm5066i };
+ 
+ #define LM25066_READ_VAUX		0xd0
+ #define LM25066_MFR_READ_IIN		0xd1
+@@ -468,8 +469,6 @@ static int lm25066_probe(struct i2c_client *client)
+ 	struct lm25066_data *data;
+ 	struct pmbus_driver_info *info;
+ 	const struct __coeff *coeff;
+-	const struct of_device_id *of_id;
+-	const struct i2c_device_id *i2c_id;
+ 
+ 	if (!i2c_check_functionality(client->adapter,
+ 				     I2C_FUNC_SMBUS_READ_BYTE_DATA))
+@@ -484,14 +483,8 @@ static int lm25066_probe(struct i2c_client *client)
+ 	if (config < 0)
+ 		return config;
+ 
+-	i2c_id = i2c_match_id(lm25066_id, client);
++	data->id = (enum chips)(unsigned long)i2c_get_match_data(client);
+ 
+-	of_id = of_match_device(lm25066_of_match, &client->dev);
+-	if (of_id && (unsigned long)of_id->data != i2c_id->driver_data)
+-		dev_notice(&client->dev, "Device mismatch: %s in device tree, %s detected\n",
+-			   of_id->name, i2c_id->name);
+-
+-	data->id = i2c_id->driver_data;
+ 	info = &data->info;
+ 
+ 	info->pages = 1;
+@@ -548,8 +541,8 @@ static int lm25066_probe(struct i2c_client *client)
+ 	if (of_property_read_u32(client->dev.of_node, "shunt-resistor-micro-ohms", &shunt))
+ 		shunt = 1000;
+ 
+-	info->m[PSC_CURRENT_IN] = info->m[PSC_CURRENT_IN] * shunt / 1000;
+-	info->m[PSC_POWER] = info->m[PSC_POWER] * shunt / 1000;
++	info->m[PSC_CURRENT_IN] = DIV_ROUND_CLOSEST_ULL((u64)info->m[PSC_CURRENT_IN] * shunt, 1000);
++	info->m[PSC_POWER] = DIV_ROUND_CLOSEST_ULL((u64)info->m[PSC_POWER] * shunt, 1000);
+ 
+ #if IS_ENABLED(CONFIG_SENSORS_LM25066_REGULATOR)
+ 	/* LM25056 doesn't support OPERATION */
+diff --git a/drivers/input/evdev.c b/drivers/input/evdev.c
+index 95f90699d2b17b..db014dae950018 100644
+--- a/drivers/input/evdev.c
++++ b/drivers/input/evdev.c
+@@ -21,6 +21,7 @@
+ #include <linux/init.h>
+ #include <linux/input/mt.h>
+ #include <linux/major.h>
++#include <linux/nospec.h>
+ #include <linux/device.h>
+ #include <linux/cdev.h>
+ #include "input-compat.h"
+@@ -67,8 +68,10 @@ static size_t evdev_get_mask_cnt(unsigned int type)
+ 		[EV_SND]	= SND_CNT,
+ 		[EV_FF]		= FF_CNT,
+ 	};
++	unsigned long mask = array_index_mask_nospec(type, EV_CNT);
+ 
+-	return (type < EV_CNT) ? counts[type] : 0;
++	/* Returns 0 for out-of-bounds types, including speculatively */
++	return counts[type & mask] & mask;
+ }
+ 
+ /* requires the buffer lock to be held */
+@@ -146,11 +149,11 @@ static void __evdev_queue_syn_dropped(struct evdev_client *client)
+ 	struct timespec64 ts = ktime_to_timespec64(ev_time[client->clk_type]);
+ 	struct input_event ev;
+ 
++	memset(&ev, 0, sizeof(ev));
+ 	ev.input_event_sec = ts.tv_sec;
+ 	ev.input_event_usec = ts.tv_nsec / NSEC_PER_USEC;
+ 	ev.type = EV_SYN;
+ 	ev.code = SYN_DROPPED;
+-	ev.value = 0;
+ 
+ 	client->buffer[client->head++] = ev;
+ 	client->head &= client->bufsize - 1;
+@@ -218,20 +221,20 @@ static void __pass_event(struct evdev_client *client,
+ 	client->head &= client->bufsize - 1;
+ 
+ 	if (unlikely(client->head == client->tail)) {
++		struct input_event ev;
++
++		memset(&ev, 0, sizeof(ev));
++		ev.input_event_sec = event->input_event_sec;
++		ev.input_event_usec = event->input_event_usec;
++		ev.type = EV_SYN;
++		ev.code = SYN_DROPPED;
++
+ 		/*
+ 		 * This effectively "drops" all unconsumed events, leaving
+ 		 * EV_SYN/SYN_DROPPED plus the newest event in the queue.
+ 		 */
+ 		client->tail = (client->head - 2) & (client->bufsize - 1);
+-
+-		client->buffer[client->tail] = (struct input_event) {
+-			.input_event_sec = event->input_event_sec,
+-			.input_event_usec = event->input_event_usec,
+-			.type = EV_SYN,
+-			.code = SYN_DROPPED,
+-			.value = 0,
+-		};
+-
++		client->buffer[client->tail] = ev;
+ 		client->packet_head = client->tail;
+ 	}
+ 
+@@ -253,6 +256,8 @@ static void evdev_pass_values(struct evdev_client *client,
+ 	if (client->revoked)
+ 		return;
+ 
++	memset(&event, 0, sizeof(event));
++
+ 	ts = ktime_to_timespec64(ev_time[client->clk_type]);
+ 	event.input_event_sec = ts.tv_sec;
+ 	event.input_event_usec = ts.tv_nsec / NSEC_PER_USEC;
+diff --git a/drivers/misc/fastrpc.c b/drivers/misc/fastrpc.c
+index 35e311dfa49d70..0a5ab9ea89d447 100644
+--- a/drivers/misc/fastrpc.c
++++ b/drivers/misc/fastrpc.c
+@@ -468,6 +468,7 @@ static void fastrpc_channel_ctx_free(struct kref *ref)
+ 
+ 	cctx = container_of(ref, struct fastrpc_channel_ctx, refcount);
+ 
++	idr_destroy(&cctx->ctx_idr);
+ 	kfree(cctx);
+ }
+ 
+@@ -1275,10 +1276,12 @@ bail:
+ 	}
+ 
+ 	if (err == -ERESTARTSYS) {
++		spin_lock(&fl->lock);
+ 		list_for_each_entry_safe(buf, b, &fl->mmaps, node) {
+ 			list_del(&buf->node);
+ 			list_add_tail(&buf->node, &fl->cctx->invoke_interrupted_mmaps);
+ 		}
++		spin_unlock(&fl->lock);
+ 	}
+ 
+ 	if (err)
+@@ -1644,7 +1647,7 @@ static int fastrpc_device_open(struct inode *inode, struct file *filp)
+ 		dev_err(&cctx->rpdev->dev, "No session available\n");
+ 		mutex_destroy(&fl->mutex);
+ 		kfree(fl);
+-
++		fastrpc_channel_ctx_put(cctx);
+ 		return -EBUSY;
+ 	}
+ 
+@@ -1872,9 +1875,6 @@ static int fastrpc_req_munmap_impl(struct fastrpc_user *fl, struct fastrpc_buf *
+ 				      &args[0]);
+ 	if (!err) {
+ 		dev_dbg(dev, "unmmap\tpt 0x%09lx OK\n", buf->raddr);
+-		spin_lock(&fl->lock);
+-		list_del(&buf->node);
+-		spin_unlock(&fl->lock);
+ 		fastrpc_buf_free(buf);
+ 	} else {
+ 		dev_err(dev, "unmmap\tpt 0x%09lx ERROR\n", buf->raddr);
+@@ -1888,6 +1888,7 @@ static int fastrpc_req_munmap(struct fastrpc_user *fl, char __user *argp)
+ 	struct fastrpc_buf *buf = NULL, *iter, *b;
+ 	struct fastrpc_req_munmap req;
+ 	struct device *dev = fl->sctx->dev;
++	int err;
+ 
+ 	if (copy_from_user(&req, argp, sizeof(req)))
+ 		return -EFAULT;
+@@ -1895,6 +1896,7 @@ static int fastrpc_req_munmap(struct fastrpc_user *fl, char __user *argp)
+ 	spin_lock(&fl->lock);
+ 	list_for_each_entry_safe(iter, b, &fl->mmaps, node) {
+ 		if ((iter->raddr == req.vaddrout) && (iter->size == req.size)) {
++			list_del(&iter->node);
+ 			buf = iter;
+ 			break;
+ 		}
+@@ -1907,7 +1909,14 @@ static int fastrpc_req_munmap(struct fastrpc_user *fl, char __user *argp)
+ 		return -EINVAL;
+ 	}
+ 
+-	return fastrpc_req_munmap_impl(fl, buf);
++	err = fastrpc_req_munmap_impl(fl, buf);
++	if (err) {
++		spin_lock(&fl->lock);
++		list_add_tail(&buf->node, &fl->mmaps);
++		spin_unlock(&fl->lock);
++	}
++
++	return err;
+ }
+ 
+ static int fastrpc_req_mmap(struct fastrpc_user *fl, char __user *argp)
+diff --git a/drivers/misc/mei/client.c b/drivers/misc/mei/client.c
+index 699fa2362ed4d7..133c36a353bde5 100644
+--- a/drivers/misc/mei/client.c
++++ b/drivers/misc/mei/client.c
+@@ -447,18 +447,24 @@ static void mei_io_tx_list_free_cl(struct list_head *head,
+ }
+ 
+ /**
+- * mei_io_list_free_fp - free cb from a list that matches file pointer
++ * mei_io_rd_list_free_fp - free cb from a rd_completed list that matches file pointer
+  *
+- * @head: io list
++ * @cl: host client
+  * @fp: file pointer (matching cb file object), may be NULL
+  */
+-static void mei_io_list_free_fp(struct list_head *head, const struct file *fp)
++static void mei_io_rd_list_free_fp(struct mei_cl *cl, const struct file *fp)
+ {
+ 	struct mei_cl_cb *cb, *next;
++	LIST_HEAD(cmpl_list);
+ 
+-	list_for_each_entry_safe(cb, next, head, list)
++	spin_lock(&cl->rd_completed_lock);
++	list_for_each_entry_safe(cb, next, &cl->rd_completed, list)
+ 		if (!fp || fp == cb->fp)
+-			mei_io_cb_free(cb);
++			list_move(&cb->list, &cmpl_list);
++	spin_unlock(&cl->rd_completed_lock);
++
++	list_for_each_entry_safe(cb, next, &cmpl_list, list)
++		mei_io_cb_free(cb);
+ }
+ 
+ /**
+@@ -587,9 +593,7 @@ int mei_cl_flush_queues(struct mei_cl *cl, const struct file *fp)
+ 		mei_io_list_flush_cl(&cl->dev->ctrl_rd_list, cl);
+ 		mei_cl_free_pending(cl);
+ 	}
+-	spin_lock(&cl->rd_completed_lock);
+-	mei_io_list_free_fp(&cl->rd_completed, fp);
+-	spin_unlock(&cl->rd_completed_lock);
++	mei_io_rd_list_free_fp(cl, fp);
+ 
+ 	return 0;
+ }
+@@ -1426,7 +1430,7 @@ void mei_cl_add_rd_completed(struct mei_cl *cl, struct mei_cl_cb *cb)
+ }
+ 
+ /**
+- * mei_cl_del_rd_completed - free read completed callback with lock
++ * mei_cl_del_rd_completed - unlink read completed callback with lock and free it
+  *
+  * @cl: host client
+  * @cb: callback block
+@@ -1435,8 +1439,9 @@ void mei_cl_add_rd_completed(struct mei_cl *cl, struct mei_cl_cb *cb)
+ void mei_cl_del_rd_completed(struct mei_cl *cl, struct mei_cl_cb *cb)
+ {
+ 	spin_lock(&cl->rd_completed_lock);
+-	mei_io_cb_free(cb);
++	list_del_init(&cb->list);
+ 	spin_unlock(&cl->rd_completed_lock);
++	mei_io_cb_free(cb);
+ }
+ 
+ /**
+diff --git a/drivers/net/bonding/bond_alb.c b/drivers/net/bonding/bond_alb.c
+index 7edf0fd58c3463..ce6a3a0a2e1537 100644
+--- a/drivers/net/bonding/bond_alb.c
++++ b/drivers/net/bonding/bond_alb.c
+@@ -1535,8 +1535,8 @@ void bond_alb_monitor(struct work_struct *work)
+ 	struct bonding *bond = container_of(work, struct bonding,
+ 					    alb_work.work);
+ 	struct alb_bond_info *bond_info = &(BOND_ALB_INFO(bond));
++	struct slave *slave, *curr;
+ 	struct list_head *iter;
+-	struct slave *slave;
+ 
+ 	if (!bond_has_slaves(bond)) {
+ 		atomic_set(&bond_info->tx_rebalance_counter, 0);
+@@ -1598,9 +1598,11 @@ void bond_alb_monitor(struct work_struct *work)
+ 			 * because a slave was disabled then
+ 			 * it can now leave promiscuous mode.
+ 			 */
+-			dev_set_promiscuity(rtnl_dereference(bond->curr_active_slave)->dev,
+-					    -1);
+-			bond_info->primary_is_promisc = 0;
++			curr = rtnl_dereference(bond->curr_active_slave);
++			if (bond_info->primary_is_promisc && curr) {
++				dev_set_promiscuity(curr->dev, -1);
++				bond_info->primary_is_promisc = 0;
++			}
+ 
+ 			rtnl_unlock();
+ 			rcu_read_lock();
+diff --git a/drivers/net/ethernet/aquantia/atlantic/aq_ring.c b/drivers/net/ethernet/aquantia/atlantic/aq_ring.c
+index 3f004d08307fb8..ec7654823f4ecc 100644
+--- a/drivers/net/ethernet/aquantia/atlantic/aq_ring.c
++++ b/drivers/net/ethernet/aquantia/atlantic/aq_ring.c
+@@ -336,6 +336,35 @@ out:
+ 	return !!budget;
+ }
+ 
++void aq_ring_tx_deinit(struct aq_ring_s *self)
++{
++	if (!self)
++		return;
++
++	for (; self->sw_head != self->sw_tail;
++		self->sw_head = aq_ring_next_dx(self, self->sw_head)) {
++		struct aq_ring_buff_s *buff = &self->buff_ring[self->sw_head];
++		struct device *ndev = aq_nic_get_dev(self->aq_nic);
++
++		if (buff->is_mapped) {
++			if (buff->is_sop) {
++				dma_unmap_single(ndev, buff->pa, buff->len,
++						 DMA_TO_DEVICE);
++			} else {
++				dma_unmap_page(ndev, buff->pa, buff->len,
++					       DMA_TO_DEVICE);
++			}
++		}
++
++		if (buff->is_eop) {
++			if (buff->skb)
++				dev_kfree_skb_any(buff->skb);
++			else if (buff->xdpf)
++				xdp_return_frame(buff->xdpf);
++		}
++	}
++}
++
+ static void aq_rx_checksum(struct aq_ring_s *self,
+ 			   struct aq_ring_buff_s *buff,
+ 			   struct sk_buff *skb)
+@@ -897,15 +926,29 @@ err_exit:
+ 
+ void aq_ring_rx_deinit(struct aq_ring_s *self)
+ {
+-	if (!self)
++	unsigned int i;
++
++	if (!self || !self->buff_ring)
+ 		return;
+ 
+-	for (; self->sw_head != self->sw_tail;
+-		self->sw_head = aq_ring_next_dx(self, self->sw_head)) {
+-		struct aq_ring_buff_s *buff = &self->buff_ring[self->sw_head];
++	/* Release every page still owned by the ring.
++	 *
++	 * Walking [sw_head, sw_tail) is not enough: refill is batched
++	 * (aq_ring_rx_fill() waits for AQ_CFG_RX_REFILL_THRES free slots),
++	 * so slots that were cleaned but not yet reposted accumulate in the
++	 * [sw_tail, sw_head) gap, and they keep their page for reuse. Walk
++	 * the whole ring and release whatever is left.
++	 */
++	for (i = 0; i < self->size; i++) {
++		struct aq_ring_buff_s *buff = &self->buff_ring[i];
++
++		if (!buff->rxdata.page)
++			continue;
+ 
+ 		aq_free_rxpage(&buff->rxdata, aq_nic_get_dev(self->aq_nic));
+ 	}
++
++	self->sw_head = self->sw_tail;
+ }
+ 
+ void aq_ring_free(struct aq_ring_s *self)
+diff --git a/drivers/net/ethernet/aquantia/atlantic/aq_ring.h b/drivers/net/ethernet/aquantia/atlantic/aq_ring.h
+index d627ace850ff54..67503c51267605 100644
+--- a/drivers/net/ethernet/aquantia/atlantic/aq_ring.h
++++ b/drivers/net/ethernet/aquantia/atlantic/aq_ring.h
+@@ -199,6 +199,7 @@ void aq_ring_update_queue_state(struct aq_ring_s *ring);
+ void aq_ring_queue_wake(struct aq_ring_s *ring);
+ void aq_ring_queue_stop(struct aq_ring_s *ring);
+ bool aq_ring_tx_clean(struct aq_ring_s *self);
++void aq_ring_tx_deinit(struct aq_ring_s *self);
+ int aq_xdp_xmit(struct net_device *dev, int num_frames,
+ 		struct xdp_frame **frames, u32 flags);
+ int aq_ring_rx_clean(struct aq_ring_s *self,
+diff --git a/drivers/net/ethernet/aquantia/atlantic/aq_vec.c b/drivers/net/ethernet/aquantia/atlantic/aq_vec.c
+index 9769ab4f9bef01..62b5967b6dcc66 100644
+--- a/drivers/net/ethernet/aquantia/atlantic/aq_vec.c
++++ b/drivers/net/ethernet/aquantia/atlantic/aq_vec.c
+@@ -275,7 +275,7 @@ void aq_vec_deinit(struct aq_vec_s *self)
+ 
+ 	for (i = 0U; self->tx_rings > i; ++i) {
+ 		ring = self->ring[i];
+-		aq_ring_tx_clean(&ring[AQ_VEC_TX_ID]);
++		aq_ring_tx_deinit(&ring[AQ_VEC_TX_ID]);
+ 		aq_ring_rx_deinit(&ring[AQ_VEC_RX_ID]);
+ 	}
+ 
+diff --git a/drivers/net/ethernet/broadcom/bnxt/bnxt.c b/drivers/net/ethernet/broadcom/bnxt/bnxt.c
+index afe700575f530d..e305b02b775e39 100644
+--- a/drivers/net/ethernet/broadcom/bnxt/bnxt.c
++++ b/drivers/net/ethernet/broadcom/bnxt/bnxt.c
+@@ -3715,7 +3715,17 @@ static int bnxt_init_one_rx_ring(struct bnxt *bp, int ring_nr)
+ 
+ 	if ((bp->flags & BNXT_FLAG_AGG_RINGS)) {
+ 		type = ((u32)BNXT_RX_PAGE_SIZE << RX_BD_LEN_SHIFT) |
+-			RX_BD_TYPE_RX_AGG_BD | RX_BD_FLAGS_SOP;
++			RX_BD_TYPE_RX_AGG_BD;
++
++		/* Disable EOP if TPA is enabled to prevent overlapping zero
++		 * padding with the next segment's data.  On P7_PLUS, EOP will
++		 * automatically disable Relaxed Ordering (RO) to prevent
++		 * potential data corruption (and may degrade performance).  On
++		 * older chips, RO will not be automatically disabled and may
++		 * cause corruption.
++		 */
++		if (!(bp->flags & BNXT_FLAG_TPA))
++			type |= RX_BD_FLAGS_AGG_EOP;
+ 
+ 		bnxt_init_rxbd_pages(ring, type);
+ 	}
+diff --git a/drivers/net/ethernet/broadcom/bnxt/bnxt.h b/drivers/net/ethernet/broadcom/bnxt/bnxt.h
+index bc1ff1085da7f6..739ed9d0b5ab5b 100644
+--- a/drivers/net/ethernet/broadcom/bnxt/bnxt.h
++++ b/drivers/net/ethernet/broadcom/bnxt/bnxt.h
+@@ -104,6 +104,7 @@ struct rx_bd {
+ 	 #define RX_BD_TYPE_48B_BD_SIZE				 (2 << 4)
+ 	 #define RX_BD_TYPE_64B_BD_SIZE				 (3 << 4)
+ 	#define RX_BD_FLAGS_SOP					(1 << 6)
++	#define RX_BD_FLAGS_AGG_EOP				(1 << 6)
+ 	#define RX_BD_FLAGS_EOP					(1 << 7)
+ 	#define RX_BD_FLAGS_BUFFERS				(3 << 8)
+ 	 #define RX_BD_FLAGS_1_BUFFER_PACKET			 (0 << 8)
+diff --git a/drivers/net/ethernet/broadcom/bnxt/bnxt_ptp.c b/drivers/net/ethernet/broadcom/bnxt/bnxt_ptp.c
+index 404b433f1bc08e..d8f39776481b6f 100644
+--- a/drivers/net/ethernet/broadcom/bnxt/bnxt_ptp.c
++++ b/drivers/net/ethernet/broadcom/bnxt/bnxt_ptp.c
+@@ -475,12 +475,15 @@ static int bnxt_ptp_enable(struct ptp_clock_info *ptp_info,
+ 		return rc;
+ 	case PTP_CLK_REQ_PPS:
+ 		/* Configure PHC PPS IN */
+-		rc = bnxt_ptp_cfg_pin(bp, 0, BNXT_PPS_PIN_PPS_IN);
++		pin_id = 0;
++		if (!on)
++			break;
++		rc = bnxt_ptp_cfg_pin(bp, pin_id, BNXT_PPS_PIN_PPS_IN);
+ 		if (rc)
+ 			return rc;
+ 		rc = bnxt_ptp_cfg_event(bp, BNXT_PPS_EVENT_INTERNAL);
+ 		if (!rc)
+-			ptp->pps_info.pins[0].event = BNXT_PPS_EVENT_INTERNAL;
++			ptp->pps_info.pins[pin_id].event = BNXT_PPS_EVENT_INTERNAL;
+ 		return rc;
+ 	default:
+ 		netdev_err(ptp->bp->dev, "Unrecognized PIN function\n");
+diff --git a/drivers/net/ethernet/freescale/fec_main.c b/drivers/net/ethernet/freescale/fec_main.c
+index 49297b83c3fdb8..ec7fe943e56828 100644
+--- a/drivers/net/ethernet/freescale/fec_main.c
++++ b/drivers/net/ethernet/freescale/fec_main.c
+@@ -3322,8 +3322,15 @@ static void fec_enet_free_buffers(struct net_device *ndev)
+ 
+ 	for (q = 0; q < fep->num_rx_queues; q++) {
+ 		rxq = fep->rx_queue[q];
+-		for (i = 0; i < rxq->bd.ring_size; i++)
+-			page_pool_put_full_page(rxq->page_pool, rxq->rx_skb_info[i].page, false);
++		for (i = 0; i < rxq->bd.ring_size; i++) {
++			struct page *page = rxq->rx_skb_info[i].page;
++
++			if (!page)
++				continue;
++
++			page_pool_put_full_page(rxq->page_pool, page, false);
++			rxq->rx_skb_info[i].page = NULL;
++		}
+ 
+ 		for (i = 0; i < XDP_STATS_TOTAL; i++)
+ 			rxq->stats[i] = 0;
+diff --git a/drivers/net/ethernet/hisilicon/hix5hd2_gmac.c b/drivers/net/ethernet/hisilicon/hix5hd2_gmac.c
+index 26d22bb04b8790..e8cedc2608654b 100644
+--- a/drivers/net/ethernet/hisilicon/hix5hd2_gmac.c
++++ b/drivers/net/ethernet/hisilicon/hix5hd2_gmac.c
+@@ -1287,7 +1287,6 @@ static int hix5hd2_dev_remove(struct platform_device *pdev)
+ 	struct net_device *ndev = platform_get_drvdata(pdev);
+ 	struct hix5hd2_priv *priv = netdev_priv(ndev);
+ 
+-	netif_napi_del(&priv->napi);
+ 	unregister_netdev(ndev);
+ 	mdiobus_unregister(priv->bus);
+ 	mdiobus_free(priv->bus);
+diff --git a/drivers/net/ethernet/marvell/octeontx2/nic/otx2_tc.c b/drivers/net/ethernet/marvell/octeontx2/nic/otx2_tc.c
+index 635cfb9a3e2c5f..1d1e5cea9395d3 100644
+--- a/drivers/net/ethernet/marvell/octeontx2/nic/otx2_tc.c
++++ b/drivers/net/ethernet/marvell/octeontx2/nic/otx2_tc.c
+@@ -72,10 +72,12 @@ static void otx2_get_egress_burst_cfg(struct otx2_nic *nic, u32 burst,
+ 	if (burst) {
+ 		*burst_exp = ilog2(burst) ? ilog2(burst) - 1 : 0;
+ 		tmp = burst - rounddown_pow_of_two(burst);
+-		if (burst < max_mantissa)
++		if (burst <= max_mantissa) {
+ 			*burst_mantissa = tmp * 2;
+-		else
++		} else {
++			WARN_ON(*burst_exp < 7);
+ 			*burst_mantissa = tmp / (1ULL << (*burst_exp - 7));
++		}
+ 	} else {
+ 		*burst_exp = MAX_BURST_EXPONENT;
+ 		*burst_mantissa = max_mantissa;
+diff --git a/drivers/net/ethernet/marvell/prestera/prestera_pci.c b/drivers/net/ethernet/marvell/prestera/prestera_pci.c
+index 35857dc19542f7..5db2c9e5e077df 100644
+--- a/drivers/net/ethernet/marvell/prestera/prestera_pci.c
++++ b/drivers/net/ethernet/marvell/prestera/prestera_pci.c
+@@ -684,6 +684,9 @@ static int prestera_fw_hdr_parse(struct prestera_fw *fw)
+ 	struct prestera_fw_header *hdr;
+ 	u32 magic;
+ 
++	if (fw->bin->size < sizeof(*hdr))
++		return -EINVAL;
++
+ 	hdr = (struct prestera_fw_header *)fw->bin->data;
+ 
+ 	magic = be32_to_cpu(hdr->magic_number);
+diff --git a/drivers/net/ethernet/mellanox/mlx5/core/diag/fw_tracer.c b/drivers/net/ethernet/mellanox/mlx5/core/diag/fw_tracer.c
+index 0a33ab5f53fd30..dba0d73ac37d52 100644
+--- a/drivers/net/ethernet/mellanox/mlx5/core/diag/fw_tracer.c
++++ b/drivers/net/ethernet/mellanox/mlx5/core/diag/fw_tracer.c
+@@ -1050,13 +1050,11 @@ struct mlx5_fw_tracer *mlx5_fw_tracer_create(struct mlx5_core_dev *dev)
+ 
+ 	tracer = kvzalloc(sizeof(*tracer), GFP_KERNEL);
+ 	if (!tracer)
+-		return ERR_PTR(-ENOMEM);
++		return NULL;
+ 
+ 	tracer->work_queue = create_singlethread_workqueue("mlx5_fw_tracer");
+-	if (!tracer->work_queue) {
+-		err = -ENOMEM;
++	if (!tracer->work_queue)
+ 		goto free_tracer;
+-	}
+ 
+ 	tracer->dev = dev;
+ 
+@@ -1098,7 +1096,7 @@ destroy_workqueue:
+ 	destroy_workqueue(tracer->work_queue);
+ free_tracer:
+ 	kvfree(tracer);
+-	return ERR_PTR(err);
++	return NULL;
+ }
+ 
+ static int fw_tracer_event(struct notifier_block *nb, unsigned long action, void *data);
+@@ -1109,7 +1107,7 @@ int mlx5_fw_tracer_init(struct mlx5_fw_tracer *tracer)
+ 	struct mlx5_core_dev *dev;
+ 	int err;
+ 
+-	if (IS_ERR_OR_NULL(tracer))
++	if (!tracer)
+ 		return 0;
+ 
+ 	if (!tracer->str_db.loaded)
+@@ -1159,7 +1157,7 @@ err_cancel_work:
+ /* Stop tracer + Cleanup HW resources */
+ void mlx5_fw_tracer_cleanup(struct mlx5_fw_tracer *tracer)
+ {
+-	if (IS_ERR_OR_NULL(tracer))
++	if (!tracer)
+ 		return;
+ 
+ 	mutex_lock(&tracer->state_lock);
+@@ -1188,7 +1186,7 @@ unlock:
+ /* Free software resources (Buffers, etc ..) */
+ void mlx5_fw_tracer_destroy(struct mlx5_fw_tracer *tracer)
+ {
+-	if (IS_ERR_OR_NULL(tracer))
++	if (!tracer)
+ 		return;
+ 
+ 	mlx5_core_dbg(tracer->dev, "FWTracer: Destroy\n");
+@@ -1240,7 +1238,7 @@ int mlx5_fw_tracer_reload(struct mlx5_fw_tracer *tracer)
+ 	struct mlx5_core_dev *dev;
+ 	int err;
+ 
+-	if (IS_ERR_OR_NULL(tracer))
++	if (!tracer)
+ 		return 0;
+ 
+ 	dev = tracer->dev;
+diff --git a/drivers/net/ethernet/mellanox/mlx5/core/en/tc_priv.h b/drivers/net/ethernet/mellanox/mlx5/core/en/tc_priv.h
+index 6cc23af66b5be0..a23d0df42f0278 100644
+--- a/drivers/net/ethernet/mellanox/mlx5/core/en/tc_priv.h
++++ b/drivers/net/ethernet/mellanox/mlx5/core/en/tc_priv.h
+@@ -30,6 +30,7 @@ enum {
+ 	MLX5E_TC_FLOW_FLAG_FAILED                = MLX5E_TC_FLOW_BASE + 9,
+ 	MLX5E_TC_FLOW_FLAG_SAMPLE                = MLX5E_TC_FLOW_BASE + 10,
+ 	MLX5E_TC_FLOW_FLAG_USE_ACT_STATS         = MLX5E_TC_FLOW_BASE + 11,
++	MLX5E_TC_FLOW_FLAG_PEER                  = MLX5E_TC_FLOW_BASE + 12,
+ };
+ 
+ struct mlx5e_tc_flow_parse_attr {
+diff --git a/drivers/net/ethernet/mellanox/mlx5/core/en_tc.c b/drivers/net/ethernet/mellanox/mlx5/core/en_tc.c
+index f1f42250573115..8c52bbeabb7e0c 100644
+--- a/drivers/net/ethernet/mellanox/mlx5/core/en_tc.c
++++ b/drivers/net/ethernet/mellanox/mlx5/core/en_tc.c
+@@ -2043,7 +2043,8 @@ static void mlx5e_tc_del_flow(struct mlx5e_priv *priv,
+ 	if (mlx5e_is_eswitch_flow(flow)) {
+ 		struct mlx5_devcom_comp_dev *devcom = flow->priv->mdev->priv.eswitch->devcom;
+ 
+-		if (!mlx5_devcom_for_each_peer_begin(devcom)) {
++		if (flow_flag_test(flow, PEER) ||
++		    !mlx5_devcom_for_each_peer_begin(devcom)) {
+ 			mlx5e_tc_del_fdb_flow(priv, flow);
+ 			return;
+ 		}
+@@ -4489,6 +4490,7 @@ static int mlx5e_tc_add_fdb_peer_flow(struct flow_cls_offload *f,
+ 	else
+ 		in_mdev = priv->mdev;
+ 
++	flow_flags |= BIT(MLX5E_TC_FLOW_FLAG_PEER);
+ 	parse_attr = flow->attr->parse_attr;
+ 	peer_flow = __mlx5e_add_fdb_flow(peer_priv, f, flow_flags,
+ 					 parse_attr->filter_dev,
+diff --git a/drivers/net/thunderbolt/main.c b/drivers/net/thunderbolt/main.c
+index 5d7d11d75b0b8f..ceaba08cd378ae 100644
+--- a/drivers/net/thunderbolt/main.c
++++ b/drivers/net/thunderbolt/main.c
+@@ -389,11 +389,16 @@ static void tbnet_tear_down(struct tbnet *net, bool send_logout)
+ 				break;
+ 		}
+ 
+-		tb_ring_stop(net->rx_ring.ring);
+-		tb_ring_stop(net->tx_ring.ring);
+-		tbnet_free_buffers(&net->rx_ring);
+-		tbnet_free_buffers(&net->tx_ring);
+-
++		/* Tear the paths down before stopping the rings.  This mirrors
++		 * tbnet_connected_work(), which enables the paths last so the
++		 * Rx ring is primed before packets can arrive.  Stopping a
++		 * ring zeroes its descriptor base and tbnet_free_buffers()
++		 * unmaps and frees the frame buffers, leaving anything still
++		 * in flight with nowhere to drain to;
++		 * __tb_path_deactivate_hop() then waits for the hop's
++		 * 'pending' bit, which on some host routers never clears in
++		 * that state.
++		 */
+ 		ret = tb_xdomain_disable_paths(net->xd,
+ 					       net->local_transmit_path,
+ 					       net->tx_ring.ring->hop,
+@@ -402,6 +407,11 @@ static void tbnet_tear_down(struct tbnet *net, bool send_logout)
+ 		if (ret)
+ 			netdev_warn(net->dev, "failed to disable DMA paths\n");
+ 
++		tb_ring_stop(net->rx_ring.ring);
++		tb_ring_stop(net->tx_ring.ring);
++		tbnet_free_buffers(&net->rx_ring);
++		tbnet_free_buffers(&net->tx_ring);
++
+ 		tb_xdomain_release_in_hopid(net->xd, net->remote_transmit_path);
+ 		net->remote_transmit_path = 0;
+ 	}
+@@ -928,12 +938,8 @@ static int tbnet_open(struct net_device *dev)
+ 
+ 	netif_carrier_off(dev);
+ 
+-	flags = RING_FLAG_FRAME;
+-	/* Only enable full E2E if the other end supports it too */
+-	if (tbnet_e2e && net->svc->prtcstns & TBNET_E2E)
+-		flags |= RING_FLAG_E2E;
+-
+-	ring = tb_ring_alloc_tx(xd->tb->nhi, -1, TBNET_RING_SIZE, flags);
++	ring = tb_ring_alloc_tx(xd->tb->nhi, -1, TBNET_RING_SIZE,
++				RING_FLAG_FRAME);
+ 	if (!ring) {
+ 		netdev_err(dev, "failed to allocate Tx ring\n");
+ 		return -ENOMEM;
+@@ -952,6 +958,11 @@ static int tbnet_open(struct net_device *dev)
+ 	sof_mask = BIT(TBIP_PDF_FRAME_START);
+ 	eof_mask = BIT(TBIP_PDF_FRAME_END);
+ 
++	flags = RING_FLAG_FRAME;
++	/* Only enable full E2E if the other end supports it too */
++	if (tbnet_e2e && net->svc->prtcstns & TBNET_E2E)
++		flags |= RING_FLAG_E2E;
++
+ 	ring = tb_ring_alloc_rx(xd->tb->nhi, -1, TBNET_RING_SIZE, flags,
+ 				net->tx_ring.ring->hop, sof_mask,
+ 				eof_mask, tbnet_start_poll, net);
+diff --git a/drivers/net/usb/ax88179_178a.c b/drivers/net/usb/ax88179_178a.c
+index 73de34179f3525..619093d3337320 100644
+--- a/drivers/net/usb/ax88179_178a.c
++++ b/drivers/net/usb/ax88179_178a.c
+@@ -1491,8 +1491,10 @@ ax88179_tx_fixup(struct usbnet *dev, struct sk_buff *skb, gfp_t flags)
+ 
+ 	headroom = skb_headroom(skb) - 8;
+ 
+-	if ((dev->net->features & NETIF_F_SG) && skb_linearize(skb))
++	if ((dev->net->features & NETIF_F_SG) && skb_linearize(skb)) {
++		dev_kfree_skb_any(skb);
+ 		return NULL;
++	}
+ 
+ 	if ((skb_header_cloned(skb) || headroom < 0) &&
+ 	    pskb_expand_head(skb, headroom < 0 ? 8 : 0, 0, GFP_ATOMIC)) {
+diff --git a/drivers/net/veth.c b/drivers/net/veth.c
+index d85a11e9477f04..e2fa5ba5a032c9 100644
+--- a/drivers/net/veth.c
++++ b/drivers/net/veth.c
+@@ -902,18 +902,24 @@ static struct sk_buff *veth_xdp_rcv_skb(struct veth_rq *rq,
+ 
+ 	skb_reset_mac_header(skb);
+ 
+-	/* check if bpf_xdp_adjust_tail was used */
+-	off = xdp->data_end - orig_data_end;
+-	if (off != 0)
+-		__skb_put(skb, off); /* positive on grow, negative on shrink */
+-
+ 	/* XDP frag metadata (e.g. nr_frags) are updated in eBPF helpers
+-	 * (e.g. bpf_xdp_adjust_tail), we need to update data_len here.
++	 * (e.g. bpf_xdp_adjust_tail). Remove the old fragment contribution
++	 * from skb->len before updating data_len, then add the new one back.
+ 	 */
+-	if (xdp_buff_has_frags(xdp))
++	skb->len -= skb->data_len;
++	if (xdp_buff_has_frags(xdp)) {
+ 		skb->data_len = skb_shinfo(skb)->xdp_frags_size;
+-	else
++		skb->len += skb->data_len;
++	} else {
+ 		skb->data_len = 0;
++	}
++
++	/* Synchronize the skb tail with XDP's updated linear area. */
++	off = xdp->data_end - orig_data_end;
++	if (off != 0) {
++		skb_set_tail_pointer(skb, xdp->data_end - xdp->data);
++		skb->len += off; /* positive on grow, negative on shrink */
++	}
+ 
+ 	skb->protocol = eth_type_trans(skb, rq->dev);
+ 
+diff --git a/drivers/net/vxlan/vxlan_core.c b/drivers/net/vxlan/vxlan_core.c
+index 0e9aeb03fcc73e..9d3546f95fa459 100644
+--- a/drivers/net/vxlan/vxlan_core.c
++++ b/drivers/net/vxlan/vxlan_core.c
+@@ -4338,7 +4338,7 @@ static int vxlan_changelink(struct net_device *dev, struct nlattr *tb[],
+ 	if (change_igmp && vxlan_addr_multicast(&dst->remote_ip))
+ 		err = vxlan_multicast_leave(vxlan);
+ 
+-	if (conf.age_interval != vxlan->cfg.age_interval)
++	if (netif_running(dev) && conf.age_interval != vxlan->cfg.age_interval)
+ 		mod_timer(&vxlan->age_timer, jiffies);
+ 
+ 	netdev_adjacent_change_commit(dst->remote_dev, lowerdev, dev);
+diff --git a/drivers/pinctrl/renesas/pinctrl-rzg2l.c b/drivers/pinctrl/renesas/pinctrl-rzg2l.c
+index ac629c72d59277..b713cc8e0fde8f 100644
+--- a/drivers/pinctrl/renesas/pinctrl-rzg2l.c
++++ b/drivers/pinctrl/renesas/pinctrl-rzg2l.c
+@@ -710,7 +710,7 @@ static int rzg2l_pinctrl_pinconf_set(struct pinctrl_dev *pctldev,
+ 		}
+ 
+ 		default:
+-			return -EOPNOTSUPP;
++			return -ENOTSUPP;
+ 		}
+ 	}
+ 
+@@ -759,7 +759,7 @@ static int rzg2l_pinctrl_pinconf_group_get(struct pinctrl_dev *pctldev,
+ 
+ 		/* Check config matching between to pin  */
+ 		if (i && prev_config != *config)
+-			return -EOPNOTSUPP;
++			return -ENOTSUPP;
+ 
+ 		prev_config = *config;
+ 	}
+diff --git a/drivers/ptp/ptp_ocp.c b/drivers/ptp/ptp_ocp.c
+index 4899fdf9bdf7a2..2d21699586ce7e 100644
+--- a/drivers/ptp/ptp_ocp.c
++++ b/drivers/ptp/ptp_ocp.c
+@@ -1671,9 +1671,11 @@ ptp_ocp_devlink_info_get(struct devlink *devlink, struct devlink_info_req *req,
+ 	if (err)
+ 		return err;
+ 
++	snprintf(buf, sizeof(buf), "%.*s", OCP_BOARD_ID_LEN,
++		 (const char *)bp->board_id);
+ 	err = devlink_info_version_fixed_put(req,
+ 			DEVLINK_INFO_VERSION_GENERIC_BOARD_ID,
+-			bp->board_id);
++			buf);
+ 	if (err)
+ 		return err;
+ 
+diff --git a/drivers/regulator/devres.c b/drivers/regulator/devres.c
+index 90bb0d178885af..7111c46e9de13f 100644
+--- a/drivers/regulator/devres.c
++++ b/drivers/regulator/devres.c
+@@ -145,6 +145,65 @@ struct regulator *devm_regulator_get_optional(struct device *dev,
+ }
+ EXPORT_SYMBOL_GPL(devm_regulator_get_optional);
+ 
++/**
++ * devm_regulator_get_enable_read_voltage - Resource managed regulator get and
++ *                                          enable that returns the voltage
++ * @dev: device to supply
++ * @id:  supply name or regulator ID.
++ *
++ * Get and enable regulator for duration of the device life-time.
++ * regulator_disable() and regulator_put() are automatically called on driver
++ * detach. See regulator_get_optional(), regulator_enable(), and
++ * regulator_get_voltage() for more information.
++ *
++ * This is a convenience function for supplies that provide a reference voltage
++ * where the consumer driver just needs to know the voltage and keep the
++ * regulator enabled.
++ *
++ * In cases where the supply is not strictly required, callers can check for
++ * -ENODEV error and handle it accordingly.
++ *
++ * Returns: voltage in microvolts on success, or an error code on failure.
++ */
++int devm_regulator_get_enable_read_voltage(struct device *dev, const char *id)
++{
++	struct regulator *r;
++	int ret;
++
++	/*
++	 * Since we need a real voltage, we use devm_regulator_get_optional()
++	 * rather than getting a dummy regulator with devm_regulator_get() and
++	 * then letting regulator_get_voltage() fail with -EINVAL. This way, the
++	 * caller can handle the -ENODEV error code if needed instead of the
++	 * ambiguous -EINVAL.
++	 */
++	r = devm_regulator_get_optional(dev, id);
++	if (IS_ERR(r))
++		return PTR_ERR(r);
++
++	ret = regulator_enable(r);
++	if (ret)
++		goto err_regulator_put;
++
++	ret = devm_add_action_or_reset(dev, regulator_action_disable, r);
++	if (ret)
++		goto err_regulator_put;
++
++	ret = regulator_get_voltage(r);
++	if (ret < 0)
++		goto err_release_action;
++
++	return ret;
++
++err_release_action:
++	devm_release_action(dev, regulator_action_disable, r);
++err_regulator_put:
++	devm_regulator_put(r);
++
++	return ret;
++}
++EXPORT_SYMBOL_GPL(devm_regulator_get_enable_read_voltage);
++
+ static int devm_regulator_match(struct device *dev, void *res, void *data)
+ {
+ 	struct regulator **r = res;
+diff --git a/drivers/s390/crypto/zcrypt_ccamisc.c b/drivers/s390/crypto/zcrypt_ccamisc.c
+index c3e3f3a3d8f960..b8526219ecebe3 100644
+--- a/drivers/s390/crypto/zcrypt_ccamisc.c
++++ b/drivers/s390/crypto/zcrypt_ccamisc.c
+@@ -946,7 +946,8 @@ static int _ip_cprb_helper(u16 cardnr, u16 domain,
+ 			   const u8 *clr_key_value,
+ 			   int clr_key_bit_size,
+ 			   u8 *key_token,
+-			   int *key_token_size)
++			   int *key_token_size,
++			   bool scrub)
+ {
+ 	int rc, n;
+ 	u8 *mem, *ptr;
+@@ -1087,7 +1088,7 @@ static int _ip_cprb_helper(u16 cardnr, u16 domain,
+ 	*key_token_size = t->len;
+ 
+ out:
+-	free_cprbmem(mem, PARMBSIZE, 0);
++	free_cprbmem(mem, PARMBSIZE, scrub);
+ 	return rc;
+ }
+ 
+@@ -1130,7 +1131,8 @@ int cca_clr2cipherkey(u16 card, u16 dom, u32 keybitsize, u32 keygenflags,
+ 	 * 4/4 COMPLETE the secure cipher key import
+ 	 */
+ 	rc = _ip_cprb_helper(card, dom, "AES     ", "FIRST   ", "MIN3PART",
+-			     exorbuf, keybitsize, token, &tokensize);
++			     exorbuf, keybitsize, token, &tokensize,
++			     true);
+ 	if (rc) {
+ 		DEBUG_ERR(
+ 			"%s clear key import 1/4 with CSNBKPI2 failed, rc=%d\n",
+@@ -1138,7 +1140,8 @@ int cca_clr2cipherkey(u16 card, u16 dom, u32 keybitsize, u32 keygenflags,
+ 		goto out;
+ 	}
+ 	rc = _ip_cprb_helper(card, dom, "AES     ", "ADD-PART", NULL,
+-			     clrkey, keybitsize, token, &tokensize);
++			     clrkey, keybitsize, token, &tokensize,
++			     true);
+ 	if (rc) {
+ 		DEBUG_ERR(
+ 			"%s clear key import 2/4 with CSNBKPI2 failed, rc=%d\n",
+@@ -1146,7 +1149,8 @@ int cca_clr2cipherkey(u16 card, u16 dom, u32 keybitsize, u32 keygenflags,
+ 		goto out;
+ 	}
+ 	rc = _ip_cprb_helper(card, dom, "AES     ", "ADD-PART", NULL,
+-			     exorbuf, keybitsize, token, &tokensize);
++			     exorbuf, keybitsize, token, &tokensize,
++			     true);
+ 	if (rc) {
+ 		DEBUG_ERR(
+ 			"%s clear key import 3/4 with CSNBKPI2 failed, rc=%d\n",
+@@ -1154,7 +1158,8 @@ int cca_clr2cipherkey(u16 card, u16 dom, u32 keybitsize, u32 keygenflags,
+ 		goto out;
+ 	}
+ 	rc = _ip_cprb_helper(card, dom, "AES     ", "COMPLETE", NULL,
+-			     NULL, keybitsize, token, &tokensize);
++			     NULL, keybitsize, token, &tokensize,
++			     true);
+ 	if (rc) {
+ 		DEBUG_ERR(
+ 			"%s clear key import 4/4 with CSNBKPI2 failed, rc=%d\n",
+@@ -1172,7 +1177,8 @@ int cca_clr2cipherkey(u16 card, u16 dom, u32 keybitsize, u32 keygenflags,
+ 	*keybufsize = tokensize;
+ 
+ out:
+-	kfree(token);
++	memzero_explicit(exorbuf, sizeof(exorbuf));
++	kfree_sensitive(token);
+ 	return rc;
+ }
+ EXPORT_SYMBOL(cca_clr2cipherkey);
+diff --git a/drivers/scsi/scsi_debug.c b/drivers/scsi/scsi_debug.c
+index 573bb3fcecd5c5..5d8561ec323b97 100644
+--- a/drivers/scsi/scsi_debug.c
++++ b/drivers/scsi/scsi_debug.c
+@@ -3077,8 +3077,8 @@ static bool comp_write_worker(struct sdeb_store_info *sip, u64 lba, u32 num,
+ 	if (!res)
+ 		return res;
+ 	if (rest)
+-		res = memcmp(fsp, arr + ((num - rest) * lb_size),
+-			     rest * lb_size);
++		res = !memcmp(fsp, arr + ((num - rest) * lb_size),
++			      rest * lb_size);
+ 	if (!res)
+ 		return res;
+ 	if (compare_only)
+diff --git a/drivers/spi/spi-fsl-dspi.c b/drivers/spi/spi-fsl-dspi.c
+index 3206c84c6f22fb..b7dc2add9114e5 100644
+--- a/drivers/spi/spi-fsl-dspi.c
++++ b/drivers/spi/spi-fsl-dspi.c
+@@ -751,8 +751,12 @@ static void dspi_setup_accel(struct fsl_dspi *dspi)
+ 	struct spi_transfer *xfer = dspi->cur_transfer;
+ 	bool odd = !!(dspi->len & 1);
+ 
+-	/* No accel for frames not multiple of 8 bits at the moment */
+-	if (xfer->bits_per_word % 8)
++	/*
++	 * No accel for DMA transfers or frames not multiples of 8 bits at the
++	 * moment.
++	 */
++	if (dspi->devtype_data->trans_mode == DSPI_DMA_MODE ||
++	    xfer->bits_per_word % 8)
+ 		goto no_accel;
+ 
+ 	if (!odd && dspi->len <= dspi->devtype_data->fifo_size * 2) {
+@@ -761,10 +765,7 @@ static void dspi_setup_accel(struct fsl_dspi *dspi)
+ 		dspi->oper_bits_per_word = 8;
+ 	} else {
+ 		/* Start off with maximum supported by hardware */
+-		if (dspi->devtype_data->trans_mode == DSPI_XSPI_MODE)
+-			dspi->oper_bits_per_word = 32;
+-		else
+-			dspi->oper_bits_per_word = 16;
++		dspi->oper_bits_per_word = 32;
+ 
+ 		/*
+ 		 * And go down only if the buffer can't be sent with
+diff --git a/drivers/staging/rtl8723bs/core/rtw_ieee80211.c b/drivers/staging/rtl8723bs/core/rtw_ieee80211.c
+index 95e4d29242249f..003946633633fc 100644
+--- a/drivers/staging/rtl8723bs/core/rtw_ieee80211.c
++++ b/drivers/staging/rtl8723bs/core/rtw_ieee80211.c
+@@ -371,6 +371,9 @@ unsigned char *rtw_get_wpa_ie(unsigned char *pie, int *wpa_ie_len, int limit)
+ 		pbuf = rtw_get_ie(pbuf, WLAN_EID_VENDOR_SPECIFIC, &len, limit_new);
+ 
+ 		if (pbuf) {
++			if (len < 6)
++				goto check_next_ie;
++
+ 			/* check if oui matches... */
+ 			if (memcmp((pbuf + 2), wpa_oui_type, sizeof(wpa_oui_type)))
+ 				goto check_next_ie;
+diff --git a/drivers/staging/rtl8723bs/core/rtw_mlme_ext.c b/drivers/staging/rtl8723bs/core/rtw_mlme_ext.c
+index f4c0fd703c5afc..98b46182afd637 100644
+--- a/drivers/staging/rtl8723bs/core/rtw_mlme_ext.c
++++ b/drivers/staging/rtl8723bs/core/rtw_mlme_ext.c
+@@ -905,7 +905,7 @@ unsigned int OnAuthClient(struct adapter *padapter, union recv_frame *precv_fram
+ 			p = rtw_get_ie(pframe + WLAN_HDR_A3_LEN + _AUTH_IE_OFFSET_, WLAN_EID_CHALLENGE, (int *)&len,
+ 				pkt_len - WLAN_HDR_A3_LEN - _AUTH_IE_OFFSET_);
+ 
+-			if (!p)
++			if (!p || len != WLAN_AUTH_CHALLENGE_LEN)
+ 				goto authclnt_fail;
+ 
+ 			memcpy((void *)(pmlmeinfo->chg_txt), (void *)(p + 2), len);
+diff --git a/drivers/staging/rtl8723bs/core/rtw_wlan_util.c b/drivers/staging/rtl8723bs/core/rtw_wlan_util.c
+index aba34053037833..3faf0da668c527 100644
+--- a/drivers/staging/rtl8723bs/core/rtw_wlan_util.c
++++ b/drivers/staging/rtl8723bs/core/rtw_wlan_util.c
+@@ -731,6 +731,9 @@ int WMM_param_handler(struct adapter *padapter, struct ndis_80211_var_ie *pIE)
+ 		return false;
+ 	}
+ 
++	if (pIE->length != WLAN_WMM_LEN)
++		return false;
++
+ 	if (!memcmp(&(pmlmeinfo->WMM_param), (pIE->data + 6), sizeof(struct WMM_para_element)))
+ 		return false;
+ 	else
+diff --git a/drivers/staging/rtl8723bs/os_dep/ioctl_cfg80211.c b/drivers/staging/rtl8723bs/os_dep/ioctl_cfg80211.c
+index 557b9c6513e14a..941d6b8406b60a 100644
+--- a/drivers/staging/rtl8723bs/os_dep/ioctl_cfg80211.c
++++ b/drivers/staging/rtl8723bs/os_dep/ioctl_cfg80211.c
+@@ -2043,6 +2043,8 @@ static netdev_tx_t rtw_cfg80211_monitor_if_xmit_entry(struct sk_buff *skb, struc
+ 
+ 	/* Skip the ratio tap header */
+ 	skb_pull(skb, rtap_len);
++	if (skb->len < dot11_hdr_len)
++		goto fail;
+ 
+ 	dot11_hdr = (struct ieee80211_hdr *)skb->data;
+ 	frame_control = le16_to_cpu(dot11_hdr->frame_control);
+@@ -2055,6 +2057,8 @@ static netdev_tx_t rtw_cfg80211_monitor_if_xmit_entry(struct sk_buff *skb, struc
+ 			qos_len = 2;
+ 		if ((frame_control & 0x0300) == 0x0300)
+ 			dot11_hdr_len += 6;
++		if (skb->len < dot11_hdr_len + qos_len + snap_len)
++			goto fail;
+ 
+ 		memcpy(dst_mac_addr, dot11_hdr->addr1, sizeof(dst_mac_addr));
+ 		memcpy(src_mac_addr, dot11_hdr->addr2, sizeof(src_mac_addr));
+diff --git a/drivers/thermal/thermal_hwmon.c b/drivers/thermal/thermal_hwmon.c
+index 0e0c4061792cc5..79a4de5f9f0e1a 100644
+--- a/drivers/thermal/thermal_hwmon.c
++++ b/drivers/thermal/thermal_hwmon.c
+@@ -218,7 +218,8 @@ int thermal_add_hwmon_sysfs(struct thermal_zone_device *tz)
+ 	if (new_hwmon_device)
+ 		hwmon_device_unregister(hwmon->device);
+  free_mem:
+-	kfree(hwmon);
++	if (new_hwmon_device)
++		kfree(hwmon);
+ 
+ 	return result;
+ }
+diff --git a/drivers/thunderbolt/eeprom.c b/drivers/thunderbolt/eeprom.c
+index eb241b270f790b..6e76c3432a9a2a 100644
+--- a/drivers/thunderbolt/eeprom.c
++++ b/drivers/thunderbolt/eeprom.c
+@@ -392,9 +392,16 @@ static int tb_drom_parse_entry_port(struct tb_switch *sw,
+ 			return -EIO;
+ 		}
+ 		port->link_nr = entry->link_nr;
+-		if (entry->has_dual_link_port)
++		if (entry->has_dual_link_port) {
++			if (entry->dual_link_port_nr > sw->config.max_port_number) {
++				tb_sw_warn(sw,
++					"port entry has invalid dual link port number %u\n",
++					entry->dual_link_port_nr);
++				return -EIO;
++			}
+ 			port->dual_link_port =
+ 				&port->sw->ports[entry->dual_link_port_nr];
++		}
+ 	}
+ 	return 0;
+ }
+diff --git a/drivers/thunderbolt/icm.c b/drivers/thunderbolt/icm.c
+index 623aa81a883371..c07fed6c117e2c 100644
+--- a/drivers/thunderbolt/icm.c
++++ b/drivers/thunderbolt/icm.c
+@@ -2291,7 +2291,7 @@ static int icm_usb4_switch_op(struct tb_switch *sw, u16 opcode, u32 *metadata,
+ 	if (tx_data_len) {
+ 		request.data_len_valid |= ICM_USB4_SWITCH_DATA_VALID;
+ 		if (tx_data_len < ARRAY_SIZE(request.data))
+-			request.data_len_valid =
++			request.data_len_valid |=
+ 				tx_data_len & ICM_USB4_SWITCH_DATA_LEN_MASK;
+ 		memcpy(request.data, tx_data, tx_data_len * sizeof(u32));
+ 	}
+diff --git a/drivers/tty/serial/8250/8250_dma.c b/drivers/tty/serial/8250/8250_dma.c
+index 745a7399c9597b..daf66b0a28553e 100644
+--- a/drivers/tty/serial/8250/8250_dma.c
++++ b/drivers/tty/serial/8250/8250_dma.c
+@@ -201,11 +201,12 @@ void serial8250_rx_dma_flush(struct uart_8250_port *p)
+ {
+ 	struct uart_8250_dma *dma = p->dma;
+ 
+-	if (dma->rx_running) {
+-		dmaengine_pause(dma->rxchan);
+-		__dma_rx_complete(p);
+-		dmaengine_terminate_async(dma->rxchan);
+-	}
++	if (!dma || !dma->rxchan || !dma->rx_running)
++		return;
++
++	dmaengine_pause(dma->rxchan);
++	__dma_rx_complete(p);
++	dmaengine_terminate_async(dma->rxchan);
+ }
+ EXPORT_SYMBOL_GPL(serial8250_rx_dma_flush);
+ 
+@@ -314,6 +315,7 @@ void serial8250_release_dma(struct uart_8250_port *p)
+ 
+ 	/* Release RX resources */
+ 	dmaengine_terminate_sync(dma->rxchan);
++	dma->rx_running = 0;
+ 	dma_free_coherent(dma->rxchan->device->dev, dma->rx_size, dma->rx_buf,
+ 			  dma->rx_addr);
+ 	dma_release_channel(dma->rxchan);
+diff --git a/drivers/tty/vt/keyboard.c b/drivers/tty/vt/keyboard.c
+index 18b3c197c1349b..5a4f2f67f08aa0 100644
+--- a/drivers/tty/vt/keyboard.c
++++ b/drivers/tty/vt/keyboard.c
+@@ -1405,7 +1405,7 @@ static void kbd_keycode(unsigned int keycode, int down, bool hw_raw)
+ 	struct keyboard_notifier_param param = { .vc = vc, .value = keycode, .down = down };
+ 	int rc;
+ 
+-	tty = vc->port.tty;
++	tty = tty_port_tty_get(&vc->port);
+ 
+ 	if (tty && (!tty->driver_data)) {
+ 		/* No driver data? Strange. Okay we fix it then. */
+@@ -1465,9 +1465,12 @@ static void kbd_keycode(unsigned int keycode, int down, bool hw_raw)
+ 		 * characters get aren't echoed locally. This makes key repeat
+ 		 * usable with slow applications and under heavy loads.
+ 		 */
++		tty_kref_put(tty);
+ 		return;
+ 	}
+ 
++	tty_kref_put(tty);
++
+ 	param.shift = shift_final = (shift_state | kbd->slockstate) ^ kbd->lockstate;
+ 	param.ledstate = kbd->ledflagstate;
+ 	key_map = key_maps[shift_final];
+diff --git a/drivers/tty/vt/vt_ioctl.c b/drivers/tty/vt/vt_ioctl.c
+index 5b21b60547da1f..e8abf4572dae2a 100644
+--- a/drivers/tty/vt/vt_ioctl.c
++++ b/drivers/tty/vt/vt_ioctl.c
+@@ -408,6 +408,8 @@ static int vt_k_ioctl(struct tty_struct *tty, unsigned int cmd,
+ 	/* this could be folded into KDSKBMODE, but for compatibility
+ 	   reasons it is not so easy to fold KDGKBMETA into KDGKBMODE */
+ 	case KDSKBMETA:
++		if (!perm)
++			return -EPERM;
+ 		return vt_do_kdskbmeta(console, arg);
+ 
+ 	case KDGKBMETA:
+diff --git a/drivers/usb/atm/cxacru.c b/drivers/usb/atm/cxacru.c
+index db9a8f2731f1a4..071d2a079f141b 100644
+--- a/drivers/usb/atm/cxacru.c
++++ b/drivers/usb/atm/cxacru.c
+@@ -700,6 +700,8 @@ static int cxacru_cm(struct cxacru_data *instance, enum cxacru_cm_request cm,
+ 	ret = offd;
+ 	usb_dbg(instance->usbatm, "cm %#x\n", cm);
+ fail:
++	if (ret < 0)
++		usb_kill_urb(instance->rcv_urb);
+ 	mutex_unlock(&instance->cm_serialize);
+ err:
+ 	return ret;
+diff --git a/drivers/usb/cdns3/cdnsp-gadget.c b/drivers/usb/cdns3/cdnsp-gadget.c
+index fb192b120d77fe..89d3d8167e5993 100644
+--- a/drivers/usb/cdns3/cdnsp-gadget.c
++++ b/drivers/usb/cdns3/cdnsp-gadget.c
+@@ -154,9 +154,9 @@ static void cdnsp_set_apb_timeout_value(struct cdnsp_device *pdev)
+ 	offset = cdnsp_find_next_ext_cap(base, offset, D_XEC_PRE_REGS_CAP);
+ 	reg = base + offset + REG_CHICKEN_BITS_3_OFFSET;
+ 
+-	val  = le32_to_cpu(readl(reg));
++	val  = readl(reg);
+ 	val = CHICKEN_APB_TIMEOUT_SET(val, cdns->override_apb_timeout);
+-	writel(cpu_to_le32(val), reg);
++	writel(val, reg);
+ }
+ 
+ static void cdnsp_set_chicken_bits_2(struct cdnsp_device *pdev, u32 bit)
+diff --git a/drivers/usb/gadget/function/f_ncm.c b/drivers/usb/gadget/function/f_ncm.c
+index 40e20a0ec47151..6535f3393e314d 100644
+--- a/drivers/usb/gadget/function/f_ncm.c
++++ b/drivers/usb/gadget/function/f_ncm.c
+@@ -1161,7 +1161,7 @@ static int ncm_unwrap_ntb(struct gether *port,
+ 	unsigned char	*ntb_ptr = skb->data;
+ 	__le16		*tmp;
+ 	unsigned	index, index2;
+-	int		ndp_index;
++	unsigned int	ndp_index;
+ 	unsigned	dg_len, dg_len2;
+ 	unsigned	ndp_len;
+ 	unsigned	block_len;
+diff --git a/drivers/vhost/vdpa.c b/drivers/vhost/vdpa.c
+index 3645d83f240d9d..5e2f7f44776797 100644
+--- a/drivers/vhost/vdpa.c
++++ b/drivers/vhost/vdpa.c
+@@ -998,6 +998,7 @@ static int vhost_vdpa_pa_map(struct vhost_vdpa *v,
+ 	unsigned int gup_flags = FOLL_LONGTERM;
+ 	unsigned long npages, cur_base, map_pfn, last_pfn = 0;
+ 	unsigned long lock_limit, sz2pin, nchunks, i;
++	unsigned long page_offset;
+ 	u64 start = iova;
+ 	long pinned;
+ 	int ret = 0;
+@@ -1010,7 +1011,13 @@ static int vhost_vdpa_pa_map(struct vhost_vdpa *v,
+ 	if (perm & VHOST_ACCESS_WO)
+ 		gup_flags |= FOLL_WRITE;
+ 
+-	npages = PFN_UP(size + (iova & ~PAGE_MASK));
++	page_offset = iova & ~PAGE_MASK;
++	if (size > ULONG_MAX - page_offset) {
++		ret = -EINVAL;
++		goto free;
++	}
++
++	npages = PFN_UP(size + page_offset);
+ 	if (!npages) {
+ 		ret = -EINVAL;
+ 		goto free;
+diff --git a/drivers/vhost/vhost.c b/drivers/vhost/vhost.c
+index 147cfb64bba2d5..fd8298490a31d1 100644
+--- a/drivers/vhost/vhost.c
++++ b/drivers/vhost/vhost.c
+@@ -1937,6 +1937,14 @@ static long vhost_vring_set_num_addr(struct vhost_dev *d,
+ 		BUG();
+ 	}
+ 
++	/*
++	 * The metadata cache holds the IOTLB mapping that backed the previous
++	 * desc/avail/used addresses and vring size, both of which are being
++	 * replaced here.  iotlb_access_ok() takes a cache hit as proof that the
++	 * region was validated, so the stale entries have to go.
++	 */
++	__vhost_vq_meta_reset(vq);
++
+ 	mutex_unlock(&vq->mutex);
+ 
+ 	return r;
+diff --git a/drivers/video/fbdev/core/bitblit.c b/drivers/video/fbdev/core/bitblit.c
+index ed853a2aec2fde..8b58f94ce44c53 100644
+--- a/drivers/video/fbdev/core/bitblit.c
++++ b/drivers/video/fbdev/core/bitblit.c
+@@ -274,9 +274,14 @@ static void bit_cursor(struct vc_data *vc, struct fb_info *info, int mode,
+ 	if (!vc->vc_font.data)
+ 		return;
+ 
+- 	c = scr_readw((u16 *) vc->vc_pos);
++	c = scr_readw((u16 *) vc->vc_pos);
+ 	attribute = get_attribute(info, c);
+-	src = vc->vc_font.data + ((c & charmask) * (w * vc->vc_font.height));
++	c &= charmask;
++
++	/* Clamp to font size, same as bit_putcs_aligned() */
++	if (c >= vc->vc_font.charcount)
++		c = 0;
++	src = vc->vc_font.data + (c * (w * vc->vc_font.height));
+ 
+ 	if (par->cursor_state.image.data != src ||
+ 	    par->cursor_reset) {
+diff --git a/fs/btrfs/inode.c b/fs/btrfs/inode.c
+index b1e2b3f732ccec..e843531201bef4 100644
+--- a/fs/btrfs/inode.c
++++ b/fs/btrfs/inode.c
+@@ -10640,6 +10640,7 @@ out_pages:
+ 	}
+ 	kvfree(pages);
+ out:
++	extent_changeset_free(data_reserved);
+ 	if (ret >= 0)
+ 		iocb->ki_pos += encoded->len;
+ 	return ret;
+diff --git a/fs/crypto/fscrypt_private.h b/fs/crypto/fscrypt_private.h
+index 14b26036055e40..8be25746fd72ee 100644
+--- a/fs/crypto/fscrypt_private.h
++++ b/fs/crypto/fscrypt_private.h
+@@ -422,6 +422,19 @@ fscrypt_is_key_prepared(struct fscrypt_prepared_key *prep_key,
+ 
+ /* keyring.c */
+ 
++/*
++ * fscrypt_master_key_user - a user's claim to a master key
++ */
++struct fscrypt_master_key_user {
++	struct list_head link;
++	kuid_t uid;
++	/*
++	 * This 'struct key' contains no secret.  It exists solely to charge the
++	 * appropriate user's key quota.
++	 */
++	struct key *quota_key;
++};
++
+ /*
+  * fscrypt_master_key_secret - secret key material of an in-use master key
+  */
+@@ -506,19 +519,18 @@ struct fscrypt_master_key {
+ 	struct fscrypt_key_specifier		mk_spec;
+ 
+ 	/*
+-	 * Keyring which contains a key of type 'key_type_fscrypt_user' for each
+-	 * user who has added this key.  Normally each key will be added by just
+-	 * one user, but it's possible that multiple users share a key, and in
+-	 * that case we need to keep track of those users so that one user can't
+-	 * remove the key before the others want it removed too.
++	 * List of user claims to this key (struct fscrypt_master_key_user).
++	 * Normally each key will be added by just one user, but it's possible
++	 * that multiple users share a key, and in that case we need to keep
++	 * track of those users so that one user can't remove the key before the
++	 * others want it removed too.
+ 	 *
+-	 * This is NULL for v1 policy keys; those can only be added by root.
++	 * Used only for v2 policy keys.  v1 policy keys can be added only by
++	 * root, so user tracking doesn't apply to them.
+ 	 *
+-	 * Locking: protected by ->mk_sem.  (We don't just rely on the keyrings
+-	 * subsystem semaphore ->mk_users->sem, as we need support for atomic
+-	 * search+insert along with proper synchronization with ->mk_secret.)
++	 * Locking: protected by ->mk_sem.
+ 	 */
+-	struct key		*mk_users;
++	struct list_head	mk_users;
+ 
+ 	/*
+ 	 * List of inodes that were unlocked using this key.  This allows the
+diff --git a/fs/crypto/keyring.c b/fs/crypto/keyring.c
+index 7cbb1fd872acca..f2a0d89d5f5e1e 100644
+--- a/fs/crypto/keyring.c
++++ b/fs/crypto/keyring.c
+@@ -64,18 +64,19 @@ static void fscrypt_free_master_key(struct rcu_head *head)
+ 	kfree_sensitive(mk);
+ }
+ 
++static void clear_mk_users(struct fscrypt_master_key *mk);
++
+ void fscrypt_put_master_key(struct fscrypt_master_key *mk)
+ {
+ 	if (!refcount_dec_and_test(&mk->mk_struct_refs))
+ 		return;
+ 	/*
+-	 * No structural references left, so free ->mk_users, and also free the
++	 * No structural references left, so clear ->mk_users, and also free the
+ 	 * fscrypt_master_key struct itself after an RCU grace period ensures
+ 	 * that concurrent keyring lookups can no longer find it.
+ 	 */
+ 	WARN_ON_ONCE(refcount_read(&mk->mk_active_refs) != 0);
+-	key_put(mk->mk_users);
+-	mk->mk_users = NULL;
++	clear_mk_users(mk);
+ 	call_rcu(&mk->mk_rcu_head, fscrypt_free_master_key);
+ }
+ 
+@@ -145,8 +146,8 @@ static void fscrypt_user_key_describe(const struct key *key, struct seq_file *m)
+ }
+ 
+ /*
+- * Type of key in ->mk_users.  Each key of this type represents a particular
+- * user who has added a particular master key.
++ * Type of fscrypt_master_key_user::quota_key.  This contains no secret; it
++ * exists solely to charge a user's key quota.
+  *
+  * Note that the name of this key type really should be something like
+  * ".fscrypt-user" instead of simply ".fscrypt".  But the shorter name is chosen
+@@ -160,30 +161,9 @@ static struct key_type key_type_fscrypt_user = {
+ 	.describe		= fscrypt_user_key_describe,
+ };
+ 
+-#define FSCRYPT_MK_USERS_DESCRIPTION_SIZE	\
+-	(CONST_STRLEN("fscrypt-") + 2 * FSCRYPT_KEY_IDENTIFIER_SIZE + \
+-	 CONST_STRLEN("-users") + 1)
+-
+ #define FSCRYPT_MK_USER_DESCRIPTION_SIZE	\
+ 	(2 * FSCRYPT_KEY_IDENTIFIER_SIZE + CONST_STRLEN(".uid.") + 10 + 1)
+ 
+-static void format_mk_users_keyring_description(
+-			char description[FSCRYPT_MK_USERS_DESCRIPTION_SIZE],
+-			const u8 mk_identifier[FSCRYPT_KEY_IDENTIFIER_SIZE])
+-{
+-	sprintf(description, "fscrypt-%*phN-users",
+-		FSCRYPT_KEY_IDENTIFIER_SIZE, mk_identifier);
+-}
+-
+-static void format_mk_user_description(
+-			char description[FSCRYPT_MK_USER_DESCRIPTION_SIZE],
+-			const u8 mk_identifier[FSCRYPT_KEY_IDENTIFIER_SIZE])
+-{
+-
+-	sprintf(description, "%*phN.uid.%u", FSCRYPT_KEY_IDENTIFIER_SIZE,
+-		mk_identifier, __kuid_val(current_fsuid()));
+-}
+-
+ /* Create ->s_master_keys if needed.  Synchronized by fscrypt_add_key_mutex. */
+ static int allocate_filesystem_keyring(struct super_block *sb)
+ {
+@@ -319,91 +299,94 @@ out:
+ 	return mk;
+ }
+ 
+-static int allocate_master_key_users_keyring(struct fscrypt_master_key *mk)
++/* Find the current user's claim in ->mk_users.  ->mk_sem must be held. */
++static struct fscrypt_master_key_user *
++find_master_key_user(struct fscrypt_master_key *mk)
+ {
+-	char description[FSCRYPT_MK_USERS_DESCRIPTION_SIZE];
+-	struct key *keyring;
+-
+-	format_mk_users_keyring_description(description,
+-					    mk->mk_spec.u.identifier);
+-	keyring = keyring_alloc(description, GLOBAL_ROOT_UID, GLOBAL_ROOT_GID,
+-				current_cred(), KEY_POS_SEARCH |
+-				  KEY_USR_SEARCH | KEY_USR_READ | KEY_USR_VIEW,
+-				KEY_ALLOC_NOT_IN_QUOTA, NULL, NULL);
+-	if (IS_ERR(keyring))
+-		return PTR_ERR(keyring);
+-
+-	mk->mk_users = keyring;
+-	return 0;
+-}
++	struct fscrypt_master_key_user *mk_user;
++	kuid_t uid = current_fsuid();
+ 
+-/*
+- * Find the current user's "key" in the master key's ->mk_users.
+- * Returns ERR_PTR(-ENOKEY) if not found.
+- */
+-static struct key *find_master_key_user(struct fscrypt_master_key *mk)
+-{
+-	char description[FSCRYPT_MK_USER_DESCRIPTION_SIZE];
+-	key_ref_t keyref;
+-
+-	format_mk_user_description(description, mk->mk_spec.u.identifier);
+-
+-	/*
+-	 * We need to mark the keyring reference as "possessed" so that we
+-	 * acquire permission to search it, via the KEY_POS_SEARCH permission.
+-	 */
+-	keyref = keyring_search(make_key_ref(mk->mk_users, true /*possessed*/),
+-				&key_type_fscrypt_user, description, false);
+-	if (IS_ERR(keyref)) {
+-		if (PTR_ERR(keyref) == -EAGAIN || /* not found */
+-		    PTR_ERR(keyref) == -EKEYREVOKED) /* recently invalidated */
+-			keyref = ERR_PTR(-ENOKEY);
+-		return ERR_CAST(keyref);
++	list_for_each_entry(mk_user, &mk->mk_users, link) {
++		if (uid_eq(mk_user->uid, uid))
++			return mk_user;
+ 	}
+-	return key_ref_to_ptr(keyref);
++	return NULL;
+ }
+ 
+ /*
+- * Give the current user a "key" in ->mk_users.  This charges the user's quota
++ * Give the current user a claim in ->mk_users.  This charges the user's quota
+  * and marks the master key as added by the current user, so that it cannot be
+  * removed by another user with the key.  Either ->mk_sem must be held for
+  * write, or the master key must be still undergoing initialization.
+  */
+ static int add_master_key_user(struct fscrypt_master_key *mk)
+ {
++	kuid_t uid = current_fsuid();
+ 	char description[FSCRYPT_MK_USER_DESCRIPTION_SIZE];
+-	struct key *mk_user;
++	struct key *quota_key;
++	struct fscrypt_master_key_user *mk_user;
+ 	int err;
+ 
+-	format_mk_user_description(description, mk->mk_spec.u.identifier);
+-	mk_user = key_alloc(&key_type_fscrypt_user, description,
+-			    current_fsuid(), current_gid(), current_cred(),
+-			    KEY_POS_SEARCH | KEY_USR_VIEW, 0, NULL);
+-	if (IS_ERR(mk_user))
+-		return PTR_ERR(mk_user);
++	snprintf(description, sizeof(description), "%*phN.uid.%u",
++		 FSCRYPT_KEY_IDENTIFIER_SIZE, mk->mk_spec.u.identifier,
++		 __kuid_val(uid));
++	quota_key = key_alloc(&key_type_fscrypt_user, description, uid,
++			      current_gid(), current_cred(),
++			      KEY_POS_SEARCH | KEY_USR_VIEW, 0, NULL);
++	if (IS_ERR(quota_key))
++		return PTR_ERR(quota_key);
++
++	err = key_instantiate_and_link(quota_key, NULL, 0, NULL, NULL);
++	if (err) {
++		key_put(quota_key);
++		return err;
++	}
+ 
+-	err = key_instantiate_and_link(mk_user, NULL, 0, mk->mk_users, NULL);
+-	key_put(mk_user);
+-	return err;
++	mk_user = kzalloc(sizeof(*mk_user), GFP_KERNEL);
++	if (!mk_user) {
++		key_put(quota_key);
++		return -ENOMEM;
++	}
++	mk_user->uid = uid;
++	mk_user->quota_key = quota_key;
++	list_add(&mk_user->link, &mk->mk_users);
++	return 0;
++}
++
++static void unlink_and_free_mk_user(struct fscrypt_master_key_user *mk_user)
++{
++	list_del(&mk_user->link);
++	key_put(mk_user->quota_key);
++	kfree(mk_user);
+ }
+ 
+ /*
+- * Remove the current user's "key" from ->mk_users.
++ * Remove the current user's claim from ->mk_users.
+  * ->mk_sem must be held for write.
+  *
+- * Returns 0 if removed, -ENOKEY if not found, or another -errno code.
++ * Returns 0 if removed or -ENOKEY if not found.
+  */
+ static int remove_master_key_user(struct fscrypt_master_key *mk)
+ {
+-	struct key *mk_user;
+-	int err;
++	struct fscrypt_master_key_user *mk_user;
+ 
+ 	mk_user = find_master_key_user(mk);
+-	if (IS_ERR(mk_user))
+-		return PTR_ERR(mk_user);
+-	err = key_unlink(mk->mk_users, mk_user);
+-	key_put(mk_user);
+-	return err;
++	if (!mk_user)
++		return -ENOKEY;
++	unlink_and_free_mk_user(mk_user);
++	return 0;
++}
++
++/*
++ * Clear ->mk_users.  Either ->mk_sem must be held for write, or 'mk' must have
++ * no structural references left.
++ */
++static void clear_mk_users(struct fscrypt_master_key *mk)
++{
++	struct fscrypt_master_key_user *mk_user, *tmp;
++
++	list_for_each_entry_safe(mk_user, tmp, &mk->mk_users, link)
++		unlink_and_free_mk_user(mk_user);
+ }
+ 
+ /*
+@@ -426,13 +409,12 @@ static int add_new_master_key(struct super_block *sb,
+ 	refcount_set(&mk->mk_struct_refs, 1);
+ 	mk->mk_spec = *mk_spec;
+ 
++	INIT_LIST_HEAD(&mk->mk_users);
++
+ 	INIT_LIST_HEAD(&mk->mk_decrypted_inodes);
+ 	spin_lock_init(&mk->mk_decrypted_inodes_lock);
+ 
+ 	if (mk_spec->type == FSCRYPT_KEY_SPEC_TYPE_IDENTIFIER) {
+-		err = allocate_master_key_users_keyring(mk);
+-		if (err)
+-			goto out_put;
+ 		err = add_master_key_user(mk);
+ 		if (err)
+ 			goto out_put;
+@@ -460,19 +442,13 @@ static int add_existing_master_key(struct fscrypt_master_key *mk,
+ 	int err;
+ 
+ 	/*
+-	 * If the current user is already in ->mk_users, then there's nothing to
+-	 * do.  Otherwise, we need to add the user to ->mk_users.  (Neither is
+-	 * applicable for v1 policy keys, which have NULL ->mk_users.)
++	 * For v2 policy keys (FSCRYPT_KEY_SPEC_TYPE_IDENTIFIER): If the current
++	 * user is already in ->mk_users, then there's nothing to do.
++	 * Otherwise, add the user to ->mk_users.
+ 	 */
+-	if (mk->mk_users) {
+-		struct key *mk_user = find_master_key_user(mk);
+-
+-		if (mk_user != ERR_PTR(-ENOKEY)) {
+-			if (IS_ERR(mk_user))
+-				return PTR_ERR(mk_user);
+-			key_put(mk_user);
++	if (mk->mk_spec.type == FSCRYPT_KEY_SPEC_TYPE_IDENTIFIER) {
++		if (find_master_key_user(mk) != NULL)
+ 			return 0;
+-		}
+ 		err = add_master_key_user(mk);
+ 		if (err)
+ 			return err;
+@@ -819,7 +795,6 @@ int fscrypt_verify_key_added(struct super_block *sb,
+ {
+ 	struct fscrypt_key_specifier mk_spec;
+ 	struct fscrypt_master_key *mk;
+-	struct key *mk_user;
+ 	int err;
+ 
+ 	mk_spec.type = FSCRYPT_KEY_SPEC_TYPE_IDENTIFIER;
+@@ -831,13 +806,10 @@ int fscrypt_verify_key_added(struct super_block *sb,
+ 		goto out;
+ 	}
+ 	down_read(&mk->mk_sem);
+-	mk_user = find_master_key_user(mk);
+-	if (IS_ERR(mk_user)) {
+-		err = PTR_ERR(mk_user);
+-	} else {
+-		key_put(mk_user);
++	if (find_master_key_user(mk) != NULL)
+ 		err = 0;
+-	}
++	else
++		err = -ENOKEY;
+ 	up_read(&mk->mk_sem);
+ 	fscrypt_put_master_key(mk);
+ out:
+@@ -1030,16 +1002,18 @@ static int do_remove_key(struct file *filp, void __user *_uarg, bool all_users)
+ 	down_write(&mk->mk_sem);
+ 
+ 	/* If relevant, remove current user's (or all users) claim to the key */
+-	if (mk->mk_users && mk->mk_users->keys.nr_leaves_on_tree != 0) {
+-		if (all_users)
+-			err = keyring_clear(mk->mk_users);
+-		else
++	if (!list_empty(&mk->mk_users)) {
++		if (all_users) {
++			clear_mk_users(mk);
++			err = 0;
++		} else {
+ 			err = remove_master_key_user(mk);
++		}
+ 		if (err) {
+ 			up_write(&mk->mk_sem);
+ 			goto out_put_key;
+ 		}
+-		if (mk->mk_users->keys.nr_leaves_on_tree != 0) {
++		if (!list_empty(&mk->mk_users)) {
+ 			/*
+ 			 * Other users have still added the key too.  We removed
+ 			 * the current user's claim to the key, but we still
+@@ -1127,6 +1101,8 @@ int fscrypt_ioctl_get_key_status(struct file *filp, void __user *uarg)
+ 	struct super_block *sb = file_inode(filp)->i_sb;
+ 	struct fscrypt_get_key_status_arg arg;
+ 	struct fscrypt_master_key *mk;
++	kuid_t uid;
++	const struct fscrypt_master_key_user *mk_user;
+ 	int err;
+ 
+ 	if (copy_from_user(&arg, uarg, sizeof(arg)))
+@@ -1159,19 +1135,13 @@ int fscrypt_ioctl_get_key_status(struct file *filp, void __user *uarg)
+ 	}
+ 
+ 	arg.status = FSCRYPT_KEY_STATUS_PRESENT;
+-	if (mk->mk_users) {
+-		struct key *mk_user;
+ 
+-		arg.user_count = mk->mk_users->keys.nr_leaves_on_tree;
+-		mk_user = find_master_key_user(mk);
+-		if (!IS_ERR(mk_user)) {
++	uid = current_fsuid();
++	list_for_each_entry(mk_user, &mk->mk_users, link) {
++		arg.user_count++;
++		if (uid_eq(mk_user->uid, uid))
+ 			arg.status_flags |=
+ 				FSCRYPT_KEY_STATUS_FLAG_ADDED_BY_SELF;
+-			key_put(mk_user);
+-		} else if (mk_user != ERR_PTR(-ENOKEY)) {
+-			err = PTR_ERR(mk_user);
+-			goto out_release_key;
+-		}
+ 	}
+ 	err = 0;
+ out_release_key:
+diff --git a/fs/crypto/policy.c b/fs/crypto/policy.c
+index f4456ecb3f8776..2ba184ceb4d7b3 100644
+--- a/fs/crypto/policy.c
++++ b/fs/crypto/policy.c
+@@ -505,7 +505,7 @@ int fscrypt_ioctl_set_policy(struct file *filp, const void __user *arg)
+ 		return -EFAULT;
+ 	policy.version = version;
+ 
+-	if (!inode_owner_or_capable(&nop_mnt_idmap, inode))
++	if (!inode_owner_or_capable(file_mnt_idmap(filp), inode))
+ 		return -EACCES;
+ 
+ 	ret = mnt_want_write_file(filp);
+diff --git a/fs/namespace.c b/fs/namespace.c
+index 646d9e7d41ee8a..f185de5f5df4a7 100644
+--- a/fs/namespace.c
++++ b/fs/namespace.c
+@@ -4050,6 +4050,11 @@ SYSCALL_DEFINE3(fsmount, int, fs_fd, unsigned int, flags,
+ 		ret = PTR_ERR(newmount.mnt);
+ 		goto err_unlock;
+ 	}
++	if (newmount.mnt->mnt_sb->s_flags & SB_NOUSER) {
++		mntput(newmount.mnt);
++		ret = -EINVAL;
++		goto err_unlock;
++	}
+ 	newmount.dentry = dget(fc->root);
+ 	newmount.mnt->mnt_flags = mnt_flags;
+ 
+diff --git a/fs/nfs/nfs4proc.c b/fs/nfs/nfs4proc.c
+index 42fa7c915e29b9..ce3ab0a9c0ef79 100644
+--- a/fs/nfs/nfs4proc.c
++++ b/fs/nfs/nfs4proc.c
+@@ -10383,6 +10383,7 @@ static void nfs41_free_stateid_release(void *calldata)
+ 	struct nfs_free_stateid_data *data = calldata;
+ 	struct nfs_client *clp = data->server->nfs_client;
+ 
++	nfs_sb_deactive(data->server->super);
+ 	nfs_put_client(clp);
+ 	kfree(calldata);
+ }
+@@ -10424,6 +10425,10 @@ static int nfs41_free_stateid(struct nfs_server *server,
+ 
+ 	if (!refcount_inc_not_zero(&clp->cl_count))
+ 		return -EIO;
++	if (!nfs_sb_active(server->super)) {
++		nfs_put_client(clp);
++		return -EIO;
++	}
+ 
+ 	nfs4_state_protect(server->nfs_client, NFS_SP4_MACH_CRED_STATEID,
+ 		&task_setup.rpc_client, &msg);
+diff --git a/fs/overlayfs/super.c b/fs/overlayfs/super.c
+index 93ee57bc82ade9..76316d143aaa28 100644
+--- a/fs/overlayfs/super.c
++++ b/fs/overlayfs/super.c
+@@ -1345,7 +1345,8 @@ int ovl_fill_super(struct super_block *sb, struct fs_context *fc)
+ 	int err;
+ 
+ 	err = -EIO;
+-	if (WARN_ON(fc->user_ns != current_user_ns()))
++	/* The fscontext fd may have been passed to another user namespace. */
++	if (fc->user_ns != current_user_ns())
+ 		goto out_err;
+ 
+ 	sb->s_d_op = &ovl_dentry_operations;
+diff --git a/fs/smb/client/sess.c b/fs/smb/client/sess.c
+index bbde7180a90ac4..6fac7a10759206 100644
+--- a/fs/smb/client/sess.c
++++ b/fs/smb/client/sess.c
+@@ -271,9 +271,9 @@ int cifs_try_adding_channels(struct cifs_ses *ses)
+ 				cifs_dbg(VFS, "failed to open extra channel on iface:%pIS rc=%d\n",
+ 					 &iface->sockaddr,
+ 					 rc);
+-				kref_put(&iface->refcount, release_iface);
+ 				/* failure to add chan should increase weight */
+ 				iface->weight_fulfilled++;
++				kref_put(&iface->refcount, release_iface);
+ 				continue;
+ 			}
+ 
+diff --git a/fs/tracefs/event_inode.c b/fs/tracefs/event_inode.c
+index 36257e1092d6ea..4ac459c7efc3f7 100644
+--- a/fs/tracefs/event_inode.c
++++ b/fs/tracefs/event_inode.c
+@@ -922,7 +922,7 @@ struct eventfs_inode *eventfs_create_events_dir(const char *name, struct dentry
+  */
+ static void eventfs_remove_rec(struct eventfs_inode *ei, int level)
+ {
+-	struct eventfs_inode *ei_child;
++	struct eventfs_inode *ei_child, *tmp;
+ 
+ 	/*
+ 	 * Check recursion depth. It should never be greater than 3:
+@@ -935,7 +935,7 @@ static void eventfs_remove_rec(struct eventfs_inode *ei, int level)
+ 		return;
+ 
+ 	/* search for nested folders or files */
+-	list_for_each_entry(ei_child, &ei->children, list)
++	list_for_each_entry_safe(ei_child, tmp, &ei->children, list)
+ 		eventfs_remove_rec(ei_child, level + 1);
+ 
+ 	list_del_rcu(&ei->list);
+diff --git a/include/linux/netdevice.h b/include/linux/netdevice.h
+index 74474139fb9ac8..4901f765a14d3e 100644
+--- a/include/linux/netdevice.h
++++ b/include/linux/netdevice.h
+@@ -301,9 +301,11 @@ struct hh_cache {
+  * We could use other alignment values, but we must maintain the
+  * relationship HH alignment <= LL alignment.
+  */
+-#define LL_RESERVED_SPACE(dev) \
+-	((((dev)->hard_header_len + READ_ONCE((dev)->needed_headroom)) \
++#define LL_RESERVED_SPACE_EX(dev, hlen) \
++	((((hlen) + READ_ONCE((dev)->needed_headroom)) \
+ 	  & ~(HH_DATA_MOD - 1)) + HH_DATA_MOD)
++#define LL_RESERVED_SPACE(dev) \
++	LL_RESERVED_SPACE_EX(dev, (dev)->hard_header_len)
+ #define LL_RESERVED_SPACE_EXTRA(dev,extra) \
+ 	((((dev)->hard_header_len + READ_ONCE((dev)->needed_headroom) + (extra)) \
+ 	  & ~(HH_DATA_MOD - 1)) + HH_DATA_MOD)
+@@ -3197,11 +3199,6 @@ static inline bool dev_validate_header(const struct net_device *dev,
+ 	if (len < dev->min_header_len)
+ 		return false;
+ 
+-	if (capable(CAP_SYS_RAWIO)) {
+-		memset(ll_header + len, 0, dev->hard_header_len - len);
+-		return true;
+-	}
+-
+ 	if (dev->header_ops && dev->header_ops->validate)
+ 		return dev->header_ops->validate(ll_header, len);
+ 
+diff --git a/include/linux/netfilter/ipset/ip_set.h b/include/linux/netfilter/ipset/ip_set.h
+index b98331572ad298..cadae9b2578f1f 100644
+--- a/include/linux/netfilter/ipset/ip_set.h
++++ b/include/linux/netfilter/ipset/ip_set.h
+@@ -273,7 +273,7 @@ struct ip_set {
+ 	/* Number of elements (vs timeout) */
+ 	u32 elements;
+ 	/* Size of the dynamic extensions (vs timeout) */
+-	size_t ext_size;
++	atomic64_t ext_size;
+ 	/* Element data size */
+ 	size_t dsize;
+ 	/* Offsets to extensions in elements */
+diff --git a/include/linux/regulator/consumer.h b/include/linux/regulator/consumer.h
+index 25d0684d37b3e3..9a2f1e9a94a852 100644
+--- a/include/linux/regulator/consumer.h
++++ b/include/linux/regulator/consumer.h
+@@ -209,6 +209,7 @@ struct regulator *__must_check devm_regulator_get_optional(struct device *dev,
+ 							   const char *id);
+ int devm_regulator_get_enable(struct device *dev, const char *id);
+ int devm_regulator_get_enable_optional(struct device *dev, const char *id);
++int devm_regulator_get_enable_read_voltage(struct device *dev, const char *id);
+ void regulator_put(struct regulator *regulator);
+ void devm_regulator_put(struct regulator *regulator);
+ 
+@@ -374,6 +375,12 @@ static inline int devm_regulator_get_enable_optional(struct device *dev,
+ 	return 0;
+ }
+ 
++static inline int devm_regulator_get_enable_read_voltage(struct device *dev,
++							 const char *id)
++{
++	return -ENODEV;
++}
++
+ static inline struct regulator *__must_check
+ regulator_get_optional(struct device *dev, const char *id)
+ {
+diff --git a/include/linux/tcp.h b/include/linux/tcp.h
+index e15452df9804f6..c38778b0baa059 100644
+--- a/include/linux/tcp.h
++++ b/include/linux/tcp.h
+@@ -445,13 +445,18 @@ struct tcp_sock {
+ 	bool	syn_smc;	/* SYN includes SMC */
+ #endif
+ 
+-#ifdef CONFIG_TCP_MD5SIG
+-/* TCP AF-Specific parts; only used by MD5 Signature support so far */
++#if defined(CONFIG_TCP_MD5SIG) || defined(CONFIG_TCP_AO)
++/* TCP AF-Specific parts; only used by TCP-AO/MD5 Signature support so far */
+ 	const struct tcp_sock_af_ops	*af_specific;
+ 
++#ifdef CONFIG_TCP_MD5SIG
+ /* TCP MD5 Signature Option information */
+ 	struct tcp_md5sig_info	__rcu *md5sig_info;
+ #endif
++#ifdef CONFIG_TCP_AO
++	struct tcp_ao_info	__rcu *ao_info;
++#endif
++#endif
+ 
+ /* TCP fastopen related information */
+ 	struct tcp_fastopen_request *fastopen_req;
+diff --git a/include/net/act_api.h b/include/net/act_api.h
+index 56f49351fd5177..b196134e42059a 100644
+--- a/include/net/act_api.h
++++ b/include/net/act_api.h
+@@ -268,6 +268,25 @@ int tcf_action_check_ctrlact(int action, struct tcf_proto *tp,
+ struct tcf_chain *tcf_action_set_ctrlact(struct tc_action *a, int action,
+ 					 struct tcf_chain *newchain);
+ 
++/* Range check for a control action supplied by user space.
++ *
++ * This is the same test tcf_action_check_ctrlact() applies to the primary
++ * control action, factored out for the *fallback* control actions
++ * (act_gact's TCA_GACT_PROB.paction and act_police's TCA_POLICE_RESULT),
++ * which must not reach tcf_action_check_ctrlact() because they have no
++ * goto_chain to allocate.  Without it, user space can store kernel-internal
++ * verdicts such as TC_ACT_CONSUMED, which is TC_ACT_VALUE_MAX + 1 and is
++ * deliberately not part of the UAPI value range.
++ */
++static inline bool tcf_action_valid(int action)
++{
++	int opcode = TC_ACT_EXT_OPCODE(action);
++
++	if (!opcode)
++		return action <= TC_ACT_VALUE_MAX;
++	return opcode <= TC_ACT_EXT_OPCODE_MAX || action == TC_ACT_UNSPEC;
++}
++
+ #ifdef CONFIG_INET
+ DECLARE_STATIC_KEY_FALSE(tcf_frag_xmit_count);
+ #endif
+diff --git a/include/net/addrconf.h b/include/net/addrconf.h
+index 0a9b055a8ee114..5db1d088d81958 100644
+--- a/include/net/addrconf.h
++++ b/include/net/addrconf.h
+@@ -370,8 +370,8 @@ static inline struct inet6_dev *in6_dev_get(const struct net_device *dev)
+ 
+ 	rcu_read_lock();
+ 	idev = rcu_dereference(dev->ip6_ptr);
+-	if (idev)
+-		refcount_inc(&idev->refcnt);
++	if (idev && !refcount_inc_not_zero(&idev->refcnt))
++		idev = NULL;
+ 	rcu_read_unlock();
+ 	return idev;
+ }
+diff --git a/include/net/ip_vs.h b/include/net/ip_vs.h
+index 6935ec09af24de..e0077fd28ad1cc 100644
+--- a/include/net/ip_vs.h
++++ b/include/net/ip_vs.h
+@@ -24,9 +24,7 @@
+ #include <linux/netfilter.h>		/* for union nf_inet_addr */
+ #include <linux/ip.h>
+ #include <linux/ipv6.h>			/* for struct ipv6hdr */
+-#include <net/route.h>
+ #include <net/ipv6.h>
+-#include <net/ip6_fib.h>
+ #if IS_ENABLED(CONFIG_NF_CONNTRACK)
+ #include <net/netfilter/nf_conntrack.h>
+ #endif
+@@ -738,10 +736,11 @@ struct ip_vs_dest {
+ 
+ 	/* connection counters and thresholds */
+ 	atomic_t		activeconns;	/* active connections */
+-	atomic_t		inactconns;	/* inactive connections */
++	atomic_t		totalconns;	/* total connections */
+ 	atomic_t		persistconns;	/* persistent connections */
+ 	__u32			u_threshold;	/* upper threshold */
+ 	__u32			l_threshold;	/* lower threshold */
++	__u32			l_threshold_val;/* used lower threshold */
+ 
+ 	/* for destination cache */
+ 	spinlock_t		dst_lock;	/* lock of dst_cache */
+@@ -1569,6 +1568,8 @@ static inline void ip_vs_dest_put_and_free(struct ip_vs_dest *dest)
+ 		kfree(dest);
+ }
+ 
++void ip_vs_dest_update_overload(struct ip_vs_dest *dest, int mode);
++
+ /* IPVS sync daemon data and function prototypes
+  * (from ip_vs_sync.c)
+  */
+@@ -1707,7 +1708,7 @@ static inline char ip_vs_fwd_tag(struct ip_vs_conn *cp)
+ 
+ void ip_vs_nat_icmp(struct sk_buff *skb, struct ip_vs_protocol *pp,
+ 		    struct ip_vs_conn *cp, int dir, unsigned int toff,
+-		    bool has_ports);
++		    bool has_ports, struct ip_vs_iphdr *ciph);
+ 
+ #ifdef CONFIG_IP_VS_IPV6
+ void ip_vs_nat_icmp_v6(struct sk_buff *skb, struct ip_vs_protocol *pp,
+@@ -1740,30 +1741,23 @@ static inline __wsum ip_vs_check_diff2(__be16 old, __be16 new, __wsum oldsum)
+ 	return csum_partial(diff, sizeof(diff), oldsum);
+ }
+ 
+-static inline bool ip_vs_checksum_needed(struct sk_buff *skb, int af)
++static inline bool ip_vs_checksum_needed(struct sk_buff *skb)
+ {
+ 	/* Checksum unnecessary or already validated? */
+ 	if (skb_csum_unnecessary(skb))
+ 		return false;
+-	/* LOCAL_OUT ? */
+-	if (!skb->dev || skb->dev->flags & IFF_LOOPBACK)
++	/* Locally generated ? */
++	if (!skb->dev)
+ 		return false;
+-	/* !LOCAL_IN (FORWARD) ? */
+-	if (af == AF_INET6) {
+-		if (!(dst_rt6_info(skb_dst(skb))->rt6i_flags & RTF_LOCAL))
+-			return false;
+-	} else {
+-		if (!(skb_rtable(skb)->rt_flags & RTCF_LOCAL))
+-			return false;
+-	}
+ 	return true;
+ }
+ 
+ static inline bool ip_vs_checksum_common_check(struct sk_buff *skb,
+ 					       int offset, int proto, int af)
+ {
+-	if (!ip_vs_checksum_needed(skb, af))
++	if (!ip_vs_checksum_needed(skb))
+ 		return true;
++	/* Validate csum even for FORWARD */
+ 	return !nf_checksum(skb, NF_INET_LOCAL_IN, offset, proto, af);
+ }
+ 
+@@ -1874,14 +1868,21 @@ void ip_vs_unregister_hooks(struct netns_ipvs *ipvs, unsigned int af);
+ static inline int
+ ip_vs_dest_conn_overhead(struct ip_vs_dest *dest)
+ {
+-	/* We think the overhead of processing active connections is 256
++	/* We think the overhead of processing active connections is 257
+ 	 * times higher than that of inactive connections in average. (This
+-	 * 256 times might not be accurate, we will change it later) We
++	 * 257 times might not be accurate, we will change it later) We
+ 	 * use the following formula to estimate the overhead now:
+-	 *		  dest->activeconns*256 + dest->inactconns
++	 *		  dest->activeconns*256 + dest->totalconns
+ 	 */
+ 	return (atomic_read(&dest->activeconns) << 8) +
+-		atomic_read(&dest->inactconns);
++		atomic_read(&dest->totalconns);
++}
++
++static inline int
++ip_vs_dest_inactconns(const struct ip_vs_dest *dest)
++{
++	return max(atomic_read(&dest->totalconns) -
++		   atomic_read(&dest->activeconns), 0);
+ }
+ 
+ #ifdef CONFIG_IP_VS_PROTO_TCP
+diff --git a/include/net/pkt_cls.h b/include/net/pkt_cls.h
+index ccc1c698ed0076..307478c2332234 100644
+--- a/include/net/pkt_cls.h
++++ b/include/net/pkt_cls.h
+@@ -72,6 +72,15 @@ static inline bool tcf_block_non_null_shared(struct tcf_block *block)
+ 	return block && block->index;
+ }
+ 
++#ifdef CONFIG_NET_CLS_ACT
++DECLARE_STATIC_KEY_FALSE(tcf_sw_enabled_key);
++
++static inline bool tcf_block_bypass_sw(struct tcf_block *block)
++{
++	return block && !atomic_read(&block->useswcnt);
++}
++#endif
++
+ static inline struct Qdisc *tcf_block_q(struct tcf_block *block)
+ {
+ 	WARN_ON(tcf_block_shared(block));
+@@ -750,6 +759,15 @@ tc_cls_common_offload_init(struct flow_cls_common_offload *cls_common,
+ 		cls_common->extack = extack;
+ }
+ 
++static inline void tcf_proto_update_usesw(struct tcf_proto *tp, u32 flags)
++{
++	if (tp->usesw)
++		return;
++	if (tc_skip_sw(flags) && tc_in_hw(flags))
++		return;
++	tp->usesw = true;
++}
++
+ #if IS_ENABLED(CONFIG_NET_TC_SKB_EXT)
+ static inline struct tc_skb_ext *tc_skb_ext_alloc(struct sk_buff *skb)
+ {
+diff --git a/include/net/route.h b/include/net/route.h
+index 22d8095a3a81e9..1d5d975c1707ff 100644
+--- a/include/net/route.h
++++ b/include/net/route.h
+@@ -244,6 +244,8 @@ int fib_dump_info_fnhe(struct sk_buff *skb, struct netlink_callback *cb,
+ 		       u32 table_id, struct fib_info *fi,
+ 		       int *fa_index, int fa_start, unsigned int flags);
+ 
++void fnhe_update_pmtu(struct fib_nh_exception *fnhe, u32 new, u32 orig);
++
+ static inline void ip_rt_put(struct rtable *rt)
+ {
+ 	/* dst_release() accepts a NULL parameter.
+diff --git a/include/net/sch_generic.h b/include/net/sch_generic.h
+index 385af747b0b4e0..8ad29d2c210abd 100644
+--- a/include/net/sch_generic.h
++++ b/include/net/sch_generic.h
+@@ -100,6 +100,7 @@ struct Qdisc {
+ 	struct hlist_node       hash;
+ 	u32			handle;
+ 	u32			parent;
++	int			depth;
+ 
+ 	struct netdev_queue	*dev_queue;
+ 
+@@ -429,6 +430,8 @@ struct tcf_proto {
+ 	 */
+ 	spinlock_t		lock;
+ 	bool			deleting;
++	bool			counted;
++	bool			usesw;
+ 	refcount_t		refcnt;
+ 	struct rcu_head		rcu;
+ 	struct hlist_node	destroy_ht_node;
+@@ -477,6 +480,7 @@ struct tcf_block {
+ 	struct flow_block flow_block;
+ 	struct list_head owner_list;
+ 	bool keep_dst;
++	atomic_t useswcnt;
+ 	atomic_t offloadcnt; /* Number of oddloaded filters */
+ 	unsigned int nooffloaddevcnt; /* Number of devs unable to do offload */
+ 	unsigned int lockeddevcnt; /* Number of devs that require rtnl lock. */
+diff --git a/include/net/tcp.h b/include/net/tcp.h
+index a6def0aab3ed31..0eb9341f748887 100644
+--- a/include/net/tcp.h
++++ b/include/net/tcp.h
+@@ -37,6 +37,7 @@
+ #include <net/snmp.h>
+ #include <net/ip.h>
+ #include <net/tcp_states.h>
++#include <net/tcp_ao.h>
+ #include <net/inet_ecn.h>
+ #include <net/dst.h>
+ #include <net/mptcp.h>
+@@ -1681,12 +1682,7 @@ static inline void tcp_clear_all_retrans_hints(struct tcp_sock *tp)
+ 	tp->retransmit_skb_hint = NULL;
+ }
+ 
+-union tcp_md5_addr {
+-	struct in_addr  a4;
+-#if IS_ENABLED(CONFIG_IPV6)
+-	struct in6_addr	a6;
+-#endif
+-};
++#define tcp_md5_addr tcp_ao_addr
+ 
+ /* - key database */
+ struct tcp_md5sig_key {
+@@ -1730,12 +1726,39 @@ union tcp_md5sum_block {
+ #endif
+ };
+ 
+-/* - pool: digest algorithm, hash description and scratch buffer */
+-struct tcp_md5sig_pool {
+-	struct ahash_request	*md5_req;
+-	void			*scratch;
++/*
++ * struct tcp_sigpool - per-CPU pool of ahash_requests
++ * @scratch: per-CPU temporary area, that can be used between
++ *	     tcp_sigpool_start() and tcp_sigpool_end() to perform
++ *	     crypto request
++ * @req: pre-allocated ahash request
++ */
++struct tcp_sigpool {
++	void *scratch;
++	struct ahash_request *req;
+ };
+ 
++int tcp_sigpool_alloc_ahash(const char *alg, size_t scratch_size);
++void tcp_sigpool_get(unsigned int id);
++void tcp_sigpool_release(unsigned int id);
++int tcp_sigpool_hash_skb_data(struct tcp_sigpool *hp,
++			      const struct sk_buff *skb,
++			      unsigned int header_len);
++
++/**
++ * tcp_sigpool_start - disable bh and start using tcp_sigpool_ahash
++ * @id: tcp_sigpool that was previously allocated by tcp_sigpool_alloc_ahash()
++ * @c: returned tcp_sigpool for usage (uninitialized on failure)
++ *
++ * Returns 0 on success, error otherwise.
++ */
++int tcp_sigpool_start(unsigned int id, struct tcp_sigpool *c);
++/**
++ * tcp_sigpool_end - enable bh and stop using tcp_sigpool
++ * @c: tcp_sigpool context that was returned by tcp_sigpool_start()
++ */
++void tcp_sigpool_end(struct tcp_sigpool *c);
++size_t tcp_sigpool_algo(unsigned int id, char *buf, size_t buf_len);
+ /* - functions */
+ int tcp_v4_md5_hash_skb(char *md5_hash, const struct tcp_md5sig_key *key,
+ 			const struct sock *sk, const struct sk_buff *skb);
+@@ -1791,17 +1814,12 @@ tcp_inbound_md5_hash(const struct sock *sk, const struct sk_buff *skb,
+ #define tcp_twsk_md5_key(twsk)	NULL
+ #endif
+ 
+-bool tcp_alloc_md5sig_pool(void);
+-
+-struct tcp_md5sig_pool *tcp_get_md5sig_pool(void);
+-static inline void tcp_put_md5sig_pool(void)
+-{
+-	local_bh_enable();
+-}
++int tcp_md5_alloc_sigpool(void);
++void tcp_md5_release_sigpool(void);
++void tcp_md5_add_sigpool(void);
++extern int tcp_md5_sigpool_id;
+ 
+-int tcp_md5_hash_skb_data(struct tcp_md5sig_pool *, const struct sk_buff *,
+-			  unsigned int header_len);
+-int tcp_md5_hash_key(struct tcp_md5sig_pool *hp,
++int tcp_md5_hash_key(struct tcp_sigpool *hp,
+ 		     const struct tcp_md5sig_key *key);
+ 
+ /* From tcp_fastopen.c */
+diff --git a/include/net/tcp_ao.h b/include/net/tcp_ao.h
+new file mode 100644
+index 00000000000000..af76e1c47bea9c
+--- /dev/null
++++ b/include/net/tcp_ao.h
+@@ -0,0 +1,90 @@
++/* SPDX-License-Identifier: GPL-2.0-or-later */
++#ifndef _TCP_AO_H
++#define _TCP_AO_H
++
++#define TCP_AO_KEY_ALIGN	1
++#define __tcp_ao_key_align __aligned(TCP_AO_KEY_ALIGN)
++
++union tcp_ao_addr {
++	struct in_addr  a4;
++#if IS_ENABLED(CONFIG_IPV6)
++	struct in6_addr	a6;
++#endif
++};
++
++struct tcp_ao_hdr {
++	u8	kind;
++	u8	length;
++	u8	keyid;
++	u8	rnext_keyid;
++};
++
++struct tcp_ao_key {
++	struct hlist_node	node;
++	union tcp_ao_addr	addr;
++	u8			key[TCP_AO_MAXKEYLEN] __tcp_ao_key_align;
++	unsigned int		tcp_sigpool_id;
++	unsigned int		digest_size;
++	u8			prefixlen;
++	u8			family;
++	u8			keylen;
++	u8			keyflags;
++	u8			sndid;
++	u8			rcvid;
++	u8			maclen;
++	struct rcu_head		rcu;
++	u8			traffic_keys[];
++};
++
++static inline u8 *rcv_other_key(struct tcp_ao_key *key)
++{
++	return key->traffic_keys;
++}
++
++static inline u8 *snd_other_key(struct tcp_ao_key *key)
++{
++	return key->traffic_keys + key->digest_size;
++}
++
++static inline int tcp_ao_maclen(const struct tcp_ao_key *key)
++{
++	return key->maclen;
++}
++
++static inline int tcp_ao_len(const struct tcp_ao_key *key)
++{
++	return tcp_ao_maclen(key) + sizeof(struct tcp_ao_hdr);
++}
++
++static inline unsigned int tcp_ao_digest_size(struct tcp_ao_key *key)
++{
++	return key->digest_size;
++}
++
++static inline int tcp_ao_sizeof_key(const struct tcp_ao_key *key)
++{
++	return sizeof(struct tcp_ao_key) + (key->digest_size << 1);
++}
++
++struct tcp_ao_info {
++	/* List of tcp_ao_key's */
++	struct hlist_head	head;
++	/* current_key and rnext_key aren't maintained on listen sockets.
++	 * Their purpose is to cache keys on established connections,
++	 * saving needless lookups. Never dereference any of them from
++	 * listen sockets.
++	 * ::current_key may change in RX to the key that was requested by
++	 * the peer, please use READ_ONCE()/WRITE_ONCE() in order to avoid
++	 * load/store tearing.
++	 * Do the same for ::rnext_key, if you don't hold socket lock
++	 * (it's changed only by userspace request in setsockopt()).
++	 */
++	struct tcp_ao_key	*current_key;
++	struct tcp_ao_key	*rnext_key;
++	u32			flags;
++	__be32			lisn;
++	__be32			risn;
++	struct rcu_head		rcu;
++};
++
++#endif /* _TCP_AO_H */
+diff --git a/include/uapi/linux/tcp.h b/include/uapi/linux/tcp.h
+index d1d08da6331ab5..bf93a80809d6ad 100644
+--- a/include/uapi/linux/tcp.h
++++ b/include/uapi/linux/tcp.h
+@@ -360,6 +360,8 @@ struct tcp_diag_md5sig {
+ 	__u8	tcpm_key[TCP_MD5SIG_MAXKEYLEN];
+ };
+ 
++#define TCP_AO_MAXKEYLEN	80
++
+ /* setsockopt(fd, IPPROTO_TCP, TCP_ZEROCOPY_RECEIVE, ...) */
+ 
+ #define TCP_RECEIVE_ZEROCOPY_FLAG_TLB_CLEAN_HINT 0x1
+diff --git a/kernel/bpf/verifier.c b/kernel/bpf/verifier.c
+index 5e094c12fc94c5..ad679bc42427c8 100644
+--- a/kernel/bpf/verifier.c
++++ b/kernel/bpf/verifier.c
+@@ -12657,11 +12657,12 @@ static int adjust_ptr_min_max_vals(struct bpf_verifier_env *env,
+ 		break;
+ 	}
+ 
+-	/* In case of 'scalar += pointer', dst_reg inherits pointer type and id.
+-	 * The id may be overwritten later if we create a new variable offset.
++	/* For 'scalar += pointer', dst_reg inherits the complete pointer
++	 * register state. Individual fields may be adjusted later by pointer
++	 * arithmetic. Callers guarantee that below does not overwrite off_reg.
+ 	 */
+-	dst_reg->type = ptr_reg->type;
+-	dst_reg->id = ptr_reg->id;
++	if (dst_reg != ptr_reg)
++		*dst_reg = *ptr_reg;
+ 
+ 	if (!check_reg_sane_offset(env, off_reg, ptr_reg->type) ||
+ 	    !check_reg_sane_offset(env, ptr_reg, ptr_reg->type))
+@@ -12729,7 +12730,7 @@ static int adjust_ptr_min_max_vals(struct bpf_verifier_env *env,
+ 		}
+ 		break;
+ 	case BPF_SUB:
+-		if (dst_reg == off_reg) {
++		if (dst_reg != ptr_reg) {
+ 			/* scalar -= pointer.  Creates an unknown scalar */
+ 			verbose(env, "R%d tried to subtract pointer from scalar\n",
+ 				dst);
+@@ -13588,8 +13589,8 @@ static int adjust_reg_min_max_vals(struct bpf_verifier_env *env,
+ 				err = mark_chain_precision(env, insn->dst_reg);
+ 				if (err)
+ 					return err;
+-				return adjust_ptr_min_max_vals(env, insn,
+-							       src_reg, dst_reg);
++				off_reg = *dst_reg;
++				return adjust_ptr_min_max_vals(env, insn, src_reg, &off_reg);
+ 			}
+ 		} else if (ptr_reg) {
+ 			/* pointer += scalar */
+diff --git a/kernel/futex/core.c b/kernel/futex/core.c
+index f30a93e50f65e8..660d7061740b8a 100644
+--- a/kernel/futex/core.c
++++ b/kernel/futex/core.c
+@@ -660,8 +660,11 @@ retry:
+ 		return -1;
+ 
+ 	/*
+-	 * Special case for regular (non PI) futexes. The unlock path in
+-	 * user space has two race scenarios:
++	 * Special case for regular (non PI) futexes. Ordinarily, we do
++	 * not perform any processing here unless the current thread was
++	 * the owner of the futex (by the TID check below).
++	 *
++	 * However, the unlock path has three race scenarios:
+ 	 *
+ 	 * 1. The unlock path releases the user space futex value and
+ 	 *    before it can execute the futex() syscall to wake up
+@@ -670,41 +673,68 @@ retry:
+ 	 * 2. A woken up waiter is killed before it can acquire the
+ 	 *    futex in user space.
+ 	 *
+-	 * In the second case, the wake up notification could be generated
+-	 * by the unlock path in user space after setting the futex value
+-	 * to zero or by the kernel after setting the OWNER_DIED bit below.
++	 * 3. A woken up waiter is killed in user space after another
++	 *    thread has acquired the futex, but before it can set
++	 *    FUTEX_WAITERS.
++	 *
++	 * Note that, if userspace uses the FUTEX_ROBUST_UNLOCK flag, we
++	 * will not see case 1 here.
++	 *
++	 * In the second and third case, the wake up notification could
++	 * be generated from any of:
++	 *
++	 *    i.   An ordinary futex wakeup after unlock (with or
++	 *         without FUTEX_ROBUST_UNLOCK)
++	 *    ii.  A robust wakeup from another thread's death
++	 *    iii. A previous round through this special case
++	 *
++	 * As a result, the futex world will be in one of four states:
+ 	 *
+-	 * In both cases the TID validation below prevents a wakeup of
+-	 * potential waiters which can cause these waiters to block
+-	 * forever.
++	 *    A. The futex word is 0 (unlocked)
++	 *    B. The futex word is owned by another thread
++	 *       (FUTEX_WAITERS is not set)
++	 *    C. The futex word is owned by another thread
++	 *       (FUTEX_WAITERS set)
++	 *    D. The futex's owner died and OWNER_DIED is set
++	 *       (the owner part of the word is 0)
+ 	 *
+-	 * In both cases the following conditions are met:
++	 * The key issue is that the kernel usually (at least from
++	 * sources ii. and iii. or when so requested by userspace from
++	 * source i.) only ever wakes *one* waiter at a time. If this
++	 * waiter dies before acquiring the futex (or setting the
++	 * FUTEX_WAITERS bit), the kernel *must* still wake the next
++	 * waiter down the line to uphold the futex invariants and
++	 * avoid lost wakeups. Note we do not need to handle state C,
++	 * as it does not matter to us whether *we* successfully set
++	 * the bit or a third thread did so in the meantime.
+ 	 *
+-	 *	1) task->robust_list->list_op_pending != NULL
+-	 *	   @pending_op == true
+-	 *	2) The owner part of user space futex value == 0
++	 * Therefore, in these cases we must issue an additional
++	 * futex_wake(). Note however that we *must not* set OWNER_DIED
++	 * here. Our thread is *not* the owner of the futex.
++	 *
++	 * Thus to summarize, the conditions for needing the additional
++	 * futex_wake() are:
++	 *
++	 *	1) @pending_op == true (the thread has not finished the
++	 *	   mutex operation)
++	 *	2) The futex word is in one of the states A, B or D
+ 	 *	3) Regular futex: @pi == false
+ 	 *
+-	 * If these conditions are met, it is safe to attempt waking up a
+-	 * potential waiter without touching the user space futex value and
+-	 * trying to set the OWNER_DIED bit. If the futex value is zero,
+-	 * the rest of the user space mutex state is consistent, so a woken
+-	 * waiter will just take over the uncontended futex. Setting the
+-	 * OWNER_DIED bit would create inconsistent state and malfunction
+-	 * of the user space owner died handling. Otherwise, the OWNER_DIED
+-	 * bit is already set, and the woken waiter is expected to deal with
+-	 * this.
++	 * Note in particular that in all of the states A-D the owner
++	 * portion of the futex word differs from our thread's TID
++	 * (unless the actual owner has the same TID in another PID
++	 * namespace, but we cannot currently distinguish that
++	 * scenario), so this can be a special-case wakeup in the bail
++	 * path of the ordinary TID check.
+ 	 */
+ 	owner = uval & FUTEX_TID_MASK;
+ 
+-	if (pending_op && !pi && !owner) {
+-		futex_wake(uaddr, 1, 1, FUTEX_BITSET_MATCH_ANY);
++	if (owner != task_pid_vnr(curr)) {
++		if (pending_op && !pi && (!owner || !(uval & FUTEX_WAITERS)))
++			futex_wake(uaddr, 1, 1, FUTEX_BITSET_MATCH_ANY);
+ 		return 0;
+ 	}
+ 
+-	if (owner != task_pid_vnr(curr))
+-		return 0;
+-
+ 	/*
+ 	 * Ok, this dying thread is truly holding a futex
+ 	 * of interest. Set the OWNER_DIED bit atomically
+diff --git a/kernel/sched/psi.c b/kernel/sched/psi.c
+index 08a9a9f909d518..b7a2fd895eb5ec 100644
+--- a/kernel/sched/psi.c
++++ b/kernel/sched/psi.c
+@@ -1138,6 +1138,12 @@ void psi_cgroup_free(struct cgroup *cgroup)
+ 		return;
+ 
+ 	cancel_delayed_work_sync(&cgroup->psi->avgs_work);
++	/*
++	 * A psi_schedule_rtpoll_work() call racing the last trigger's
++	 * destruction may have re-armed the timer after psi_trigger_destroy()
++	 * deleted it. Spurious firing while the group is alive is harmless.
++	 */
++	timer_shutdown_sync(&cgroup->psi->rtpoll_timer);
+ 	free_percpu(cgroup->psi->pcpu);
+ 	/* All triggers must be removed by now */
+ 	WARN_ONCE(cgroup->psi->rtpoll_states, "psi: trigger leak\n");
+diff --git a/kernel/trace/ring_buffer.c b/kernel/trace/ring_buffer.c
+index 0f761bca5135de..0b2ed121741e15 100644
+--- a/kernel/trace/ring_buffer.c
++++ b/kernel/trace/ring_buffer.c
+@@ -6090,7 +6090,7 @@ static __init int test_ringbuffer(void)
+ 
+  out_free:
+ 	for_each_online_cpu(cpu) {
+-		if (!rb_threads[cpu])
++		if (IS_ERR_OR_NULL(rb_threads[cpu]))
+ 			break;
+ 		kthread_stop(rb_threads[cpu]);
+ 	}
+diff --git a/kernel/trace/trace_events.c b/kernel/trace/trace_events.c
+index 9588344ef8f7b6..bd8167d006f91f 100644
+--- a/kernel/trace/trace_events.c
++++ b/kernel/trace/trace_events.c
+@@ -3038,6 +3038,7 @@ void trace_event_eval_update(struct trace_eval_map **map, int len)
+ 	int last_i;
+ 	int i;
+ 
++	mutex_lock(&event_mutex);
+ 	down_write(&trace_event_sem);
+ 	list_for_each_entry_safe(call, p, &ftrace_events, list) {
+ 		/* events are usually grouped together with systems */
+@@ -3071,6 +3072,7 @@ void trace_event_eval_update(struct trace_eval_map **map, int len)
+ 		cond_resched();
+ 	}
+ 	up_write(&trace_event_sem);
++	mutex_unlock(&event_mutex);
+ }
+ 
+ static bool event_in_systems(struct trace_event_call *call,
+diff --git a/lib/.gitignore b/lib/.gitignore
+index 54596b634ecbff..101a4aa92fb537 100644
+--- a/lib/.gitignore
++++ b/lib/.gitignore
+@@ -5,5 +5,3 @@
+ /gen_crc32table
+ /gen_crc64table
+ /oid_registry_data.c
+-/test_fortify.log
+-/test_fortify/*.log
+diff --git a/lib/Makefile b/lib/Makefile
+index b9d2577fbbe190..62737ad5aa74ed 100644
+--- a/lib/Makefile
++++ b/lib/Makefile
+@@ -407,36 +407,4 @@ CFLAGS_longest_symbol_kunit.o += $(call cc-disable-warning, missing-prototypes)
+ 
+ obj-$(CONFIG_GENERIC_LIB_DEVMEM_IS_ALLOWED) += devmem_is_allowed.o
+ 
+-# FORTIFY_SOURCE compile-time behavior tests
+-TEST_FORTIFY_SRCS = $(wildcard $(srctree)/$(src)/test_fortify/*-*.c)
+-TEST_FORTIFY_LOGS = $(patsubst $(srctree)/$(src)/%.c, %.log, $(TEST_FORTIFY_SRCS))
+-TEST_FORTIFY_LOG = test_fortify.log
+-
+-quiet_cmd_test_fortify = TEST    $@
+-      cmd_test_fortify = $(CONFIG_SHELL) $(srctree)/scripts/test_fortify.sh \
+-			$< $@ "$(NM)" $(CC) $(c_flags) \
+-			$(call cc-disable-warning,fortify-source) \
+-			-DKBUILD_EXTRA_WARN1
+-
+-targets += $(TEST_FORTIFY_LOGS)
+-clean-files += $(TEST_FORTIFY_LOGS)
+-clean-files += $(addsuffix .o, $(TEST_FORTIFY_LOGS))
+-$(obj)/test_fortify/%.log: $(src)/test_fortify/%.c \
+-			   $(src)/test_fortify/test_fortify.h \
+-			   $(srctree)/include/linux/fortify-string.h \
+-			   $(srctree)/scripts/test_fortify.sh \
+-			   FORCE
+-	$(call if_changed,test_fortify)
+-
+-quiet_cmd_gen_fortify_log = GEN     $@
+-      cmd_gen_fortify_log = cat </dev/null $(filter-out FORCE,$^) 2>/dev/null > $@ || true
+-
+-targets += $(TEST_FORTIFY_LOG)
+-clean-files += $(TEST_FORTIFY_LOG)
+-$(obj)/$(TEST_FORTIFY_LOG): $(addprefix $(obj)/, $(TEST_FORTIFY_LOGS)) FORCE
+-	$(call if_changed,gen_fortify_log)
+-
+-# Fake dependency to trigger the fortify tests.
+-ifeq ($(CONFIG_FORTIFY_SOURCE),y)
+-$(obj)/string.o: $(obj)/$(TEST_FORTIFY_LOG)
+-endif
++subdir-$(CONFIG_FORTIFY_SOURCE) += test_fortify
+diff --git a/lib/test_fortify/.gitignore b/lib/test_fortify/.gitignore
+new file mode 100644
+index 00000000000000..c1ba37d14b50e3
+--- /dev/null
++++ b/lib/test_fortify/.gitignore
+@@ -0,0 +1,2 @@
++# SPDX-License-Identifier: GPL-2.0-only
++/*.log
+diff --git a/lib/test_fortify/Makefile b/lib/test_fortify/Makefile
+new file mode 100644
+index 00000000000000..eba2ba0faeb6a4
+--- /dev/null
++++ b/lib/test_fortify/Makefile
+@@ -0,0 +1,29 @@
++# SPDX-License-Identifier: GPL-2.0
++
++ccflags-y := $(call cc-disable-warning,fortify-source)
++ccflags-y += $(call cc-disable-warning,stringop-overread)
++
++quiet_cmd_test_fortify = TEST    $@
++      cmd_test_fortify = $(CONFIG_SHELL) $(srctree)/scripts/test_fortify.sh \
++			$< $@ "$(NM)" $(CC) $(c_flags) -DKBUILD_EXTRA_WARN1
++
++$(obj)/%.log: $(src)/%.c $(srctree)/scripts/test_fortify.sh \
++	      $(src)/test_fortify.h \
++	      $(srctree)/include/linux/fortify-string.h \
++	      FORCE
++	$(call if_changed,test_fortify)
++
++logs = $(patsubst $(srctree)/$(src)/%.c, %.log, $(wildcard $(srctree)/$(src)/*-*.c))
++targets += $(logs)
++
++quiet_cmd_gen_fortify_log = CAT     $@
++      cmd_gen_fortify_log = cat $(or $(real-prereqs),/dev/null) > $@
++
++$(obj)/test_fortify.log: $(addprefix $(obj)/, $(logs)) FORCE
++	$(call if_changed,gen_fortify_log)
++
++always-y += test_fortify.log
++
++# Some architectures define __NO_FORTIFY if __SANITIZE_ADDRESS__ is undefined.
++# Pass CFLAGS_KASAN to avoid warnings.
++KASAN_SANITIZE := y
+diff --git a/net/atm/common.c b/net/atm/common.c
+index 96f680a45e306d..f3f68c231935aa 100644
+--- a/net/atm/common.c
++++ b/net/atm/common.c
+@@ -760,7 +760,7 @@ int vcc_setsockopt(struct socket *sock, int level, int optname,
+ 		   sockptr_t optval, unsigned int optlen)
+ {
+ 	struct atm_vcc *vcc;
+-	unsigned long value;
++	int value;
+ 	int error;
+ 
+ 	if (__SO_LEVEL_MATCH(optname, level) && optlen != __SO_SIZE(optname))
+@@ -772,8 +772,10 @@ int vcc_setsockopt(struct socket *sock, int level, int optname,
+ 	{
+ 		struct atm_qos qos;
+ 
+-		if (copy_from_sockptr(&qos, optval, sizeof(qos)))
+-			return -EFAULT;
++		error = copy_safe_from_sockptr(&qos, sizeof(qos), optval,
++					       optlen);
++		if (error)
++			return error;
+ 		error = check_qos(&qos);
+ 		if (error)
+ 			return error;
+@@ -786,8 +788,10 @@ int vcc_setsockopt(struct socket *sock, int level, int optname,
+ 		return 0;
+ 	}
+ 	case SO_SETCLP:
+-		if (copy_from_sockptr(&value, optval, sizeof(value)))
+-			return -EFAULT;
++		error = copy_safe_from_sockptr(&value, sizeof(value), optval,
++					       optlen);
++		if (error)
++			return error;
+ 		if (value)
+ 			vcc->atm_options |= ATM_ATMOPT_CLP;
+ 		else
+diff --git a/net/bridge/br_mrp.c b/net/bridge/br_mrp.c
+index 5fd22bb4f5b604..a837ff7d6f36d9 100644
+--- a/net/bridge/br_mrp.c
++++ b/net/bridge/br_mrp.c
+@@ -224,11 +224,9 @@ static struct sk_buff *br_mrp_alloc_test_skb(struct br_mrp *mrp,
+ 		sub_opt = skb_put(skb, sizeof(*sub_opt));
+ 		memset(sub_opt, 0x0, sizeof(*sub_opt));
+ 
+-		sub_tlv = skb_put(skb, sizeof(*sub_tlv));
+-		sub_tlv->type = BR_MRP_SUB_TLV_HEADER_TEST_AUTO_MGR;
+-
+ 		/* 32 bit alligment shall be ensured therefore add 2 bytes */
+-		skb_put(skb, MRP_OPT_PADDING);
++		sub_tlv = skb_put_zero(skb, sizeof(*sub_tlv) + MRP_OPT_PADDING);
++		sub_tlv->type = BR_MRP_SUB_TLV_HEADER_TEST_AUTO_MGR;
+ 	}
+ 
+ 	br_mrp_skb_tlv(skb, BR_MRP_TLV_HEADER_END, 0x0);
+diff --git a/net/bridge/netfilter/ebt_nflog.c b/net/bridge/netfilter/ebt_nflog.c
+index 61bf8f4465ab7d..426f8adc912c75 100644
+--- a/net/bridge/netfilter/ebt_nflog.c
++++ b/net/bridge/netfilter/ebt_nflog.c
+@@ -41,11 +41,25 @@ ebt_nflog_tg(struct sk_buff *skb, const struct xt_action_param *par)
+ static int ebt_nflog_tg_check(const struct xt_tgchk_param *par)
+ {
+ 	struct ebt_nflog_info *info = par->targinfo;
++	int ret;
+ 
+ 	if (info->flags & ~EBT_NFLOG_MASK)
+ 		return -EINVAL;
+ 	info->prefix[EBT_NFLOG_PREFIX_SIZE - 1] = '\0';
+-	return 0;
++
++	ret = nf_logger_find_get(par->family, NF_LOG_TYPE_ULOG);
++	if (ret != 0 && !par->nft_compat) {
++		request_module("%s", "nfnetlink_log");
++
++		ret = nf_logger_find_get(par->family, NF_LOG_TYPE_ULOG);
++	}
++
++	return ret;
++}
++
++static void ebt_nflog_tg_destroy(const struct xt_tgdtor_param *par)
++{
++	nf_logger_put(par->family, NF_LOG_TYPE_ULOG);
+ }
+ 
+ static struct xt_target ebt_nflog_tg_reg __read_mostly = {
+@@ -54,6 +68,7 @@ static struct xt_target ebt_nflog_tg_reg __read_mostly = {
+ 	.family     = NFPROTO_BRIDGE,
+ 	.target     = ebt_nflog_tg,
+ 	.checkentry = ebt_nflog_tg_check,
++	.destroy    = ebt_nflog_tg_destroy,
+ 	.targetsize = sizeof(struct ebt_nflog_info),
+ 	.me         = THIS_MODULE,
+ };
+diff --git a/net/bridge/netfilter/nf_conntrack_bridge.c b/net/bridge/netfilter/nf_conntrack_bridge.c
+index 4b4a396d972259..8834a45f697b8d 100644
+--- a/net/bridge/netfilter/nf_conntrack_bridge.c
++++ b/net/bridge/netfilter/nf_conntrack_bridge.c
+@@ -281,6 +281,7 @@ static unsigned int nf_ct_bridge_pre(void *priv, struct sk_buff *skb,
+ 		ret = nf_ct_br_defrag6(skb, &bridge_state);
+ 		break;
+ 	default:
++		nf_reset_ct(skb);
+ 		nf_ct_set(skb, NULL, IP_CT_UNTRACKED);
+ 		return NF_ACCEPT;
+ 	}
+diff --git a/net/core/dev.c b/net/core/dev.c
+index 0cc03e6c6fb144..0fa5431de2cc09 100644
+--- a/net/core/dev.c
++++ b/net/core/dev.c
+@@ -2146,6 +2146,11 @@ void net_dec_egress_queue(void)
+ EXPORT_SYMBOL_GPL(net_dec_egress_queue);
+ #endif
+ 
++#ifdef CONFIG_NET_CLS_ACT
++DEFINE_STATIC_KEY_FALSE(tcf_sw_enabled_key);
++EXPORT_SYMBOL(tcf_sw_enabled_key);
++#endif
++
+ DEFINE_STATIC_KEY_FALSE(netstamp_needed_key);
+ EXPORT_SYMBOL(netstamp_needed_key);
+ #ifdef CONFIG_JUMP_LABEL
+@@ -4030,6 +4035,14 @@ static int tc_run(struct tcx_entry *entry, struct sk_buff *skb)
+ 	if (!miniq)
+ 		return ret;
+ 
++	/* Global bypass */
++	if (!static_branch_likely(&tcf_sw_enabled_key))
++		return ret;
++
++	/* Block-wise bypass */
++	if (tcf_block_bypass_sw(miniq->block))
++		return ret;
++
+ 	tc_skb_cb(skb)->mru = 0;
+ 	tc_skb_cb(skb)->post_ct = false;
+ 
+diff --git a/net/core/sock.c b/net/core/sock.c
+index 87e6060c8bca7f..846e95805c1996 100644
+--- a/net/core/sock.c
++++ b/net/core/sock.c
+@@ -776,7 +776,6 @@ bool sk_mc_loop(struct sock *sk)
+ 		return inet6_sk(sk)->mc_loop;
+ #endif
+ 	}
+-	WARN_ON_ONCE(1);
+ 	return true;
+ }
+ EXPORT_SYMBOL(sk_mc_loop);
+diff --git a/net/core/xdp.c b/net/core/xdp.c
+index 5ee3f8f165e5aa..f640576090f207 100644
+--- a/net/core/xdp.c
++++ b/net/core/xdp.c
+@@ -674,7 +674,7 @@ struct xdp_frame *xdpf_clone(struct xdp_frame *xdpf)
+ 	headroom = xdpf->headroom + sizeof(*xdpf);
+ 	totalsize = headroom + xdpf->len;
+ 
+-	if (unlikely(totalsize > PAGE_SIZE))
++	if (unlikely(totalsize > SKB_WITH_OVERHEAD(PAGE_SIZE)))
+ 		return NULL;
+ 	page = dev_alloc_page();
+ 	if (!page)
+diff --git a/net/devlink/dev.c b/net/devlink/dev.c
+index bba4ace7d22ba8..c70d4dc599b85d 100644
+--- a/net/devlink/dev.c
++++ b/net/devlink/dev.c
+@@ -505,6 +505,7 @@ int devlink_nl_cmd_reload(struct sk_buff *skb, struct genl_info *info)
+ 		    action != DEVLINK_RELOAD_ACTION_DRIVER_REINIT) {
+ 			NL_SET_ERR_MSG_MOD(info->extack,
+ 					   "Changing namespace is only supported for reinit action");
++			put_net(dest_net);
+ 			return -EOPNOTSUPP;
+ 		}
+ 	}
+diff --git a/net/ipv4/Kconfig b/net/ipv4/Kconfig
+index 2dfb12230f0894..8e94ed7c56a0ea 100644
+--- a/net/ipv4/Kconfig
++++ b/net/ipv4/Kconfig
+@@ -741,10 +741,27 @@ config DEFAULT_TCP_CONG
+ 	default "bbr" if DEFAULT_BBR
+ 	default "cubic"
+ 
++config TCP_SIGPOOL
++	tristate
++
++config TCP_AO
++	bool "TCP: Authentication Option (RFC5925)"
++	select CRYPTO
++	select TCP_SIGPOOL
++	depends on 64BIT && IPV6 != m # seq-number extension needs WRITE_ONCE(u64)
++	help
++	  TCP-AO specifies the use of stronger Message Authentication Codes (MACs),
++	  protects against replays for long-lived TCP connections, and
++	  provides more details on the association of security with TCP
++	  connections than TCP MD5 (See RFC5925)
++
++	  If unsure, say N.
++
+ config TCP_MD5SIG
+ 	bool "TCP: MD5 Signature Option support (RFC2385)"
+ 	select CRYPTO
+ 	select CRYPTO_MD5
++	select TCP_SIGPOOL
+ 	help
+ 	  RFC2385 specifies a method of giving MD5 protection to TCP sessions.
+ 	  Its main (only?) use is to protect BGP sessions between core routers
+diff --git a/net/ipv4/Makefile b/net/ipv4/Makefile
+index b18ba8ef93ad2b..cd760793cfcbae 100644
+--- a/net/ipv4/Makefile
++++ b/net/ipv4/Makefile
+@@ -62,6 +62,7 @@ obj-$(CONFIG_TCP_CONG_SCALABLE) += tcp_scalable.o
+ obj-$(CONFIG_TCP_CONG_LP) += tcp_lp.o
+ obj-$(CONFIG_TCP_CONG_YEAH) += tcp_yeah.o
+ obj-$(CONFIG_TCP_CONG_ILLINOIS) += tcp_illinois.o
++obj-$(CONFIG_TCP_SIGPOOL) += tcp_sigpool.o
+ obj-$(CONFIG_NET_SOCK_MSG) += tcp_bpf.o
+ obj-$(CONFIG_BPF_SYSCALL) += udp_bpf.o
+ obj-$(CONFIG_NETLABEL) += cipso_ipv4.o
+diff --git a/net/ipv4/fib_semantics.c b/net/ipv4/fib_semantics.c
+index 233d9d0437c278..facbda1ff51d74 100644
+--- a/net/ipv4/fib_semantics.c
++++ b/net/ipv4/fib_semantics.c
+@@ -462,6 +462,34 @@ int ip_fib_check_default(__be32 gw, struct net_device *dev)
+ 	return -1;
+ }
+ 
++static size_t fib_nexthop_nlmsg_size(const struct fib_nh_common *nhc,
++				     bool skip_oif)
++{
++	size_t nhsize = 0;
++
++	switch (nhc->nhc_gw_family) {
++	case AF_INET:
++		nhsize += nla_total_size(4); /* RTA_GATEWAY */
++		break;
++	case AF_INET6:
++		nhsize += nla_total_size(sizeof(struct rtvia) +
++					 sizeof(struct in6_addr));
++		break;
++	}
++
++	if (!skip_oif && nhc->nhc_dev)
++		nhsize += nla_total_size(4); /* RTA_OIF */
++
++	if (nhc->nhc_lwtstate) {
++		/* RTA_ENCAP */
++		nhsize += lwtunnel_get_encap_size(nhc->nhc_lwtstate);
++		/* RTA_ENCAP_TYPE */
++		nhsize += nla_total_size(2);
++	}
++
++	return nhsize;
++}
++
+ size_t fib_nlmsg_size(struct fib_info *fi)
+ {
+ 	size_t payload = NLMSG_ALIGN(sizeof(struct rtmsg))
+@@ -479,32 +507,35 @@ size_t fib_nlmsg_size(struct fib_info *fi)
+ 		payload += nla_total_size(4); /* RTA_NH_ID */
+ 
+ 	if (nhs) {
+-		size_t nh_encapsize = 0;
+-		/* Also handles the special case nhs == 1 */
+-
+-		/* each nexthop is packed in an attribute */
+-		size_t nhsize = nla_total_size(sizeof(struct rtnexthop));
++		size_t mpsize = 0;
+ 		unsigned int i;
+ 
+-		/* may contain flow and gateway attribute */
+-		nhsize += 2 * nla_total_size(4);
+-
+-		/* grab encap info */
+ 		for (i = 0; i < fib_info_num_path(fi); i++) {
+ 			struct fib_nh_common *nhc = fib_info_nhc(fi, i);
++			size_t nhsize;
++
++			nhsize = fib_nexthop_nlmsg_size(nhc, nhs != 1);
++
++			if (nhs != 1)
++				nhsize += NLA_ALIGN(sizeof(struct rtnexthop));
++
++#ifdef CONFIG_IP_ROUTE_CLASSID
++			if (nhc->nhc_family == AF_INET) {
++				struct fib_nh *nh;
+ 
+-			if (nhc->nhc_lwtstate) {
+-				/* RTA_ENCAP_TYPE */
+-				nh_encapsize += lwtunnel_get_encap_size(
+-						nhc->nhc_lwtstate);
+-				/* RTA_ENCAP */
+-				nh_encapsize +=  nla_total_size(2);
++				nh = container_of(nhc, struct fib_nh, nh_common);
++				if (nh->nh_tclassid)
++					nhsize += nla_total_size(4);
+ 			}
++#endif
++			if (nhs == 1)
++				payload += nhsize;
++			else
++				mpsize += nhsize;
+ 		}
+ 
+-		/* all nexthops are packed in a nested attribute */
+-		payload += nla_total_size((nhs * nhsize) + nh_encapsize);
+-
++		if (nhs != 1)
++			payload += nla_total_size(mpsize);
+ 	}
+ 
+ 	return payload;
+@@ -1926,42 +1957,30 @@ static int call_fib_nh_notifiers(struct fib_nh *nh,
+ 	return NOTIFY_DONE;
+ }
+ 
+-/* Update the PMTU of exceptions when:
+- * - the new MTU of the first hop becomes smaller than the PMTU
+- * - the old MTU was the same as the PMTU, and it limited discovery of
+- *   larger MTUs on the path. With that limit raised, we can now
+- *   discover larger MTUs
+- * A special case is locked exceptions, for which the PMTU is smaller
+- * than the minimal accepted PMTU:
+- * - if the new MTU is greater than the PMTU, don't make any change
+- * - otherwise, unlock and set PMTU
++/* Walk the exceptions of a nexthop after its first hop MTU changed. The
++ * chain is RCU protected here, while fnhe_update_pmtu() takes fnhe_lock
++ * for the update of each entry.
+  */
+ void fib_nhc_update_mtu(struct fib_nh_common *nhc, u32 new, u32 orig)
+ {
+ 	struct fnhe_hash_bucket *bucket;
+ 	int i;
+ 
+-	bucket = rcu_dereference_protected(nhc->nhc_exceptions, 1);
++	rcu_read_lock();
++	bucket = rcu_dereference(nhc->nhc_exceptions);
+ 	if (!bucket)
+-		return;
++		goto out;
+ 
+ 	for (i = 0; i < FNHE_HASH_SIZE; i++) {
+ 		struct fib_nh_exception *fnhe;
+ 
+-		for (fnhe = rcu_dereference_protected(bucket[i].chain, 1);
++		for (fnhe = rcu_dereference(bucket[i].chain);
+ 		     fnhe;
+-		     fnhe = rcu_dereference_protected(fnhe->fnhe_next, 1)) {
+-			if (fnhe->fnhe_mtu_locked) {
+-				if (new <= fnhe->fnhe_pmtu) {
+-					fnhe->fnhe_pmtu = new;
+-					fnhe->fnhe_mtu_locked = false;
+-				}
+-			} else if (new < fnhe->fnhe_pmtu ||
+-				   orig == fnhe->fnhe_pmtu) {
+-				fnhe->fnhe_pmtu = new;
+-			}
+-		}
++		     fnhe = rcu_dereference(fnhe->fnhe_next))
++			fnhe_update_pmtu(fnhe, new, orig);
+ 	}
++out:
++	rcu_read_unlock();
+ }
+ 
+ void fib_sync_mtu(struct net_device *dev, u32 orig_mtu)
+diff --git a/net/ipv4/inet_connection_sock.c b/net/ipv4/inet_connection_sock.c
+index c7a1f763e464e4..208f8b173a0561 100644
+--- a/net/ipv4/inet_connection_sock.c
++++ b/net/ipv4/inet_connection_sock.c
+@@ -930,11 +930,23 @@ static struct request_sock *inet_reqsk_clone(struct request_sock *req,
+ 
+ 	nreq->rsk_listener = sk;
+ 
+-	/* We need not acquire fastopenq->lock
+-	 * because the child socket is locked in inet_csk_listen_stop().
+-	 */
+-	if (sk->sk_protocol == IPPROTO_TCP && tcp_rsk(nreq)->tfo_listener)
++	if (sk->sk_protocol == IPPROTO_TCP && tcp_rsk(nreq)->tfo_listener) {
++		struct fastopen_queue *fastopenq;
++
++		/* reqsk_fastopen_remove() will uncharge nreq->rsk_listener,
++		 * that is @sk, so charge it here.  Unlike the listener
++		 * being closed, @sk is live and needs its lock.
++		 */
++		fastopenq = &inet_csk(sk)->icsk_accept_queue.fastopenq;
++		spin_lock_bh(&fastopenq->lock);
++		fastopenq->qlen++;
++		spin_unlock_bh(&fastopenq->lock);
++
++		/* We need not acquire fastopenq->lock
++		 * because the child socket is locked in inet_csk_listen_stop().
++		 */
+ 		rcu_assign_pointer(tcp_sk(nreq->sk)->fastopen_rsk, nreq);
++	}
+ 
+ 	return nreq;
+ }
+diff --git a/net/ipv4/route.c b/net/ipv4/route.c
+index 87eaae03e618aa..789953096c80d2 100644
+--- a/net/ipv4/route.c
++++ b/net/ipv4/route.c
+@@ -751,6 +751,35 @@ out_unlock:
+ 	spin_unlock_bh(&fnhe_lock);
+ }
+ 
++/* Update the PMTU of an exception when:
++ * - the new MTU of the first hop becomes smaller than the PMTU
++ * - the old MTU was the same as the PMTU, and it limited discovery of
++ *   larger MTUs on the path. With that limit raised, we can now
++ *   discover larger MTUs
++ * A special case is locked exceptions, for which the PMTU is smaller
++ * than the minimal accepted PMTU:
++ * - if the new MTU is greater than the PMTU, don't make any change
++ * - otherwise, unlock and set PMTU
++ *
++ * fnhe_lock keeps fnhe_pmtu and fnhe_mtu_locked consistent against
++ * update_or_create_fnhe(), which sets both under the same lock.
++ */
++void fnhe_update_pmtu(struct fib_nh_exception *fnhe, u32 new, u32 orig)
++{
++	spin_lock_bh(&fnhe_lock);
++
++	if (fnhe->fnhe_mtu_locked) {
++		if (new <= fnhe->fnhe_pmtu) {
++			fnhe->fnhe_pmtu = new;
++			fnhe->fnhe_mtu_locked = false;
++		}
++	} else if (new < fnhe->fnhe_pmtu || orig == fnhe->fnhe_pmtu) {
++		fnhe->fnhe_pmtu = new;
++	}
++
++	spin_unlock_bh(&fnhe_lock);
++}
++
+ static void __ip_do_redirect(struct rtable *rt, struct sk_buff *skb, struct flowi4 *fl4,
+ 			     bool kill_route)
+ {
+diff --git a/net/ipv4/tcp.c b/net/ipv4/tcp.c
+index 5b1fbb0ca2ff6e..f05d1699683ff7 100644
+--- a/net/ipv4/tcp.c
++++ b/net/ipv4/tcp.c
+@@ -4365,141 +4365,52 @@ int tcp_getsockopt(struct sock *sk, int level, int optname, char __user *optval,
+ EXPORT_SYMBOL(tcp_getsockopt);
+ 
+ #ifdef CONFIG_TCP_MD5SIG
+-static DEFINE_PER_CPU(struct tcp_md5sig_pool, tcp_md5sig_pool);
+-static DEFINE_MUTEX(tcp_md5sig_mutex);
+-static bool tcp_md5sig_pool_populated = false;
++int tcp_md5_sigpool_id = -1;
++EXPORT_SYMBOL_GPL(tcp_md5_sigpool_id);
+ 
+-static void __tcp_alloc_md5sig_pool(void)
++int tcp_md5_alloc_sigpool(void)
+ {
+-	struct crypto_ahash *hash;
+-	int cpu;
+-
+-	hash = crypto_alloc_ahash("md5", 0, CRYPTO_ALG_ASYNC);
+-	if (IS_ERR(hash))
+-		return;
+-
+-	for_each_possible_cpu(cpu) {
+-		void *scratch = per_cpu(tcp_md5sig_pool, cpu).scratch;
+-		struct ahash_request *req;
+-
+-		if (!scratch) {
+-			scratch = kmalloc_node(sizeof(union tcp_md5sum_block) +
+-					       sizeof(struct tcphdr),
+-					       GFP_KERNEL,
+-					       cpu_to_node(cpu));
+-			if (!scratch)
+-				return;
+-			per_cpu(tcp_md5sig_pool, cpu).scratch = scratch;
+-		}
+-		if (per_cpu(tcp_md5sig_pool, cpu).md5_req)
+-			continue;
+-
+-		req = ahash_request_alloc(hash, GFP_KERNEL);
+-		if (!req)
+-			return;
+-
+-		ahash_request_set_callback(req, 0, NULL, NULL);
+-
+-		per_cpu(tcp_md5sig_pool, cpu).md5_req = req;
+-	}
+-	/* before setting tcp_md5sig_pool_populated, we must commit all writes
+-	 * to memory. See smp_rmb() in tcp_get_md5sig_pool()
+-	 */
+-	smp_wmb();
+-	/* Paired with READ_ONCE() from tcp_alloc_md5sig_pool()
+-	 * and tcp_get_md5sig_pool().
+-	*/
+-	WRITE_ONCE(tcp_md5sig_pool_populated, true);
+-}
+-
+-bool tcp_alloc_md5sig_pool(void)
+-{
+-	/* Paired with WRITE_ONCE() from __tcp_alloc_md5sig_pool() */
+-	if (unlikely(!READ_ONCE(tcp_md5sig_pool_populated))) {
+-		mutex_lock(&tcp_md5sig_mutex);
+-
+-		if (!tcp_md5sig_pool_populated)
+-			__tcp_alloc_md5sig_pool();
++	size_t scratch_size;
++	int ret;
+ 
+-		mutex_unlock(&tcp_md5sig_mutex);
++	scratch_size = sizeof(union tcp_md5sum_block) + sizeof(struct tcphdr);
++	ret = tcp_sigpool_alloc_ahash("md5", scratch_size);
++	if (ret >= 0) {
++		/* As long as any md5 sigpool was allocated, the return
++		 * id would stay the same. Re-write the id only for the case
++		 * when previously all MD5 keys were deleted and this call
++		 * allocates the first MD5 key, which may return a different
++		 * sigpool id than was used previously.
++		 */
++		WRITE_ONCE(tcp_md5_sigpool_id, ret); /* Avoids the compiler potentially being smart here */
++		return 0;
+ 	}
+-	/* Paired with WRITE_ONCE() from __tcp_alloc_md5sig_pool() */
+-	return READ_ONCE(tcp_md5sig_pool_populated);
++	return ret;
+ }
+-EXPORT_SYMBOL(tcp_alloc_md5sig_pool);
+-
+ 
+-/**
+- *	tcp_get_md5sig_pool - get md5sig_pool for this user
+- *
+- *	We use percpu structure, so if we succeed, we exit with preemption
+- *	and BH disabled, to make sure another thread or softirq handling
+- *	wont try to get same context.
+- */
+-struct tcp_md5sig_pool *tcp_get_md5sig_pool(void)
++void tcp_md5_release_sigpool(void)
+ {
+-	local_bh_disable();
+-
+-	/* Paired with WRITE_ONCE() from __tcp_alloc_md5sig_pool() */
+-	if (READ_ONCE(tcp_md5sig_pool_populated)) {
+-		/* coupled with smp_wmb() in __tcp_alloc_md5sig_pool() */
+-		smp_rmb();
+-		return this_cpu_ptr(&tcp_md5sig_pool);
+-	}
+-	local_bh_enable();
+-	return NULL;
++	tcp_sigpool_release(READ_ONCE(tcp_md5_sigpool_id));
+ }
+-EXPORT_SYMBOL(tcp_get_md5sig_pool);
+ 
+-int tcp_md5_hash_skb_data(struct tcp_md5sig_pool *hp,
+-			  const struct sk_buff *skb, unsigned int header_len)
++void tcp_md5_add_sigpool(void)
+ {
+-	struct scatterlist sg;
+-	const struct tcphdr *tp = tcp_hdr(skb);
+-	struct ahash_request *req = hp->md5_req;
+-	unsigned int i;
+-	const unsigned int head_data_len = skb_headlen(skb) > header_len ?
+-					   skb_headlen(skb) - header_len : 0;
+-	const struct skb_shared_info *shi = skb_shinfo(skb);
+-	struct sk_buff *frag_iter;
+-
+-	sg_init_table(&sg, 1);
+-
+-	sg_set_buf(&sg, ((u8 *) tp) + header_len, head_data_len);
+-	ahash_request_set_crypt(req, &sg, NULL, head_data_len);
+-	if (crypto_ahash_update(req))
+-		return 1;
+-
+-	for (i = 0; i < shi->nr_frags; ++i) {
+-		const skb_frag_t *f = &shi->frags[i];
+-		unsigned int offset = skb_frag_off(f);
+-		struct page *page = skb_frag_page(f) + (offset >> PAGE_SHIFT);
+-
+-		sg_set_page(&sg, page, skb_frag_size(f),
+-			    offset_in_page(offset));
+-		ahash_request_set_crypt(req, &sg, NULL, skb_frag_size(f));
+-		if (crypto_ahash_update(req))
+-			return 1;
+-	}
+-
+-	skb_walk_frags(skb, frag_iter)
+-		if (tcp_md5_hash_skb_data(hp, frag_iter, 0))
+-			return 1;
+-
+-	return 0;
++	tcp_sigpool_get(READ_ONCE(tcp_md5_sigpool_id));
+ }
+-EXPORT_SYMBOL(tcp_md5_hash_skb_data);
+ 
+-int tcp_md5_hash_key(struct tcp_md5sig_pool *hp, const struct tcp_md5sig_key *key)
++int tcp_md5_hash_key(struct tcp_sigpool *hp,
++		     const struct tcp_md5sig_key *key)
+ {
+ 	u8 keylen = READ_ONCE(key->keylen); /* paired with WRITE_ONCE() in tcp_md5_do_add */
+ 	struct scatterlist sg;
+ 
+ 	sg_init_one(&sg, key->key, keylen);
+-	ahash_request_set_crypt(hp->md5_req, &sg, NULL, keylen);
++	ahash_request_set_crypt(hp->req, &sg, NULL, keylen);
+ 
+-	/* We use data_race() because tcp_md5_do_add() might change key->key under us */
+-	return data_race(crypto_ahash_update(hp->md5_req));
++	/* We use data_race() because tcp_md5_do_add() might change
++	 * key->key under us
++	 */
++	return data_race(crypto_ahash_update(hp->req));
+ }
+ EXPORT_SYMBOL(tcp_md5_hash_key);
+ 
+diff --git a/net/ipv4/tcp_bpf.c b/net/ipv4/tcp_bpf.c
+index 337f6edd4757e3..a4a4434171a04c 100644
+--- a/net/ipv4/tcp_bpf.c
++++ b/net/ipv4/tcp_bpf.c
+@@ -455,6 +455,7 @@ more_data:
+ 	case __SK_REDIRECT:
+ 		redir_ingress = psock->redir_ingress;
+ 		sk_redir = psock->sk_redir;
++		sock_hold(sk_redir);
+ 		sk_msg_apply_bytes(psock, tosend);
+ 		if (!psock->apply_bytes) {
+ 			/* Clean up before releasing the sock lock. */
+@@ -475,6 +476,7 @@ more_data:
+ 
+ 		if (eval == __SK_REDIRECT)
+ 			sock_put(sk_redir);
++		sock_put(sk_redir);
+ 
+ 		lock_sock(sk);
+ 		sk_mem_uncharge(sk, sent);
+diff --git a/net/ipv4/tcp_input.c b/net/ipv4/tcp_input.c
+index eb1bf586347413..9efb84658a82dc 100644
+--- a/net/ipv4/tcp_input.c
++++ b/net/ipv4/tcp_input.c
+@@ -252,7 +252,7 @@ static void tcp_measure_rcv_mss(struct sock *sk, const struct sk_buff *skb)
+ 				struct tcp_sock *tp = tcp_sk(sk);
+ 
+ 				val = tcp_win_from_space(sk, sk->sk_rcvbuf);
+-				tcp_set_window_clamp(sk, val);
++				WRITE_ONCE(tp->window_clamp, val);
+ 
+ 				if (tp->window_clamp < tp->rcvq_space.space)
+ 					tp->rcvq_space.space = tp->window_clamp;
+diff --git a/net/ipv4/tcp_ipv4.c b/net/ipv4/tcp_ipv4.c
+index c8d35f1c0ece23..3f9e1cfde00833 100644
+--- a/net/ipv4/tcp_ipv4.c
++++ b/net/ipv4/tcp_ipv4.c
+@@ -58,6 +58,7 @@
+ #include <linux/times.h>
+ #include <linux/slab.h>
+ #include <linux/sched.h>
++#include <linux/sock_diag.h>
+ 
+ #include <net/net_namespace.h>
+ #include <net/icmp.h>
+@@ -1226,10 +1227,6 @@ static int __tcp_md5_do_add(struct sock *sk, const union tcp_md5_addr *addr,
+ 	key = sock_kmalloc(sk, sizeof(*key), gfp | __GFP_ZERO);
+ 	if (!key)
+ 		return -ENOMEM;
+-	if (!tcp_alloc_md5sig_pool()) {
+-		sock_kfree_s(sk, key, sizeof(*key));
+-		return -ENOMEM;
+-	}
+ 
+ 	memcpy(key->key, newkey, newkeylen);
+ 	key->keylen = newkeylen;
+@@ -1251,15 +1248,21 @@ int tcp_md5_do_add(struct sock *sk, const union tcp_md5_addr *addr,
+ 	struct tcp_sock *tp = tcp_sk(sk);
+ 
+ 	if (!rcu_dereference_protected(tp->md5sig_info, lockdep_sock_is_held(sk))) {
+-		if (tcp_md5sig_info_add(sk, GFP_KERNEL))
++		if (tcp_md5_alloc_sigpool())
+ 			return -ENOMEM;
+ 
++		if (tcp_md5sig_info_add(sk, GFP_KERNEL)) {
++			tcp_md5_release_sigpool();
++			return -ENOMEM;
++		}
++
+ 		if (!static_branch_inc(&tcp_md5_needed.key)) {
+ 			struct tcp_md5sig_info *md5sig;
+ 
+ 			md5sig = rcu_dereference_protected(tp->md5sig_info, lockdep_sock_is_held(sk));
+ 			rcu_assign_pointer(tp->md5sig_info, NULL);
+ 			kfree_rcu(md5sig, rcu);
++			tcp_md5_release_sigpool();
+ 			return -EUSERS;
+ 		}
+ 	}
+@@ -1276,8 +1279,12 @@ int tcp_md5_key_copy(struct sock *sk, const union tcp_md5_addr *addr,
+ 	struct tcp_sock *tp = tcp_sk(sk);
+ 
+ 	if (!rcu_dereference_protected(tp->md5sig_info, lockdep_sock_is_held(sk))) {
+-		if (tcp_md5sig_info_add(sk, sk_gfp_mask(sk, GFP_ATOMIC)))
++		tcp_md5_add_sigpool();
++
++		if (tcp_md5sig_info_add(sk, sk_gfp_mask(sk, GFP_ATOMIC))) {
++			tcp_md5_release_sigpool();
+ 			return -ENOMEM;
++		}
+ 
+ 		if (!static_key_fast_inc_not_disabled(&tcp_md5_needed.key.key)) {
+ 			struct tcp_md5sig_info *md5sig;
+@@ -1286,6 +1293,7 @@ int tcp_md5_key_copy(struct sock *sk, const union tcp_md5_addr *addr,
+ 			net_warn_ratelimited("Too many TCP-MD5 keys in the system\n");
+ 			rcu_assign_pointer(tp->md5sig_info, NULL);
+ 			kfree_rcu(md5sig, rcu);
++			tcp_md5_release_sigpool();
+ 			return -EUSERS;
+ 		}
+ 	}
+@@ -1385,7 +1393,7 @@ static int tcp_v4_parse_md5_keys(struct sock *sk, int optname,
+ 			      cmd.tcpm_key, cmd.tcpm_keylen);
+ }
+ 
+-static int tcp_v4_md5_hash_headers(struct tcp_md5sig_pool *hp,
++static int tcp_v4_md5_hash_headers(struct tcp_sigpool *hp,
+ 				   __be32 daddr, __be32 saddr,
+ 				   const struct tcphdr *th, int nbytes)
+ {
+@@ -1405,38 +1413,35 @@ static int tcp_v4_md5_hash_headers(struct tcp_md5sig_pool *hp,
+ 	_th->check = 0;
+ 
+ 	sg_init_one(&sg, bp, sizeof(*bp) + sizeof(*th));
+-	ahash_request_set_crypt(hp->md5_req, &sg, NULL,
++	ahash_request_set_crypt(hp->req, &sg, NULL,
+ 				sizeof(*bp) + sizeof(*th));
+-	return crypto_ahash_update(hp->md5_req);
++	return crypto_ahash_update(hp->req);
+ }
+ 
+ static int tcp_v4_md5_hash_hdr(char *md5_hash, const struct tcp_md5sig_key *key,
+ 			       __be32 daddr, __be32 saddr, const struct tcphdr *th)
+ {
+-	struct tcp_md5sig_pool *hp;
+-	struct ahash_request *req;
++	struct tcp_sigpool hp;
+ 
+-	hp = tcp_get_md5sig_pool();
+-	if (!hp)
+-		goto clear_hash_noput;
+-	req = hp->md5_req;
++	if (tcp_sigpool_start(tcp_md5_sigpool_id, &hp))
++		goto clear_hash_nostart;
+ 
+-	if (crypto_ahash_init(req))
++	if (crypto_ahash_init(hp.req))
+ 		goto clear_hash;
+-	if (tcp_v4_md5_hash_headers(hp, daddr, saddr, th, th->doff << 2))
++	if (tcp_v4_md5_hash_headers(&hp, daddr, saddr, th, th->doff << 2))
+ 		goto clear_hash;
+-	if (tcp_md5_hash_key(hp, key))
++	if (tcp_md5_hash_key(&hp, key))
+ 		goto clear_hash;
+-	ahash_request_set_crypt(req, NULL, md5_hash, 0);
+-	if (crypto_ahash_final(req))
++	ahash_request_set_crypt(hp.req, NULL, md5_hash, 0);
++	if (crypto_ahash_final(hp.req))
+ 		goto clear_hash;
+ 
+-	tcp_put_md5sig_pool();
++	tcp_sigpool_end(&hp);
+ 	return 0;
+ 
+ clear_hash:
+-	tcp_put_md5sig_pool();
+-clear_hash_noput:
++	tcp_sigpool_end(&hp);
++clear_hash_nostart:
+ 	memset(md5_hash, 0, 16);
+ 	return 1;
+ }
+@@ -1445,9 +1450,8 @@ int tcp_v4_md5_hash_skb(char *md5_hash, const struct tcp_md5sig_key *key,
+ 			const struct sock *sk,
+ 			const struct sk_buff *skb)
+ {
+-	struct tcp_md5sig_pool *hp;
+-	struct ahash_request *req;
+ 	const struct tcphdr *th = tcp_hdr(skb);
++	struct tcp_sigpool hp;
+ 	__be32 saddr, daddr;
+ 
+ 	if (sk) { /* valid for establish/request sockets */
+@@ -1459,30 +1463,28 @@ int tcp_v4_md5_hash_skb(char *md5_hash, const struct tcp_md5sig_key *key,
+ 		daddr = iph->daddr;
+ 	}
+ 
+-	hp = tcp_get_md5sig_pool();
+-	if (!hp)
+-		goto clear_hash_noput;
+-	req = hp->md5_req;
++	if (tcp_sigpool_start(tcp_md5_sigpool_id, &hp))
++		goto clear_hash_nostart;
+ 
+-	if (crypto_ahash_init(req))
++	if (crypto_ahash_init(hp.req))
+ 		goto clear_hash;
+ 
+-	if (tcp_v4_md5_hash_headers(hp, daddr, saddr, th, skb->len))
++	if (tcp_v4_md5_hash_headers(&hp, daddr, saddr, th, skb->len))
+ 		goto clear_hash;
+-	if (tcp_md5_hash_skb_data(hp, skb, th->doff << 2))
++	if (tcp_sigpool_hash_skb_data(&hp, skb, th->doff << 2))
+ 		goto clear_hash;
+-	if (tcp_md5_hash_key(hp, key))
++	if (tcp_md5_hash_key(&hp, key))
+ 		goto clear_hash;
+-	ahash_request_set_crypt(req, NULL, md5_hash, 0);
+-	if (crypto_ahash_final(req))
++	ahash_request_set_crypt(hp.req, NULL, md5_hash, 0);
++	if (crypto_ahash_final(hp.req))
+ 		goto clear_hash;
+ 
+-	tcp_put_md5sig_pool();
++	tcp_sigpool_end(&hp);
+ 	return 0;
+ 
+ clear_hash:
+-	tcp_put_md5sig_pool();
+-clear_hash_noput:
++	tcp_sigpool_end(&hp);
++clear_hash_nostart:
+ 	memset(md5_hash, 0, 16);
+ 	return 1;
+ }
+@@ -2310,6 +2312,18 @@ static int tcp_v4_init_sock(struct sock *sk)
+ 	return 0;
+ }
+ 
++#ifdef CONFIG_TCP_MD5SIG
++static void tcp_md5sig_info_free_rcu(struct rcu_head *head)
++{
++	struct tcp_md5sig_info *md5sig;
++
++	md5sig = container_of(head, struct tcp_md5sig_info, rcu);
++	kfree(md5sig);
++	static_branch_slow_dec_deferred(&tcp_md5_needed);
++	tcp_md5_release_sigpool();
++}
++#endif
++
+ void tcp_v4_destroy_sock(struct sock *sk)
+ {
+ 	struct tcp_sock *tp = tcp_sk(sk);
+@@ -2334,10 +2348,12 @@ void tcp_v4_destroy_sock(struct sock *sk)
+ #ifdef CONFIG_TCP_MD5SIG
+ 	/* Clean up the MD5 key list, if any */
+ 	if (tp->md5sig_info) {
++		struct tcp_md5sig_info *md5sig;
++
++		md5sig = rcu_dereference_protected(tp->md5sig_info, 1);
+ 		tcp_clear_md5_list(sk);
+-		kfree_rcu(rcu_dereference_protected(tp->md5sig_info, 1), rcu);
+-		tp->md5sig_info = NULL;
+-		static_branch_slow_dec_deferred(&tcp_md5_needed);
++		call_rcu(&md5sig->rcu, tcp_md5sig_info_free_rcu);
++		rcu_assign_pointer(tp->md5sig_info, NULL);
+ 	}
+ #endif
+ 
+@@ -2776,13 +2792,17 @@ out:
+ }
+ 
+ #ifdef CONFIG_BPF_SYSCALL
++union bpf_tcp_iter_batch_item {
++	struct sock *sk;
++	__u64 cookie;
++};
++
+ struct bpf_tcp_iter_state {
+ 	struct tcp_iter_state state;
+ 	unsigned int cur_sk;
+ 	unsigned int end_sk;
+ 	unsigned int max_sk;
+-	struct sock **batch;
+-	bool st_bucket_done;
++	union bpf_tcp_iter_batch_item *batch;
+ };
+ 
+ struct bpf_iter__tcp {
+@@ -2805,21 +2825,32 @@ static int tcp_prog_seq_show(struct bpf_prog *prog, struct bpf_iter_meta *meta,
+ 
+ static void bpf_iter_tcp_put_batch(struct bpf_tcp_iter_state *iter)
+ {
+-	while (iter->cur_sk < iter->end_sk)
+-		sock_gen_put(iter->batch[iter->cur_sk++]);
++	union bpf_tcp_iter_batch_item *item;
++	unsigned int cur_sk = iter->cur_sk;
++	__u64 cookie;
++
++	/* Remember the cookies of the sockets we haven't seen yet, so we can
++	 * pick up where we left off next time around.
++	 */
++	while (cur_sk < iter->end_sk) {
++		item = &iter->batch[cur_sk++];
++		cookie = sock_gen_cookie(item->sk);
++		sock_gen_put(item->sk);
++		item->cookie = cookie;
++	}
+ }
+ 
+ static int bpf_iter_tcp_realloc_batch(struct bpf_tcp_iter_state *iter,
+-				      unsigned int new_batch_sz)
++				      unsigned int new_batch_sz, gfp_t flags)
+ {
+-	struct sock **new_batch;
++	union bpf_tcp_iter_batch_item *new_batch;
+ 
+ 	new_batch = kvmalloc(sizeof(*new_batch) * new_batch_sz,
+-			     GFP_USER | __GFP_NOWARN);
++			     flags | __GFP_NOWARN);
+ 	if (!new_batch)
+ 		return -ENOMEM;
+ 
+-	bpf_iter_tcp_put_batch(iter);
++	memcpy(new_batch, iter->batch, sizeof(*iter->batch) * iter->end_sk);
+ 	kvfree(iter->batch);
+ 	iter->batch = new_batch;
+ 	iter->max_sk = new_batch_sz;
+@@ -2827,112 +2858,242 @@ static int bpf_iter_tcp_realloc_batch(struct bpf_tcp_iter_state *iter,
+ 	return 0;
+ }
+ 
+-static unsigned int bpf_iter_tcp_listening_batch(struct seq_file *seq,
+-						 struct sock *start_sk)
++static struct sock *bpf_iter_tcp_resume_bucket(struct sock *first_sk,
++					       union bpf_tcp_iter_batch_item *cookies,
++					       int n_cookies)
++{
++	struct hlist_nulls_node *node;
++	struct sock *sk;
++	int i;
++
++	for (i = 0; i < n_cookies; i++) {
++		sk = first_sk;
++		sk_nulls_for_each_from(sk, node)
++			if (cookies[i].cookie == atomic64_read(&sk->sk_cookie))
++				return sk;
++	}
++
++	return NULL;
++}
++
++static struct sock *bpf_iter_tcp_resume_listening(struct seq_file *seq)
+ {
+ 	struct inet_hashinfo *hinfo = seq_file_net(seq)->ipv4.tcp_death_row.hashinfo;
+ 	struct bpf_tcp_iter_state *iter = seq->private;
+ 	struct tcp_iter_state *st = &iter->state;
+-	struct hlist_nulls_node *node;
+-	unsigned int expected = 1;
++	unsigned int find_cookie = iter->cur_sk;
++	unsigned int end_cookie = iter->end_sk;
++	int resume_bucket = st->bucket;
+ 	struct sock *sk;
+ 
+-	sock_hold(start_sk);
+-	iter->batch[iter->end_sk++] = start_sk;
++	if (end_cookie && find_cookie == end_cookie)
++		++st->bucket;
+ 
+-	sk = sk_nulls_next(start_sk);
+-	sk_nulls_for_each_from(sk, node) {
+-		if (seq_sk_match(seq, sk)) {
+-			if (iter->end_sk < iter->max_sk) {
+-				sock_hold(sk);
+-				iter->batch[iter->end_sk++] = sk;
+-			}
+-			expected++;
++	sk = listening_get_first(seq);
++	iter->cur_sk = 0;
++	iter->end_sk = 0;
++
++	if (sk && st->bucket == resume_bucket && end_cookie) {
++		sk = bpf_iter_tcp_resume_bucket(sk, &iter->batch[find_cookie],
++						end_cookie - find_cookie);
++		if (!sk) {
++			spin_unlock(&hinfo->lhash2[st->bucket].lock);
++			++st->bucket;
++			sk = listening_get_first(seq);
+ 		}
+ 	}
+-	spin_unlock(&hinfo->lhash2[st->bucket].lock);
+ 
+-	return expected;
++	return sk;
+ }
+ 
+-static unsigned int bpf_iter_tcp_established_batch(struct seq_file *seq,
+-						   struct sock *start_sk)
++static struct sock *bpf_iter_tcp_resume_established(struct seq_file *seq)
+ {
+ 	struct inet_hashinfo *hinfo = seq_file_net(seq)->ipv4.tcp_death_row.hashinfo;
+ 	struct bpf_tcp_iter_state *iter = seq->private;
+ 	struct tcp_iter_state *st = &iter->state;
++	unsigned int find_cookie = iter->cur_sk;
++	unsigned int end_cookie = iter->end_sk;
++	int resume_bucket = st->bucket;
++	struct sock *sk;
++
++	if (end_cookie && find_cookie == end_cookie)
++		++st->bucket;
++
++	sk = established_get_first(seq);
++	iter->cur_sk = 0;
++	iter->end_sk = 0;
++
++	if (sk && st->bucket == resume_bucket && end_cookie) {
++		sk = bpf_iter_tcp_resume_bucket(sk, &iter->batch[find_cookie],
++						end_cookie - find_cookie);
++		if (!sk) {
++			spin_unlock_bh(inet_ehash_lockp(hinfo, st->bucket));
++			++st->bucket;
++			sk = established_get_first(seq);
++		}
++	}
++
++	return sk;
++}
++
++static struct sock *bpf_iter_tcp_resume(struct seq_file *seq)
++{
++	struct bpf_tcp_iter_state *iter = seq->private;
++	struct tcp_iter_state *st = &iter->state;
++	struct sock *sk = NULL;
++
++	switch (st->state) {
++	case TCP_SEQ_STATE_LISTENING:
++		sk = bpf_iter_tcp_resume_listening(seq);
++		if (sk)
++			break;
++		st->bucket = 0;
++		st->state = TCP_SEQ_STATE_ESTABLISHED;
++		fallthrough;
++	case TCP_SEQ_STATE_ESTABLISHED:
++		sk = bpf_iter_tcp_resume_established(seq);
++		break;
++	}
++
++	return sk;
++}
++
++static unsigned int bpf_iter_tcp_listening_batch(struct seq_file *seq,
++						 struct sock **start_sk)
++{
++	struct bpf_tcp_iter_state *iter = seq->private;
+ 	struct hlist_nulls_node *node;
+ 	unsigned int expected = 1;
+ 	struct sock *sk;
+ 
+-	sock_hold(start_sk);
+-	iter->batch[iter->end_sk++] = start_sk;
++	sock_hold(*start_sk);
++	iter->batch[iter->end_sk++].sk = *start_sk;
+ 
+-	sk = sk_nulls_next(start_sk);
++	sk = sk_nulls_next(*start_sk);
++	*start_sk = NULL;
+ 	sk_nulls_for_each_from(sk, node) {
+ 		if (seq_sk_match(seq, sk)) {
+ 			if (iter->end_sk < iter->max_sk) {
+ 				sock_hold(sk);
+-				iter->batch[iter->end_sk++] = sk;
++				iter->batch[iter->end_sk++].sk = sk;
++			} else if (!*start_sk) {
++				/* Remember where we left off. */
++				*start_sk = sk;
+ 			}
+ 			expected++;
+ 		}
+ 	}
+-	spin_unlock_bh(inet_ehash_lockp(hinfo, st->bucket));
+ 
+ 	return expected;
+ }
+ 
+-static struct sock *bpf_iter_tcp_batch(struct seq_file *seq)
++static unsigned int bpf_iter_tcp_established_batch(struct seq_file *seq,
++						   struct sock **start_sk)
++{
++	struct bpf_tcp_iter_state *iter = seq->private;
++	struct hlist_nulls_node *node;
++	struct sock *sk = *start_sk;
++	unsigned int expected = 0;
++
++	*start_sk = NULL;
++	sk_nulls_for_each_from(sk, node) {
++		if (!seq_sk_match(seq, sk))
++			continue;
++		expected++;
++		if (iter->end_sk < iter->max_sk) {
++			/* reqsk_queue_hash_req() inserts with sk_refcnt == 0
++			 * and refcount_set()s it after the bucket lock drops.
++			 */
++			if (unlikely(!refcount_inc_not_zero(&sk->sk_refcnt)))
++				continue;
++			iter->batch[iter->end_sk++].sk = sk;
++		} else if (!*start_sk) {
++			/* Remember where we left off. */
++			*start_sk = sk;
++		}
++	}
++
++	return expected;
++}
++
++static unsigned int bpf_iter_fill_batch(struct seq_file *seq,
++					struct sock **start_sk)
++{
++	struct bpf_tcp_iter_state *iter = seq->private;
++	struct tcp_iter_state *st = &iter->state;
++
++	if (st->state == TCP_SEQ_STATE_LISTENING)
++		return bpf_iter_tcp_listening_batch(seq, start_sk);
++	else
++		return bpf_iter_tcp_established_batch(seq, start_sk);
++}
++
++static void bpf_iter_tcp_unlock_bucket(struct seq_file *seq)
+ {
+ 	struct inet_hashinfo *hinfo = seq_file_net(seq)->ipv4.tcp_death_row.hashinfo;
+ 	struct bpf_tcp_iter_state *iter = seq->private;
+ 	struct tcp_iter_state *st = &iter->state;
++
++	if (st->state == TCP_SEQ_STATE_LISTENING)
++		spin_unlock(&hinfo->lhash2[st->bucket].lock);
++	else
++		spin_unlock_bh(inet_ehash_lockp(hinfo, st->bucket));
++}
++
++static struct sock *bpf_iter_tcp_batch(struct seq_file *seq)
++{
++	struct bpf_tcp_iter_state *iter = seq->private;
+ 	unsigned int expected;
+-	bool resized = false;
+ 	struct sock *sk;
+-
+-	/* The st->bucket is done.  Directly advance to the next
+-	 * bucket instead of having the tcp_seek_last_pos() to skip
+-	 * one by one in the current bucket and eventually find out
+-	 * it has to advance to the next bucket.
+-	 */
+-	if (iter->st_bucket_done) {
+-		st->offset = 0;
+-		st->bucket++;
+-		if (st->state == TCP_SEQ_STATE_LISTENING &&
+-		    st->bucket > hinfo->lhash2_mask) {
+-			st->state = TCP_SEQ_STATE_ESTABLISHED;
+-			st->bucket = 0;
+-		}
+-	}
++	int err;
+ 
+ again:
+-	/* Get a new batch */
+-	iter->cur_sk = 0;
+-	iter->end_sk = 0;
+-	iter->st_bucket_done = false;
++	sk = bpf_iter_tcp_resume(seq);
++	if (!sk)
++		return NULL; /* Done */
++
++	expected = bpf_iter_fill_batch(seq, &sk);
++	if (likely(!sk))
++		goto done;
+ 
+-	sk = tcp_seek_last_pos(seq);
++	/* Batch size was too small. */
++	bpf_iter_tcp_unlock_bucket(seq);
++	bpf_iter_tcp_put_batch(iter);
++	err = bpf_iter_tcp_realloc_batch(iter, expected * 3 / 2,
++					 GFP_USER);
++	if (err) {
++		iter->cur_sk = 0;
++		iter->end_sk = 0;
++		return ERR_PTR(err);
++	}
++
++	sk = bpf_iter_tcp_resume(seq);
+ 	if (!sk)
+ 		return NULL; /* Done */
+ 
+-	if (st->state == TCP_SEQ_STATE_LISTENING)
+-		expected = bpf_iter_tcp_listening_batch(seq, sk);
+-	else
+-		expected = bpf_iter_tcp_established_batch(seq, sk);
++	expected = bpf_iter_fill_batch(seq, &sk);
++	if (likely(!sk))
++		goto done;
+ 
+-	if (iter->end_sk == expected) {
+-		iter->st_bucket_done = true;
+-		return sk;
++	/* Batch size was still too small. Hold onto the lock while we try
++	 * again with a larger batch to make sure the current bucket's size
++	 * does not change in the meantime.
++	 */
++	err = bpf_iter_tcp_realloc_batch(iter, expected, GFP_NOWAIT);
++	if (err) {
++		bpf_iter_tcp_unlock_bucket(seq);
++		return ERR_PTR(err);
+ 	}
+ 
+-	if (!resized && !bpf_iter_tcp_realloc_batch(iter, expected * 3 / 2)) {
+-		resized = true;
++	bpf_iter_fill_batch(seq, &sk);
++	WARN_ON_ONCE(sk);
++done:
++	bpf_iter_tcp_unlock_bucket(seq);
++	if (unlikely(!iter->end_sk)) {
++		++iter->state.bucket;
+ 		goto again;
+ 	}
+-
+-	return sk;
++	return iter->batch[0].sk;
+ }
+ 
+ static void *bpf_iter_tcp_seq_start(struct seq_file *seq, loff_t *pos)
+@@ -2962,16 +3123,11 @@ static void *bpf_iter_tcp_seq_next(struct seq_file *seq, void *v, loff_t *pos)
+ 		 * meta.seq_num is used instead.
+ 		 */
+ 		st->num++;
+-		/* Move st->offset to the next sk in the bucket such that
+-		 * the future start() will resume at st->offset in
+-		 * st->bucket.  See tcp_seek_last_pos().
+-		 */
+-		st->offset++;
+-		sock_gen_put(iter->batch[iter->cur_sk++]);
++		sock_gen_put(iter->batch[iter->cur_sk++].sk);
+ 	}
+ 
+ 	if (iter->cur_sk < iter->end_sk)
+-		sk = iter->batch[iter->cur_sk];
++		sk = iter->batch[iter->cur_sk].sk;
+ 	else
+ 		sk = bpf_iter_tcp_batch(seq);
+ 
+@@ -3037,10 +3193,8 @@ static void bpf_iter_tcp_seq_stop(struct seq_file *seq, void *v)
+ 			(void)tcp_prog_seq_show(prog, &meta, v, 0);
+ 	}
+ 
+-	if (iter->cur_sk < iter->end_sk) {
++	if (iter->cur_sk < iter->end_sk)
+ 		bpf_iter_tcp_put_batch(iter);
+-		iter->st_bucket_done = false;
+-	}
+ }
+ 
+ static const struct seq_operations bpf_iter_tcp_seq_ops = {
+@@ -3355,7 +3509,7 @@ static int bpf_iter_init_tcp(void *priv_data, struct bpf_iter_aux_info *aux)
+ 	if (err)
+ 		return err;
+ 
+-	err = bpf_iter_tcp_realloc_batch(iter, INIT_BATCH_SZ);
++	err = bpf_iter_tcp_realloc_batch(iter, INIT_BATCH_SZ, GFP_USER);
+ 	if (err) {
+ 		bpf_iter_fini_seq_net(priv_data);
+ 		return err;
+diff --git a/net/ipv4/tcp_minisocks.c b/net/ipv4/tcp_minisocks.c
+index 2eea9672ca01ef..c3f5e4fc7b210e 100644
+--- a/net/ipv4/tcp_minisocks.c
++++ b/net/ipv4/tcp_minisocks.c
+@@ -261,10 +261,9 @@ static void tcp_time_wait_init(struct sock *sk, struct tcp_timewait_sock *tcptw)
+ 		tcptw->tw_md5_key = kmemdup(key, sizeof(*key), GFP_ATOMIC);
+ 		if (!tcptw->tw_md5_key)
+ 			return;
+-		if (!tcp_alloc_md5sig_pool())
+-			goto out_free;
+ 		if (!static_key_fast_inc_not_disabled(&tcp_md5_needed.key.key))
+ 			goto out_free;
++		tcp_md5_add_sigpool();
+ 	}
+ 	return;
+ out_free:
+@@ -348,16 +347,26 @@ void tcp_time_wait(struct sock *sk, int state, int timeo)
+ }
+ EXPORT_SYMBOL(tcp_time_wait);
+ 
++#ifdef CONFIG_TCP_MD5SIG
++static void tcp_md5_twsk_free_rcu(struct rcu_head *head)
++{
++	struct tcp_md5sig_key *key;
++
++	key = container_of(head, struct tcp_md5sig_key, rcu);
++	kfree(key);
++	static_branch_slow_dec_deferred(&tcp_md5_needed);
++	tcp_md5_release_sigpool();
++}
++#endif
++
+ void tcp_twsk_destructor(struct sock *sk)
+ {
+ #ifdef CONFIG_TCP_MD5SIG
+ 	if (static_branch_unlikely(&tcp_md5_needed.key)) {
+ 		struct tcp_timewait_sock *twsk = tcp_twsk(sk);
+ 
+-		if (twsk->tw_md5_key) {
+-			kfree_rcu(twsk->tw_md5_key, rcu);
+-			static_branch_slow_dec_deferred(&tcp_md5_needed);
+-		}
++		if (twsk->tw_md5_key)
++			call_rcu(&twsk->tw_md5_key->rcu, tcp_md5_twsk_free_rcu);
+ 	}
+ #endif
+ }
+diff --git a/net/ipv4/tcp_sigpool.c b/net/ipv4/tcp_sigpool.c
+new file mode 100644
+index 00000000000000..8512cb09ebc097
+--- /dev/null
++++ b/net/ipv4/tcp_sigpool.c
+@@ -0,0 +1,357 @@
++// SPDX-License-Identifier: GPL-2.0-or-later
++
++#include <crypto/hash.h>
++#include <linux/cpu.h>
++#include <linux/kref.h>
++#include <linux/module.h>
++#include <linux/mutex.h>
++#include <linux/percpu.h>
++#include <linux/workqueue.h>
++#include <net/tcp.h>
++
++static size_t __scratch_size;
++static DEFINE_PER_CPU(void __rcu *, sigpool_scratch);
++
++struct sigpool_entry {
++	struct crypto_ahash	*hash;
++	const char		*alg;
++	struct kref		kref;
++	uint16_t		needs_key:1,
++				reserved:15;
++};
++
++#define CPOOL_SIZE (PAGE_SIZE / sizeof(struct sigpool_entry))
++static struct sigpool_entry cpool[CPOOL_SIZE];
++static unsigned int cpool_populated;
++static DEFINE_MUTEX(cpool_mutex);
++
++/* Slow-path */
++struct scratches_to_free {
++	struct rcu_head rcu;
++	unsigned int cnt;
++	void *scratches[];
++};
++
++static void free_old_scratches(struct rcu_head *head)
++{
++	struct scratches_to_free *stf;
++
++	stf = container_of(head, struct scratches_to_free, rcu);
++	while (stf->cnt--)
++		kfree(stf->scratches[stf->cnt]);
++	kfree(stf);
++}
++
++/**
++ * sigpool_reserve_scratch - re-allocates scratch buffer, slow-path
++ * @size: request size for the scratch/temp buffer
++ */
++static int sigpool_reserve_scratch(size_t size)
++{
++	struct scratches_to_free *stf;
++	size_t stf_sz = struct_size(stf, scratches, num_possible_cpus());
++	int cpu, err = 0;
++
++	lockdep_assert_held(&cpool_mutex);
++	if (__scratch_size >= size)
++		return 0;
++
++	stf = kmalloc(stf_sz, GFP_KERNEL);
++	if (!stf)
++		return -ENOMEM;
++	stf->cnt = 0;
++
++	size = max(size, __scratch_size);
++	cpus_read_lock();
++	for_each_possible_cpu(cpu) {
++		void *scratch, *old_scratch;
++
++		scratch = kmalloc_node(size, GFP_KERNEL, cpu_to_node(cpu));
++		if (!scratch) {
++			err = -ENOMEM;
++			break;
++		}
++
++		old_scratch = rcu_replace_pointer(per_cpu(sigpool_scratch, cpu),
++					scratch, lockdep_is_held(&cpool_mutex));
++		if (!cpu_online(cpu) || !old_scratch) {
++			kfree(old_scratch);
++			continue;
++		}
++		stf->scratches[stf->cnt++] = old_scratch;
++	}
++	cpus_read_unlock();
++	if (!err)
++		__scratch_size = size;
++
++	call_rcu(&stf->rcu, free_old_scratches);
++	return err;
++}
++
++static void sigpool_scratch_free(void)
++{
++	int cpu;
++
++	for_each_possible_cpu(cpu)
++		kfree(rcu_replace_pointer(per_cpu(sigpool_scratch, cpu),
++					  NULL, lockdep_is_held(&cpool_mutex)));
++	__scratch_size = 0;
++}
++
++static int __cpool_try_clone(struct crypto_ahash *hash)
++{
++	struct crypto_ahash *tmp;
++
++	tmp = crypto_clone_ahash(hash);
++	if (IS_ERR(tmp))
++		return PTR_ERR(tmp);
++
++	crypto_free_ahash(tmp);
++	return 0;
++}
++
++static int __cpool_alloc_ahash(struct sigpool_entry *e, const char *alg)
++{
++	struct crypto_ahash *cpu0_hash;
++	int ret;
++
++	e->alg = kstrdup(alg, GFP_KERNEL);
++	if (!e->alg)
++		return -ENOMEM;
++
++	cpu0_hash = crypto_alloc_ahash(alg, 0, CRYPTO_ALG_ASYNC);
++	if (IS_ERR(cpu0_hash)) {
++		ret = PTR_ERR(cpu0_hash);
++		goto out_free_alg;
++	}
++
++	e->needs_key = crypto_ahash_get_flags(cpu0_hash) & CRYPTO_TFM_NEED_KEY;
++
++	ret = __cpool_try_clone(cpu0_hash);
++	if (ret)
++		goto out_free_cpu0_hash;
++	e->hash = cpu0_hash;
++	kref_init(&e->kref);
++	return 0;
++
++out_free_cpu0_hash:
++	crypto_free_ahash(cpu0_hash);
++out_free_alg:
++	kfree(e->alg);
++	e->alg = NULL;
++	return ret;
++}
++
++/**
++ * tcp_sigpool_alloc_ahash - allocates pool for ahash requests
++ * @alg: name of async hash algorithm
++ * @scratch_size: reserve a tcp_sigpool::scratch buffer of this size
++ */
++int tcp_sigpool_alloc_ahash(const char *alg, size_t scratch_size)
++{
++	int i, ret;
++
++	/* slow-path */
++	mutex_lock(&cpool_mutex);
++	ret = sigpool_reserve_scratch(scratch_size);
++	if (ret)
++		goto out;
++	for (i = 0; i < cpool_populated; i++) {
++		if (!cpool[i].alg)
++			continue;
++		if (strcmp(cpool[i].alg, alg))
++			continue;
++
++		/* pairs with tcp_sigpool_release() */
++		if (!kref_get_unless_zero(&cpool[i].kref))
++			kref_init(&cpool[i].kref);
++		ret = i;
++		goto out;
++	}
++
++	for (i = 0; i < cpool_populated; i++) {
++		if (!cpool[i].alg)
++			break;
++	}
++	if (i >= CPOOL_SIZE) {
++		ret = -ENOSPC;
++		goto out;
++	}
++
++	ret = __cpool_alloc_ahash(&cpool[i], alg);
++	if (!ret) {
++		ret = i;
++		if (i == cpool_populated)
++			cpool_populated++;
++	}
++out:
++	mutex_unlock(&cpool_mutex);
++	return ret;
++}
++EXPORT_SYMBOL_GPL(tcp_sigpool_alloc_ahash);
++
++static void __cpool_free_entry(struct sigpool_entry *e)
++{
++	crypto_free_ahash(e->hash);
++	kfree(e->alg);
++	memset(e, 0, sizeof(*e));
++}
++
++static void cpool_cleanup_work_cb(struct work_struct *work)
++{
++	bool free_scratch = true;
++	unsigned int i;
++
++	mutex_lock(&cpool_mutex);
++	for (i = 0; i < cpool_populated; i++) {
++		if (kref_read(&cpool[i].kref) > 0) {
++			free_scratch = false;
++			continue;
++		}
++		if (!cpool[i].alg)
++			continue;
++		__cpool_free_entry(&cpool[i]);
++	}
++	if (free_scratch)
++		sigpool_scratch_free();
++	mutex_unlock(&cpool_mutex);
++}
++
++static DECLARE_WORK(cpool_cleanup_work, cpool_cleanup_work_cb);
++static void cpool_schedule_cleanup(struct kref *kref)
++{
++	schedule_work(&cpool_cleanup_work);
++}
++
++/**
++ * tcp_sigpool_release - decreases number of users for a pool. If it was
++ * the last user of the pool, releases any memory that was consumed.
++ * @id: tcp_sigpool that was previously allocated by tcp_sigpool_alloc_ahash()
++ */
++void tcp_sigpool_release(unsigned int id)
++{
++	if (WARN_ON_ONCE(id >= cpool_populated || !cpool[id].alg))
++		return;
++
++	/* slow-path */
++	kref_put(&cpool[id].kref, cpool_schedule_cleanup);
++}
++EXPORT_SYMBOL_GPL(tcp_sigpool_release);
++
++/**
++ * tcp_sigpool_get - increases number of users (refcounter) for a pool
++ * @id: tcp_sigpool that was previously allocated by tcp_sigpool_alloc_ahash()
++ */
++void tcp_sigpool_get(unsigned int id)
++{
++	if (WARN_ON_ONCE(id >= cpool_populated || !cpool[id].alg))
++		return;
++	kref_get(&cpool[id].kref);
++}
++EXPORT_SYMBOL_GPL(tcp_sigpool_get);
++
++int tcp_sigpool_start(unsigned int id, struct tcp_sigpool *c) __cond_acquires(RCU_BH)
++{
++	struct crypto_ahash *hash;
++
++	rcu_read_lock_bh();
++	if (WARN_ON_ONCE(id >= cpool_populated || !cpool[id].alg)) {
++		rcu_read_unlock_bh();
++		return -EINVAL;
++	}
++
++	hash = crypto_clone_ahash(cpool[id].hash);
++	if (IS_ERR(hash)) {
++		rcu_read_unlock_bh();
++		return PTR_ERR(hash);
++	}
++
++	c->req = ahash_request_alloc(hash, GFP_ATOMIC);
++	if (!c->req) {
++		crypto_free_ahash(hash);
++		rcu_read_unlock_bh();
++		return -ENOMEM;
++	}
++	ahash_request_set_callback(c->req, 0, NULL, NULL);
++
++	/* Pairs with tcp_sigpool_reserve_scratch(), scratch area is
++	 * valid (allocated) until tcp_sigpool_end().
++	 */
++	c->scratch = rcu_dereference_bh(*this_cpu_ptr(&sigpool_scratch));
++	return 0;
++}
++EXPORT_SYMBOL_GPL(tcp_sigpool_start);
++
++void tcp_sigpool_end(struct tcp_sigpool *c) __releases(RCU_BH)
++{
++	struct crypto_ahash *hash = crypto_ahash_reqtfm(c->req);
++
++	rcu_read_unlock_bh();
++	ahash_request_free(c->req);
++	crypto_free_ahash(hash);
++}
++EXPORT_SYMBOL_GPL(tcp_sigpool_end);
++
++/**
++ * tcp_sigpool_algo - return algorithm of tcp_sigpool
++ * @id: tcp_sigpool that was previously allocated by tcp_sigpool_alloc_ahash()
++ * @buf: buffer to return name of algorithm
++ * @buf_len: size of @buf
++ */
++size_t tcp_sigpool_algo(unsigned int id, char *buf, size_t buf_len)
++{
++	if (WARN_ON_ONCE(id >= cpool_populated || !cpool[id].alg))
++		return -EINVAL;
++
++	return strscpy(buf, cpool[id].alg, buf_len);
++}
++EXPORT_SYMBOL_GPL(tcp_sigpool_algo);
++
++/**
++ * tcp_sigpool_hash_skb_data - hash data in skb with initialized tcp_sigpool
++ * @hp: tcp_sigpool pointer
++ * @skb: buffer to add sign for
++ * @header_len: TCP header length for this segment
++ */
++int tcp_sigpool_hash_skb_data(struct tcp_sigpool *hp,
++			      const struct sk_buff *skb,
++			      unsigned int header_len)
++{
++	const unsigned int head_data_len = skb_headlen(skb) > header_len ?
++					   skb_headlen(skb) - header_len : 0;
++	const struct skb_shared_info *shi = skb_shinfo(skb);
++	const struct tcphdr *tp = tcp_hdr(skb);
++	struct ahash_request *req = hp->req;
++	struct sk_buff *frag_iter;
++	struct scatterlist sg;
++	unsigned int i;
++
++	sg_init_table(&sg, 1);
++
++	sg_set_buf(&sg, ((u8 *)tp) + header_len, head_data_len);
++	ahash_request_set_crypt(req, &sg, NULL, head_data_len);
++	if (crypto_ahash_update(req))
++		return 1;
++
++	for (i = 0; i < shi->nr_frags; ++i) {
++		const skb_frag_t *f = &shi->frags[i];
++		unsigned int offset = skb_frag_off(f);
++		struct page *page;
++
++		page = skb_frag_page(f) + (offset >> PAGE_SHIFT);
++		sg_set_page(&sg, page, skb_frag_size(f), offset_in_page(offset));
++		ahash_request_set_crypt(req, &sg, NULL, skb_frag_size(f));
++		if (crypto_ahash_update(req))
++			return 1;
++	}
++
++	skb_walk_frags(skb, frag_iter)
++		if (tcp_sigpool_hash_skb_data(hp, frag_iter, 0))
++			return 1;
++
++	return 0;
++}
++EXPORT_SYMBOL(tcp_sigpool_hash_skb_data);
++
++MODULE_LICENSE("GPL");
++MODULE_DESCRIPTION("Per-CPU pool of crypto requests");
+diff --git a/net/ipv4/udp_offload.c b/net/ipv4/udp_offload.c
+index 84ae2759ff1956..b9b21e5af1a7fd 100644
+--- a/net/ipv4/udp_offload.c
++++ b/net/ipv4/udp_offload.c
+@@ -22,17 +22,19 @@ static struct sk_buff *__skb_udp_tunnel_segment(struct sk_buff *skb,
+ 	int tnl_hlen = skb_inner_mac_header(skb) - skb_transport_header(skb);
+ 	bool remcsum, need_csum, offload_csum, gso_partial;
+ 	struct sk_buff *segs = ERR_PTR(-EINVAL);
+-	struct udphdr *uh = udp_hdr(skb);
+ 	u16 mac_offset = skb->mac_header;
+ 	__be16 protocol = skb->protocol;
+ 	u16 mac_len = skb->mac_len;
+ 	int udp_offset, outer_hlen;
++	struct udphdr *uh;
+ 	__wsum partial;
+ 	bool need_ipsec;
+ 
+ 	if (unlikely(!pskb_may_pull(skb, tnl_hlen)))
+ 		goto out;
+ 
++	uh = udp_hdr(skb);
++
+ 	/* Adjust partial header checksum to negate old length.
+ 	 * We cannot rely on the value contained in uh->len as it is
+ 	 * possible that the actual value exceeds the boundaries of the
+diff --git a/net/ipv6/ip6_tunnel.c b/net/ipv6/ip6_tunnel.c
+index 825d40b505cde7..dfabd9969b3f32 100644
+--- a/net/ipv6/ip6_tunnel.c
++++ b/net/ipv6/ip6_tunnel.c
+@@ -675,6 +675,9 @@ ip6ip6_err(struct sk_buff *skb, struct inet6_skb_parm *opt,
+ 		if (!skb2)
+ 			return 0;
+ 
++		/* Remove debris left by outer IPv6 stack. */
++		memset(IP6CB(skb2), 0, sizeof(*IP6CB(skb2)));
++
+ 		skb_dst_drop(skb2);
+ 		skb_pull(skb2, offset);
+ 		skb_reset_network_header(skb2);
+diff --git a/net/ipv6/route.c b/net/ipv6/route.c
+index e6f1a22bc2bea2..24d097290dbc05 100644
+--- a/net/ipv6/route.c
++++ b/net/ipv6/route.c
+@@ -989,13 +989,13 @@ int rt6_route_rcv(struct net_device *dev, u8 *opt, int len,
+ 	} else if (rinfo->prefix_len > 128) {
+ 		return -EINVAL;
+ 	} else if (rinfo->prefix_len > 64) {
+-		if (rinfo->length < 2) {
++		/* RFC 4191: Length MUST be 3 when Prefix Length > 64 */
++		if (rinfo->length < 3)
+ 			return -EINVAL;
+-		}
+ 	} else if (rinfo->prefix_len > 0) {
+-		if (rinfo->length < 1) {
++		/* RFC 4191: Length MUST be 2 or 3 when Prefix Length > 0 */
++		if (rinfo->length < 2)
+ 			return -EINVAL;
+-		}
+ 	}
+ 
+ 	pref = rinfo->route_pref;
+diff --git a/net/ipv6/tcp_ipv6.c b/net/ipv6/tcp_ipv6.c
+index 2c579868fe81f9..689c0b383ebf97 100644
+--- a/net/ipv6/tcp_ipv6.c
++++ b/net/ipv6/tcp_ipv6.c
+@@ -665,7 +665,7 @@ static int tcp_v6_parse_md5_keys(struct sock *sk, int optname,
+ 			      cmd.tcpm_key, cmd.tcpm_keylen);
+ }
+ 
+-static int tcp_v6_md5_hash_headers(struct tcp_md5sig_pool *hp,
++static int tcp_v6_md5_hash_headers(struct tcp_sigpool *hp,
+ 				   const struct in6_addr *daddr,
+ 				   const struct in6_addr *saddr,
+ 				   const struct tcphdr *th, int nbytes)
+@@ -686,39 +686,36 @@ static int tcp_v6_md5_hash_headers(struct tcp_md5sig_pool *hp,
+ 	_th->check = 0;
+ 
+ 	sg_init_one(&sg, bp, sizeof(*bp) + sizeof(*th));
+-	ahash_request_set_crypt(hp->md5_req, &sg, NULL,
++	ahash_request_set_crypt(hp->req, &sg, NULL,
+ 				sizeof(*bp) + sizeof(*th));
+-	return crypto_ahash_update(hp->md5_req);
++	return crypto_ahash_update(hp->req);
+ }
+ 
+ static int tcp_v6_md5_hash_hdr(char *md5_hash, const struct tcp_md5sig_key *key,
+ 			       const struct in6_addr *daddr, struct in6_addr *saddr,
+ 			       const struct tcphdr *th)
+ {
+-	struct tcp_md5sig_pool *hp;
+-	struct ahash_request *req;
++	struct tcp_sigpool hp;
+ 
+-	hp = tcp_get_md5sig_pool();
+-	if (!hp)
+-		goto clear_hash_noput;
+-	req = hp->md5_req;
++	if (tcp_sigpool_start(tcp_md5_sigpool_id, &hp))
++		goto clear_hash_nostart;
+ 
+-	if (crypto_ahash_init(req))
++	if (crypto_ahash_init(hp.req))
+ 		goto clear_hash;
+-	if (tcp_v6_md5_hash_headers(hp, daddr, saddr, th, th->doff << 2))
++	if (tcp_v6_md5_hash_headers(&hp, daddr, saddr, th, th->doff << 2))
+ 		goto clear_hash;
+-	if (tcp_md5_hash_key(hp, key))
++	if (tcp_md5_hash_key(&hp, key))
+ 		goto clear_hash;
+-	ahash_request_set_crypt(req, NULL, md5_hash, 0);
+-	if (crypto_ahash_final(req))
++	ahash_request_set_crypt(hp.req, NULL, md5_hash, 0);
++	if (crypto_ahash_final(hp.req))
+ 		goto clear_hash;
+ 
+-	tcp_put_md5sig_pool();
++	tcp_sigpool_end(&hp);
+ 	return 0;
+ 
+ clear_hash:
+-	tcp_put_md5sig_pool();
+-clear_hash_noput:
++	tcp_sigpool_end(&hp);
++clear_hash_nostart:
+ 	memset(md5_hash, 0, 16);
+ 	return 1;
+ }
+@@ -728,10 +725,9 @@ static int tcp_v6_md5_hash_skb(char *md5_hash,
+ 			       const struct sock *sk,
+ 			       const struct sk_buff *skb)
+ {
+-	const struct in6_addr *saddr, *daddr;
+-	struct tcp_md5sig_pool *hp;
+-	struct ahash_request *req;
+ 	const struct tcphdr *th = tcp_hdr(skb);
++	const struct in6_addr *saddr, *daddr;
++	struct tcp_sigpool hp;
+ 
+ 	if (sk) { /* valid for establish/request sockets */
+ 		saddr = &sk->sk_v6_rcv_saddr;
+@@ -742,30 +738,28 @@ static int tcp_v6_md5_hash_skb(char *md5_hash,
+ 		daddr = &ip6h->daddr;
+ 	}
+ 
+-	hp = tcp_get_md5sig_pool();
+-	if (!hp)
+-		goto clear_hash_noput;
+-	req = hp->md5_req;
++	if (tcp_sigpool_start(tcp_md5_sigpool_id, &hp))
++		goto clear_hash_nostart;
+ 
+-	if (crypto_ahash_init(req))
++	if (crypto_ahash_init(hp.req))
+ 		goto clear_hash;
+ 
+-	if (tcp_v6_md5_hash_headers(hp, daddr, saddr, th, skb->len))
++	if (tcp_v6_md5_hash_headers(&hp, daddr, saddr, th, skb->len))
+ 		goto clear_hash;
+-	if (tcp_md5_hash_skb_data(hp, skb, th->doff << 2))
++	if (tcp_sigpool_hash_skb_data(&hp, skb, th->doff << 2))
+ 		goto clear_hash;
+-	if (tcp_md5_hash_key(hp, key))
++	if (tcp_md5_hash_key(&hp, key))
+ 		goto clear_hash;
+-	ahash_request_set_crypt(req, NULL, md5_hash, 0);
+-	if (crypto_ahash_final(req))
++	ahash_request_set_crypt(hp.req, NULL, md5_hash, 0);
++	if (crypto_ahash_final(hp.req))
+ 		goto clear_hash;
+ 
+-	tcp_put_md5sig_pool();
++	tcp_sigpool_end(&hp);
+ 	return 0;
+ 
+ clear_hash:
+-	tcp_put_md5sig_pool();
+-clear_hash_noput:
++	tcp_sigpool_end(&hp);
++clear_hash_nostart:
+ 	memset(md5_hash, 0, 16);
+ 	return 1;
+ }
+diff --git a/net/mac802154/scan.c b/net/mac802154/scan.c
+index 087e32582dbbf9..c8f4309f9c2480 100644
+--- a/net/mac802154/scan.c
++++ b/net/mac802154/scan.c
+@@ -415,6 +415,7 @@ void mac802154_beacon_worker(struct work_struct *work)
+ 		container_of(work, struct ieee802154_local, beacon_work.work);
+ 	struct cfg802154_beacon_request *beacon_req;
+ 	struct ieee802154_sub_if_data *sdata;
++	netdevice_tracker dev_tracker;
+ 	struct wpan_dev *wpan_dev;
+ 	u8 interval;
+ 	int ret;
+@@ -427,12 +428,14 @@ void mac802154_beacon_worker(struct work_struct *work)
+ 	}
+ 
+ 	sdata = IEEE802154_WPAN_DEV_TO_SUB_IF(beacon_req->wpan_dev);
++	netdev_hold(sdata->dev, &dev_tracker, GFP_ATOMIC);
+ 
+ 	/* Wait an arbitrary amount of time in case we cannot use the device */
+ 	if (local->suspended || !ieee802154_sdata_running(sdata)) {
+ 		rcu_read_unlock();
+ 		queue_delayed_work(local->mac_wq, &local->beacon_work,
+ 				   msecs_to_jiffies(1000));
++		netdev_put(sdata->dev, &dev_tracker);
+ 		return;
+ 	}
+ 
+@@ -450,6 +453,7 @@ void mac802154_beacon_worker(struct work_struct *work)
+ 	if (interval < IEEE802154_ACTIVE_SCAN_DURATION)
+ 		queue_delayed_work(local->mac_wq, &local->beacon_work,
+ 				   local->beacon_interval);
++	netdev_put(sdata->dev, &dev_tracker);
+ }
+ 
+ int mac802154_stop_beacons_locked(struct ieee802154_local *local,
+diff --git a/net/ncsi/ncsi-netlink.c b/net/ncsi/ncsi-netlink.c
+index 2f872d064396df..8cc538358f6a39 100644
+--- a/net/ncsi/ncsi-netlink.c
++++ b/net/ncsi/ncsi-netlink.c
+@@ -461,6 +461,10 @@ static int ncsi_send_cmd_nl(struct sk_buff *msg, struct genl_info *info)
+ 	nca.req_flags = NCSI_REQ_FLAG_NETLINK_DRIVEN;
+ 	nca.info = info;
+ 	nca.payload = ntohs(hdr->length);
++	if (nca.payload > len - sizeof(*hdr)) {
++		ret = -EINVAL;
++		goto out_netlink;
++	}
+ 	nca.data = data + sizeof(*hdr);
+ 
+ 	ret = ncsi_xmit_cmd(&nca);
+diff --git a/net/netfilter/ipset/ip_set_bitmap_gen.h b/net/netfilter/ipset/ip_set_bitmap_gen.h
+index 9523104a90da47..40f0383883f9db 100644
+--- a/net/netfilter/ipset/ip_set_bitmap_gen.h
++++ b/net/netfilter/ipset/ip_set_bitmap_gen.h
+@@ -75,7 +75,7 @@ mtype_flush(struct ip_set *set)
+ 		mtype_ext_cleanup(set);
+ 	bitmap_zero(map->members, map->elements);
+ 	set->elements = 0;
+-	set->ext_size = 0;
++	atomic64_set(&set->ext_size, 0);
+ }
+ 
+ /* Calculate the actual memory size of the set data */
+@@ -91,7 +91,7 @@ mtype_head(struct ip_set *set, struct sk_buff *skb)
+ {
+ 	const struct mtype *map = set->data;
+ 	struct nlattr *nested;
+-	size_t memsize = mtype_memsize(map, set->dsize) + set->ext_size;
++	size_t memsize = mtype_memsize(map, set->dsize) + atomic64_read(&set->ext_size);
+ 
+ 	nested = nla_nest_start(skb, IPSET_ATTR_DATA);
+ 	if (!nested)
+diff --git a/net/netfilter/ipset/ip_set_core.c b/net/netfilter/ipset/ip_set_core.c
+index f51a1af31513cd..29bf5ee74fe360 100644
+--- a/net/netfilter/ipset/ip_set_core.c
++++ b/net/netfilter/ipset/ip_set_core.c
+@@ -350,7 +350,7 @@ ip_set_init_comment(struct ip_set *set, struct ip_set_comment *comment,
+ 	size_t len = ext->comment ? strlen(ext->comment) : 0;
+ 
+ 	if (unlikely(c)) {
+-		set->ext_size -= sizeof(*c) + strlen(c->str) + 1;
++		atomic64_sub(sizeof(*c) + strlen(c->str) + 1, &set->ext_size);
+ 		rcu_assign_pointer(comment->c, NULL);
+ 		kfree_rcu(c, rcu);
+ 	}
+@@ -362,7 +362,7 @@ ip_set_init_comment(struct ip_set *set, struct ip_set_comment *comment,
+ 	if (unlikely(!c))
+ 		return;
+ 	strscpy(c->str, ext->comment, len + 1);
+-	set->ext_size += sizeof(*c) + strlen(c->str) + 1;
++	atomic64_add(sizeof(*c) + strlen(c->str) + 1, &set->ext_size);
+ 	rcu_assign_pointer(comment->c, c);
+ }
+ EXPORT_SYMBOL_GPL(ip_set_init_comment);
+@@ -392,7 +392,7 @@ ip_set_comment_free(struct ip_set *set, void *ptr)
+ 	c = rcu_dereference_protected(comment->c, 1);
+ 	if (unlikely(!c))
+ 		return;
+-	set->ext_size -= sizeof(*c) + strlen(c->str) + 1;
++	atomic64_sub(sizeof(*c) + strlen(c->str) + 1, &set->ext_size);
+ 	rcu_assign_pointer(comment->c, NULL);
+ 	kfree_rcu(c, rcu);
+ }
+diff --git a/net/netfilter/ipset/ip_set_hash_gen.h b/net/netfilter/ipset/ip_set_hash_gen.h
+index 81ad6747bc7a4a..53b65f013594a9 100644
+--- a/net/netfilter/ipset/ip_set_hash_gen.h
++++ b/net/netfilter/ipset/ip_set_hash_gen.h
+@@ -1288,7 +1288,7 @@ mtype_head(struct ip_set *set, struct sk_buff *skb)
+ 	rcu_read_lock_bh();
+ 	t = rcu_dereference_bh(h->table);
+ 	mtype_ext_size(set, &elements, &ext_size);
+-	memsize = mtype_ahash_memsize(h, t) + ext_size + set->ext_size;
++	memsize = mtype_ahash_memsize(h, t) + ext_size + atomic64_read(&set->ext_size);
+ 	htable_bits = t->htable_bits;
+ 	rcu_read_unlock_bh();
+ 
+diff --git a/net/netfilter/ipset/ip_set_list_set.c b/net/netfilter/ipset/ip_set_list_set.c
+index 83e1fdcc752d6a..9d6ab69ca1a376 100644
+--- a/net/netfilter/ipset/ip_set_list_set.c
++++ b/net/netfilter/ipset/ip_set_list_set.c
+@@ -421,7 +421,7 @@ list_set_flush(struct ip_set *set)
+ 	list_for_each_entry_safe(e, n, &map->members, list)
+ 		list_set_del(set, e);
+ 	set->elements = 0;
+-	set->ext_size = 0;
++	atomic64_set(&set->ext_size, 0);
+ }
+ 
+ static void
+@@ -455,7 +455,7 @@ list_set_head(struct ip_set *set, struct sk_buff *skb)
+ {
+ 	const struct list_set *map = set->data;
+ 	struct nlattr *nested;
+-	size_t memsize = list_set_memsize(map, set->dsize) + set->ext_size;
++	size_t memsize = list_set_memsize(map, set->dsize) + atomic64_read(&set->ext_size);
+ 
+ 	nested = nla_nest_start(skb, IPSET_ATTR_DATA);
+ 	if (!nested)
+diff --git a/net/netfilter/ipvs/ip_vs_conn.c b/net/netfilter/ipvs/ip_vs_conn.c
+index 811552669dac67..b2b74ce6749096 100644
+--- a/net/netfilter/ipvs/ip_vs_conn.c
++++ b/net/netfilter/ipvs/ip_vs_conn.c
+@@ -569,12 +569,6 @@ static inline void ip_vs_bind_xmit_v6(struct ip_vs_conn *cp)
+ #endif
+ 
+ 
+-static inline int ip_vs_dest_totalconns(struct ip_vs_dest *dest)
+-{
+-	return atomic_read(&dest->activeconns)
+-		+ atomic_read(&dest->inactconns);
+-}
+-
+ /*
+  *	Bind a connection entry with a virtual service destination
+  *	Called just after a new connection entry is created.
+@@ -626,23 +620,22 @@ ip_vs_bind_dest(struct ip_vs_conn *cp, struct ip_vs_dest *dest)
+ 
+ 	/* Update the connection counters */
+ 	if (!(flags & IP_VS_CONN_F_TEMPLATE)) {
++		int tc;
++
+ 		/* It is a normal connection, so modify the counters
+ 		 * according to the flags, later the protocol can
+ 		 * update them on state change
+ 		 */
+ 		if (!(flags & IP_VS_CONN_F_INACTIVE))
+ 			atomic_inc(&dest->activeconns);
+-		else
+-			atomic_inc(&dest->inactconns);
++		tc = atomic_inc_return(&dest->totalconns);
++		if (tc == READ_ONCE(dest->u_threshold))
++			ip_vs_dest_update_overload(dest, 1);
+ 	} else {
+ 		/* It is a persistent connection/template, so increase
+ 		   the persistent connection counter */
+ 		atomic_inc(&dest->persistconns);
+ 	}
+-
+-	if (dest->u_threshold != 0 &&
+-	    ip_vs_dest_totalconns(dest) >= dest->u_threshold)
+-		dest->flags |= IP_VS_DEST_F_OVERLOAD;
+ }
+ 
+ 
+@@ -723,30 +716,20 @@ static inline void ip_vs_unbind_dest(struct ip_vs_conn *cp)
+ 
+ 	/* Update the connection counters */
+ 	if (!(cp->flags & IP_VS_CONN_F_TEMPLATE)) {
+-		/* It is a normal connection, so decrease the inactconns
+-		   or activeconns counter */
+-		if (cp->flags & IP_VS_CONN_F_INACTIVE) {
+-			atomic_dec(&dest->inactconns);
+-		} else {
++		int tc;
++
++		/* It is a normal connection, so decrease the counters */
++		if (!(cp->flags & IP_VS_CONN_F_INACTIVE))
+ 			atomic_dec(&dest->activeconns);
+-		}
++		tc = atomic_fetch_dec(&dest->totalconns);
++		if (tc == READ_ONCE(dest->l_threshold_val))
++			ip_vs_dest_update_overload(dest, -1);
+ 	} else {
+ 		/* It is a persistent connection/template, so decrease
+ 		   the persistent connection counter */
+ 		atomic_dec(&dest->persistconns);
+ 	}
+ 
+-	if (dest->l_threshold != 0) {
+-		if (ip_vs_dest_totalconns(dest) < dest->l_threshold)
+-			dest->flags &= ~IP_VS_DEST_F_OVERLOAD;
+-	} else if (dest->u_threshold != 0) {
+-		if (ip_vs_dest_totalconns(dest) * 4 < dest->u_threshold * 3)
+-			dest->flags &= ~IP_VS_DEST_F_OVERLOAD;
+-	} else {
+-		if (dest->flags & IP_VS_DEST_F_OVERLOAD)
+-			dest->flags &= ~IP_VS_DEST_F_OVERLOAD;
+-	}
+-
+ 	ip_vs_dest_put(dest);
+ }
+ 
+diff --git a/net/netfilter/ipvs/ip_vs_core.c b/net/netfilter/ipvs/ip_vs_core.c
+index e49a4840effb3d..a722bacce4613f 100644
+--- a/net/netfilter/ipvs/ip_vs_core.c
++++ b/net/netfilter/ipvs/ip_vs_core.c
+@@ -747,28 +747,27 @@ static int ip_vs_route_me_harder(struct netns_ipvs *ipvs, int af,
+  */
+ void ip_vs_nat_icmp(struct sk_buff *skb, struct ip_vs_protocol *pp,
+ 		    struct ip_vs_conn *cp, int inout, unsigned int toff,
+-		    bool has_ports)
++		    bool has_ports, struct ip_vs_iphdr *ciph)
+ {
+ 	struct iphdr *iph	 = ip_hdr(skb);
+ 	struct icmphdr *icmph	 = (struct icmphdr *)(skb->data + toff);
+-	struct iphdr *ciph	 = (struct iphdr *)(icmph + 1);
+-	unsigned int coff __maybe_unused = toff + sizeof(struct icmphdr);
++	struct iphdr *cih	 = (struct iphdr *)(icmph + 1);
+ 
+ 	if (inout) {
+ 		iph->saddr = cp->vaddr.ip;
+ 		ip_send_check(iph);
+-		ciph->daddr = cp->vaddr.ip;
+-		ip_send_check(ciph);
++		cih->daddr = cp->vaddr.ip;
++		ip_send_check(cih);
+ 	} else {
+ 		iph->daddr = cp->daddr.ip;
+ 		ip_send_check(iph);
+-		ciph->saddr = cp->daddr.ip;
+-		ip_send_check(ciph);
++		cih->saddr = cp->daddr.ip;
++		ip_send_check(cih);
+ 	}
+ 
+ 	/* the TCP/UDP/SCTP port */
+ 	if (has_ports) {
+-		__be16 *ports = (void *)ciph + ciph->ihl*4;
++		__be16 *ports = (void *)(skb->data + ciph->len);
+ 
+ 		if (inout)
+ 			ports[1] = cp->vport;
+@@ -782,10 +781,10 @@ void ip_vs_nat_icmp(struct sk_buff *skb, struct ip_vs_protocol *pp,
+ 	skb->ip_summed = CHECKSUM_UNNECESSARY;
+ 
+ 	if (inout)
+-		IP_VS_DBG_PKT(11, AF_INET, pp, skb, coff,
++		IP_VS_DBG_PKT(11, AF_INET, pp, skb, ciph->off,
+ 			      "Forwarding altered outgoing ICMP");
+ 	else
+-		IP_VS_DBG_PKT(11, AF_INET, pp, skb, coff,
++		IP_VS_DBG_PKT(11, AF_INET, pp, skb, ciph->off,
+ 			      "Forwarding altered incoming ICMP");
+ }
+ 
+@@ -878,7 +877,7 @@ static int handle_response_icmp(int af, struct sk_buff *skb,
+ 		ip_vs_nat_icmp_v6(skb, pp, cp, 1, toff, has_ports, ciph);
+ 	else
+ #endif
+-		ip_vs_nat_icmp(skb, pp, cp, 1, toff, has_ports);
++		ip_vs_nat_icmp(skb, pp, cp, 1, toff, has_ports, ciph);
+ 
+ 	if (ip_vs_route_me_harder(cp->ipvs, af, skb, hooknum))
+ 		goto out;
+@@ -914,7 +913,7 @@ static int ip_vs_out_icmp(struct netns_ipvs *ipvs, struct sk_buff *skb,
+ 	struct ip_vs_iphdr ciph;
+ 	struct ip_vs_conn *cp;
+ 	struct ip_vs_protocol *pp;
+-	unsigned int offset, ihl;
++	unsigned int offset;
+ 	union nf_inet_addr snet;
+ 
+ 	*related = 1;
+@@ -927,7 +926,6 @@ static int ip_vs_out_icmp(struct netns_ipvs *ipvs, struct sk_buff *skb,
+ 			return NF_ACCEPT;
+ 	}
+ 
+-	ihl = ipvsh->len;
+ 	offset = ipvsh->len;
+ 	ic = skb_header_pointer(skb, offset, sizeof(_icmph), &_icmph);
+ 	if (ic == NULL)
+@@ -953,11 +951,15 @@ static int ip_vs_out_icmp(struct netns_ipvs *ipvs, struct sk_buff *skb,
+ 
+ 	/* Now find the contained IP header */
+ 	offset += sizeof(_icmph);
++	if (!ip_vs_fill_iph_skb_icmp(AF_INET, skb, offset, true, &ciph))
++		return NF_ACCEPT; /* The packet looks wrong, ignore */
++
+ 	cih = skb_header_pointer(skb, offset, sizeof(_ciph), &_ciph);
+-	if (!(cih && cih->version == 4 && cih->ihl >= 5))
++	if (!(cih && cih->version == 4 &&
++	      ciph.len - ciph.off >= sizeof(struct iphdr)))
+ 		return NF_ACCEPT; /* The packet looks wrong, ignore */
+ 
+-	pp = ip_vs_proto_get(cih->protocol);
++	pp = ip_vs_proto_get(ciph.protocol);
+ 	if (!pp)
+ 		return NF_ACCEPT;
+ 
+@@ -968,8 +970,6 @@ static int ip_vs_out_icmp(struct netns_ipvs *ipvs, struct sk_buff *skb,
+ 	IP_VS_DBG_PKT(11, AF_INET, pp, skb, offset,
+ 		      "Checking outgoing ICMP for");
+ 
+-	ip_vs_fill_iph_skb_icmp(AF_INET, skb, offset, true, &ciph);
+-
+ 	/* The embedded headers contain source and dest in reverse order */
+ 	cp = INDIRECT_CALL_1(pp->conn_out_get, ip_vs_conn_out_get_proto,
+ 			     ipvs, AF_INET, skb, &ciph);
+@@ -977,8 +977,8 @@ static int ip_vs_out_icmp(struct netns_ipvs *ipvs, struct sk_buff *skb,
+ 		return NF_ACCEPT;
+ 
+ 	snet.ip = ipvsh->saddr.ip;
+-	return handle_response_icmp(AF_INET, skb, &snet, cp, pp, &ciph, ihl,
+-				    hooknum);
++	return handle_response_icmp(AF_INET, skb, &snet, cp, pp, &ciph,
++				    ipvsh->len, hooknum);
+ }
+ 
+ #ifdef CONFIG_IP_VS_IPV6
+@@ -1621,10 +1621,12 @@ ip_vs_in_icmp(struct netns_ipvs *ipvs, struct sk_buff *skb, int *related,
+ 	/* Now find the contained IP header */
+ 	offset += sizeof(_icmph);
+ 	cih = skb_header_pointer(skb, offset, sizeof(_ciph), &_ciph);
+-	if (!(cih && cih->version == 4 && cih->ihl >= 5))
++	if (!cih)
+ 		return NF_ACCEPT; /* The packet looks wrong, ignore */
+-	raddr = (union nf_inet_addr *)&cih->daddr;
+ 	hlen_ipip = cih->ihl * 4;
++	if (!(cih->version == 4 && hlen_ipip >= sizeof(struct iphdr)))
++		return NF_ACCEPT; /* The packet looks wrong, ignore */
++	raddr = (union nf_inet_addr *)&cih->daddr;
+ 
+ 	/* Special case for errors for IPIP/UDP/GRE tunnel packets */
+ 	tunnel = false;
+@@ -1641,9 +1643,6 @@ ip_vs_in_icmp(struct netns_ipvs *ipvs, struct sk_buff *skb, int *related,
+ 		if (!dest || dest->tun_type != IP_VS_CONN_F_TUNNEL_TYPE_IPIP)
+ 			return NF_ACCEPT;
+ 		offset += hlen_ipip;
+-		cih = skb_header_pointer(skb, offset, sizeof(_ciph), &_ciph);
+-		if (!(cih && cih->version == 4 && cih->ihl >= 5))
+-			return NF_ACCEPT; /* The packet looks wrong, ignore */
+ 		tunnel = true;
+ 	} else if ((cih->protocol == IPPROTO_UDP ||	/* Can be UDP encap */
+ 		    cih->protocol == IPPROTO_GRE) &&	/* Can be GRE encap */
+@@ -1668,21 +1667,25 @@ ip_vs_in_icmp(struct netns_ipvs *ipvs, struct sk_buff *skb, int *related,
+ 			/* Skip IP and UDP/GRE tunnel headers */
+ 			offset = offset2 + ulen;
+ 			/* Now we should be at the original IP header */
+-			cih = skb_header_pointer(skb, offset, sizeof(_ciph),
+-						 &_ciph);
+-			if (cih && cih->version == 4 && cih->ihl >= 5 &&
+-			    iproto == IPPROTO_IPIP)
++			if (iproto == IPPROTO_IPIP)
+ 				tunnel = true;
+ 			else
+ 				return NF_ACCEPT;
+ 		}
+ 	}
+ 
+-	pd = ip_vs_proto_data_get(ipvs, cih->protocol);
++	if (!ip_vs_fill_iph_skb_icmp(AF_INET, skb, offset, !tunnel, &ciph))
++		return NF_ACCEPT;
++	pd = ip_vs_proto_data_get(ipvs, ciph.protocol);
+ 	if (!pd)
+ 		return NF_ACCEPT;
+ 	pp = pd->pp;
+ 
++	cih = skb_header_pointer(skb, offset, sizeof(_ciph), &_ciph);
++	if (!(cih && cih->version == 4 &&
++	      ciph.len - ciph.off >= sizeof(struct iphdr)))
++		return NF_ACCEPT; /* The packet looks wrong, ignore */
++
+ 	/* Is the embedded protocol header present? */
+ 	if (unlikely(cih->frag_off & htons(IP_OFFSET) && !pp->dont_defrag))
+ 		return NF_ACCEPT;
+@@ -1690,9 +1693,6 @@ ip_vs_in_icmp(struct netns_ipvs *ipvs, struct sk_buff *skb, int *related,
+ 	IP_VS_DBG_PKT(11, AF_INET, pp, skb, offset,
+ 		      "Checking incoming ICMP for");
+ 
+-	offset2 = offset;
+-	ip_vs_fill_iph_skb_icmp(AF_INET, skb, offset, !tunnel, &ciph);
+-
+ 	/* The embedded headers contain source and dest in reverse order.
+ 	 * For IPIP/UDP/GRE tunnel this is error for request, not for reply.
+ 	 */
+@@ -1722,11 +1722,12 @@ ip_vs_in_icmp(struct netns_ipvs *ipvs, struct sk_buff *skb, int *related,
+ 	}
+ 
+ 	if (tunnel) {
+-		unsigned int hlen_orig = cih->ihl * 4;
++		unsigned int hlen_orig = ciph.len - ciph.off;
+ 		__be32 info = ic->un.gateway;
+ 		__u8 type = ic->type;
+ 		__u8 code = ic->code;
+ 
++		offset2 = offset;
+ 		/* Update the MTU */
+ 		if (ic->type == ICMP_DEST_UNREACH &&
+ 		    ic->code == ICMP_FRAG_NEEDED) {
+@@ -1767,6 +1768,7 @@ ip_vs_in_icmp(struct netns_ipvs *ipvs, struct sk_buff *skb, int *related,
+ 		if (pskb_pull(skb, offset2) == NULL)
+ 			goto ignore_tunnel;
+ 		skb_reset_network_header(skb);
++		memset(&(IPCB(skb)->opt), 0, sizeof(IPCB(skb)->opt));
+ 		/* Ensure the IP header is present in headroom */
+ 		if (!pskb_may_pull(skb, hlen_orig))
+ 			goto ignore_tunnel;
+diff --git a/net/netfilter/ipvs/ip_vs_ctl.c b/net/netfilter/ipvs/ip_vs_ctl.c
+index 27b7552b1e2481..c98bdcea8b2f5b 100644
+--- a/net/netfilter/ipvs/ip_vs_ctl.c
++++ b/net/netfilter/ipvs/ip_vs_ctl.c
+@@ -960,6 +960,40 @@ void ip_vs_stats_free(struct ip_vs_stats *stats)
+ 	}
+ }
+ 
++/* Update overload flag based on number of dest conns and lower/upper
++ * connection thresholds:
++ * - conns reach u_threshold and exceed it: set the flag
++ * - conns go below l_threshold (or 75% of u_threshold): clear the flag
++ */
++static void __ip_vs_dest_update_overload(struct ip_vs_dest *dest, int mode)
++{
++	int conns;
++	u32 l, u;
++
++	lockdep_assert_held(&dest->dst_lock);
++	u = READ_ONCE(dest->u_threshold);
++	if (!u)
++		goto unset;
++	l = READ_ONCE(dest->l_threshold_val);
++	conns = atomic_read(&dest->totalconns);
++	if (conns >= (mode > 0 ? l : u)) {
++		dest->flags |= IP_VS_DEST_F_OVERLOAD;
++		return;
++	}
++	if (conns >= (mode < 0 ? u : l))
++		return;
++
++unset:
++	dest->flags &= ~IP_VS_DEST_F_OVERLOAD;
++}
++
++void ip_vs_dest_update_overload(struct ip_vs_dest *dest, int mode)
++{
++	spin_lock_bh(&dest->dst_lock);
++	__ip_vs_dest_update_overload(dest, mode);
++	spin_unlock_bh(&dest->dst_lock);
++}
++
+ /*
+  *	Update a destination in the given service
+  */
+@@ -1026,10 +1060,19 @@ __ip_vs_update_dest(struct ip_vs_service *svc, struct ip_vs_dest *dest,
+ 	/* set the dest status flags */
+ 	dest->flags |= IP_VS_DEST_F_AVAILABLE;
+ 
+-	if (udest->u_threshold == 0 || udest->u_threshold > dest->u_threshold)
+-		dest->flags &= ~IP_VS_DEST_F_OVERLOAD;
+-	dest->u_threshold = udest->u_threshold;
+-	dest->l_threshold = udest->l_threshold;
++	if (READ_ONCE(dest->u_threshold) != udest->u_threshold ||
++	    READ_ONCE(dest->l_threshold) != udest->l_threshold) {
++		spin_lock_bh(&dest->dst_lock);
++		WRITE_ONCE(dest->u_threshold, udest->u_threshold);
++		WRITE_ONCE(dest->l_threshold, udest->l_threshold);
++		/* Low threshold defaults to 75% of upper threshold */
++		WRITE_ONCE(dest->l_threshold_val,
++			   udest->l_threshold ? :
++			   (udest->u_threshold -
++			    (udest->u_threshold >> 2)));
++		__ip_vs_dest_update_overload(dest, 0);
++		spin_unlock_bh(&dest->dst_lock);
++	}
+ 
+ 	dest->af = udest->af;
+ 
+@@ -1101,7 +1144,7 @@ ip_vs_new_dest(struct ip_vs_service *svc, struct ip_vs_dest_user_kern *udest)
+ 	dest->port = udest->port;
+ 
+ 	atomic_set(&dest->activeconns, 0);
+-	atomic_set(&dest->inactconns, 0);
++	atomic_set(&dest->totalconns, 0);
+ 	atomic_set(&dest->persistconns, 0);
+ 	refcount_set(&dest->refcnt, 1);
+ 
+@@ -1142,6 +1185,9 @@ ip_vs_add_dest(struct ip_vs_service *svc, struct ip_vs_dest_user_kern *udest)
+ 		return -ERANGE;
+ 	}
+ 
++	if (udest->u_threshold > INT_MAX)
++		return -EINVAL;
++
+ 	if (udest->tun_type == IP_VS_CONN_F_TUNNEL_TYPE_GUE) {
+ 		if (udest->tun_port == 0) {
+ 			pr_err("%s(): tunnel port is zero\n", __func__);
+@@ -1212,6 +1258,9 @@ ip_vs_edit_dest(struct ip_vs_service *svc, struct ip_vs_dest_user_kern *udest)
+ 		return -ERANGE;
+ 	}
+ 
++	if (udest->u_threshold > INT_MAX)
++		return -EINVAL;
++
+ 	if (udest->tun_type == IP_VS_CONN_F_TUNNEL_TYPE_GUE) {
+ 		if (udest->tun_port == 0) {
+ 			pr_err("%s(): tunnel port is zero\n", __func__);
+@@ -2456,7 +2505,7 @@ static int ip_vs_info_seq_show(struct seq_file *seq, void *v)
+ 					   ip_vs_fwd_name(atomic_read(&dest->conn_flags)),
+ 					   atomic_read(&dest->weight),
+ 					   atomic_read(&dest->activeconns),
+-					   atomic_read(&dest->inactconns));
++					   ip_vs_dest_inactconns(dest));
+ 			else
+ #endif
+ 				seq_printf(seq,
+@@ -2467,7 +2516,7 @@ static int ip_vs_info_seq_show(struct seq_file *seq, void *v)
+ 					   ip_vs_fwd_name(atomic_read(&dest->conn_flags)),
+ 					   atomic_read(&dest->weight),
+ 					   atomic_read(&dest->activeconns),
+-					   atomic_read(&dest->inactconns));
++					   ip_vs_dest_inactconns(dest));
+ 
+ 		}
+ 	}
+@@ -2950,10 +2999,10 @@ __ip_vs_get_dest_entries(struct netns_ipvs *ipvs, const struct ip_vs_get_dests *
+ 			entry.port = dest->port;
+ 			entry.conn_flags = atomic_read(&dest->conn_flags);
+ 			entry.weight = atomic_read(&dest->weight);
+-			entry.u_threshold = dest->u_threshold;
+-			entry.l_threshold = dest->l_threshold;
++			entry.u_threshold = READ_ONCE(dest->u_threshold);
++			entry.l_threshold = READ_ONCE(dest->l_threshold);
+ 			entry.activeconns = atomic_read(&dest->activeconns);
+-			entry.inactconns = atomic_read(&dest->inactconns);
++			entry.inactconns = ip_vs_dest_inactconns(dest);
+ 			entry.persistconns = atomic_read(&dest->persistconns);
+ 			ip_vs_copy_stats(&kstats, &dest->stats);
+ 			ip_vs_export_stats_user(&entry.stats, &kstats);
+@@ -3552,12 +3601,14 @@ static int ip_vs_genl_fill_dest(struct sk_buff *skb, struct ip_vs_dest *dest)
+ 			 dest->tun_port) ||
+ 	    nla_put_u16(skb, IPVS_DEST_ATTR_TUN_FLAGS,
+ 			dest->tun_flags) ||
+-	    nla_put_u32(skb, IPVS_DEST_ATTR_U_THRESH, dest->u_threshold) ||
+-	    nla_put_u32(skb, IPVS_DEST_ATTR_L_THRESH, dest->l_threshold) ||
++	    nla_put_u32(skb, IPVS_DEST_ATTR_U_THRESH,
++			READ_ONCE(dest->u_threshold)) ||
++	    nla_put_u32(skb, IPVS_DEST_ATTR_L_THRESH,
++			READ_ONCE(dest->l_threshold)) ||
+ 	    nla_put_u32(skb, IPVS_DEST_ATTR_ACTIVE_CONNS,
+ 			atomic_read(&dest->activeconns)) ||
+ 	    nla_put_u32(skb, IPVS_DEST_ATTR_INACT_CONNS,
+-			atomic_read(&dest->inactconns)) ||
++			ip_vs_dest_inactconns(dest)) ||
+ 	    nla_put_u32(skb, IPVS_DEST_ATTR_PERSIST_CONNS,
+ 			atomic_read(&dest->persistconns)) ||
+ 	    nla_put_u16(skb, IPVS_DEST_ATTR_ADDR_FAMILY, dest->af))
+diff --git a/net/netfilter/ipvs/ip_vs_est.c b/net/netfilter/ipvs/ip_vs_est.c
+index b48d3a09e21742..dc12da2a5f38dd 100644
+--- a/net/netfilter/ipvs/ip_vs_est.c
++++ b/net/netfilter/ipvs/ip_vs_est.c
+@@ -186,8 +186,11 @@ static int ip_vs_estimation_kthread(void *data)
+ 		}
+ 
+ 		/* kthread 0 will handle the calc phase */
+-		if (ipvs->est_calc_phase)
++		if (ipvs->est_calc_phase) {
+ 			ip_vs_est_calc_phase(ipvs);
++			if (kthread_should_stop() || !READ_ONCE(ipvs->enable))
++				return 0;
++		}
+ 	}
+ 
+ 	while (1) {
+@@ -262,6 +265,7 @@ int ip_vs_est_kthread_start(struct netns_ipvs *ipvs,
+ 		kd->task = NULL;
+ 		goto out;
+ 	}
++	get_task_struct(kd->task);
+ 
+ 	set_user_nice(kd->task, sysctl_est_nice(ipvs));
+ 	set_cpus_allowed_ptr(kd->task, sysctl_est_cpulist(ipvs));
+@@ -277,7 +281,7 @@ void ip_vs_est_kthread_stop(struct ip_vs_est_kt_data *kd)
+ {
+ 	if (kd->task) {
+ 		pr_info("stopping estimator thread %d...\n", kd->id);
+-		kthread_stop(kd->task);
++		kthread_stop_put(kd->task);
+ 		kd->task = NULL;
+ 	}
+ }
+@@ -509,7 +513,7 @@ static void ip_vs_est_kthread_destroy(struct ip_vs_est_kt_data *kd)
+ 	if (kd) {
+ 		if (kd->task) {
+ 			pr_info("stop unused estimator thread %d...\n", kd->id);
+-			kthread_stop(kd->task);
++			kthread_stop_put(kd->task);
+ 		}
+ 		ip_vs_stats_free(kd->calc_stats);
+ 		kfree(kd);
+diff --git a/net/netfilter/ipvs/ip_vs_lc.c b/net/netfilter/ipvs/ip_vs_lc.c
+index 9d34d81fc6f1c0..534db3c4a0160f 100644
+--- a/net/netfilter/ipvs/ip_vs_lc.c
++++ b/net/netfilter/ipvs/ip_vs_lc.c
+@@ -31,7 +31,7 @@ ip_vs_lc_schedule(struct ip_vs_service *svc, const struct sk_buff *skb,
+ 
+ 	/*
+ 	 * Simply select the server with the least number of
+-	 *        (activeconns<<5) + inactconns
++	 *        (activeconns*256) + totalconns
+ 	 * Except whose weight is equal to zero.
+ 	 * If the weight is equal to zero, it means that the server is
+ 	 * quiesced, the existing connections to the server still get
+@@ -57,7 +57,7 @@ ip_vs_lc_schedule(struct ip_vs_service *svc, const struct sk_buff *skb,
+ 			      IP_VS_DBG_ADDR(least->af, &least->addr),
+ 			      ntohs(least->port),
+ 			      atomic_read(&least->activeconns),
+-			      atomic_read(&least->inactconns));
++			      ip_vs_dest_inactconns(least));
+ 
+ 	return least;
+ }
+diff --git a/net/netfilter/ipvs/ip_vs_proto_sctp.c b/net/netfilter/ipvs/ip_vs_proto_sctp.c
+index 3dbd3096e1637b..fb8af6b15a3999 100644
+--- a/net/netfilter/ipvs/ip_vs_proto_sctp.c
++++ b/net/netfilter/ipvs/ip_vs_proto_sctp.c
+@@ -193,7 +193,7 @@ sctp_csum_check(int af, struct sk_buff *skb, struct ip_vs_protocol *pp,
+ 	struct sctphdr *sh;
+ 	__le32 cmp, val;
+ 
+-	if (!ip_vs_checksum_needed(skb, af))
++	if (!ip_vs_checksum_needed(skb))
+ 		return 1;
+ 	sh = (struct sctphdr *)(skb->data + sctphoff);
+ 	cmp = sh->checksum;
+@@ -446,12 +446,10 @@ set_sctp_state(struct ip_vs_proto_data *pd, struct ip_vs_conn *cp,
+ 			if (!(cp->flags & IP_VS_CONN_F_INACTIVE) &&
+ 				(next_state != IP_VS_SCTP_S_ESTABLISHED)) {
+ 				atomic_dec(&dest->activeconns);
+-				atomic_inc(&dest->inactconns);
+ 				cp->flags |= IP_VS_CONN_F_INACTIVE;
+ 			} else if ((cp->flags & IP_VS_CONN_F_INACTIVE) &&
+ 				   (next_state == IP_VS_SCTP_S_ESTABLISHED)) {
+ 				atomic_inc(&dest->activeconns);
+-				atomic_dec(&dest->inactconns);
+ 				cp->flags &= ~IP_VS_CONN_F_INACTIVE;
+ 			}
+ 		}
+diff --git a/net/netfilter/ipvs/ip_vs_proto_tcp.c b/net/netfilter/ipvs/ip_vs_proto_tcp.c
+index 1ac9c233537d34..944efd34290cde 100644
+--- a/net/netfilter/ipvs/ip_vs_proto_tcp.c
++++ b/net/netfilter/ipvs/ip_vs_proto_tcp.c
+@@ -527,12 +527,10 @@ set_tcp_state(struct ip_vs_proto_data *pd, struct ip_vs_conn *cp,
+ 			if (!(cp->flags & IP_VS_CONN_F_INACTIVE) &&
+ 			    !tcp_state_active(new_state)) {
+ 				atomic_dec(&dest->activeconns);
+-				atomic_inc(&dest->inactconns);
+ 				cp->flags |= IP_VS_CONN_F_INACTIVE;
+ 			} else if ((cp->flags & IP_VS_CONN_F_INACTIVE) &&
+ 				   tcp_state_active(new_state)) {
+ 				atomic_inc(&dest->activeconns);
+-				atomic_dec(&dest->inactconns);
+ 				cp->flags &= ~IP_VS_CONN_F_INACTIVE;
+ 			}
+ 		}
+diff --git a/net/netfilter/ipvs/ip_vs_sync.c b/net/netfilter/ipvs/ip_vs_sync.c
+index 4174076c66fa77..515346bf915aec 100644
+--- a/net/netfilter/ipvs/ip_vs_sync.c
++++ b/net/netfilter/ipvs/ip_vs_sync.c
+@@ -879,13 +879,10 @@ static void ip_vs_proc_conn(struct netns_ipvs *ipvs, struct ip_vs_conn_param *pa
+ 		spin_lock_bh(&cp->lock);
+ 		if ((cp->flags ^ flags) & IP_VS_CONN_F_INACTIVE &&
+ 		    !(flags & IP_VS_CONN_F_TEMPLATE) && dest) {
+-			if (flags & IP_VS_CONN_F_INACTIVE) {
++			if (flags & IP_VS_CONN_F_INACTIVE)
+ 				atomic_dec(&dest->activeconns);
+-				atomic_inc(&dest->inactconns);
+-			} else {
++			else
+ 				atomic_inc(&dest->activeconns);
+-				atomic_dec(&dest->inactconns);
+-			}
+ 		}
+ 		flags &= IP_VS_CONN_F_BACKUP_UPD_MASK;
+ 		flags |= cp->flags & ~IP_VS_CONN_F_BACKUP_UPD_MASK;
+diff --git a/net/netfilter/ipvs/ip_vs_xmit.c b/net/netfilter/ipvs/ip_vs_xmit.c
+index c214e5d05524c3..5b37e92df02c59 100644
+--- a/net/netfilter/ipvs/ip_vs_xmit.c
++++ b/net/netfilter/ipvs/ip_vs_xmit.c
+@@ -1551,7 +1551,7 @@ ip_vs_icmp_xmit(struct sk_buff *skb, struct ip_vs_conn *cp,
+ 	if (skb_cow(skb, rt->dst.dev->hard_header_len))
+ 		goto tx_error;
+ 
+-	ip_vs_nat_icmp(skb, pp, cp, 0, toff, has_ports);
++	ip_vs_nat_icmp(skb, pp, cp, 0, toff, has_ports, ciph);
+ 
+ 	/* Another hack: avoid icmp_send in ip_fragment */
+ 	skb->ignore_df = 1;
+diff --git a/net/netfilter/nf_conntrack_proto.c b/net/netfilter/nf_conntrack_proto.c
+index c928ff63b10e47..aaf97483a03754 100644
+--- a/net/netfilter/nf_conntrack_proto.c
++++ b/net/netfilter/nf_conntrack_proto.c
+@@ -79,6 +79,12 @@ void nf_ct_l4proto_log_invalid(const struct sk_buff *skb,
+ 	struct net *net;
+ 	va_list args;
+ 
++	/* nfnetlink_log may re-enter conntrack attribute dumping and try to
++	 * take ct->lock again via helpers such as tcp_to_nlattr(), so invalid
++	 * conntrack logs must only be emitted after dropping ct->lock.
++	 */
++	lockdep_assert_not_held(&ct->lock);
++
+ 	net = nf_ct_net(ct);
+ 	if (likely(net->ct.sysctl_log_invalid == 0))
+ 		return;
+diff --git a/net/netfilter/nf_conntrack_proto_sctp.c b/net/netfilter/nf_conntrack_proto_sctp.c
+index 0dd55d3fba38da..ef51f0babf94a9 100644
+--- a/net/netfilter/nf_conntrack_proto_sctp.c
++++ b/net/netfilter/nf_conntrack_proto_sctp.c
+@@ -341,10 +341,12 @@ int nf_conntrack_sctp_packet(struct nf_conn *ct,
+ 	struct sctphdr _sctph;
+ 	const struct sctp_chunkhdr *sch;
+ 	struct sctp_chunkhdr _sch;
++	bool log_invalid = false;
+ 	u_int32_t offset, count;
+ 	unsigned int *timeouts;
+ 	unsigned long map[256 / sizeof(unsigned long)] = { 0 };
+ 	bool ignore = false;
++	u8 invalid_type = 0;
+ 
+ 	if (sctp_error(skb, dataoff, state))
+ 		return -NF_ACCEPT;
+@@ -456,10 +458,8 @@ int nf_conntrack_sctp_packet(struct nf_conn *ct,
+ 
+ 		/* Invalid */
+ 		if (new_state == SCTP_CONNTRACK_MAX) {
+-			nf_ct_l4proto_log_invalid(skb, ct, state,
+-						  "Invalid, old_state %d, dir %d, type %d",
+-						  old_state, dir, sch->type);
+-
++			log_invalid = true;
++			invalid_type = sch->type;
+ 			goto out_unlock;
+ 		}
+ 
+@@ -534,6 +534,10 @@ int nf_conntrack_sctp_packet(struct nf_conn *ct,
+ 
+ out_unlock:
+ 	spin_unlock_bh(&ct->lock);
++	if (log_invalid)
++		nf_ct_l4proto_log_invalid(skb, ct, state,
++					  "Invalid, old_state %d, dir %d, type %d",
++					  old_state, dir, invalid_type);
+ out:
+ 	return -NF_ACCEPT;
+ }
+diff --git a/net/netfilter/nf_conntrack_proto_tcp.c b/net/netfilter/nf_conntrack_proto_tcp.c
+index 228005a66d529b..2d39421dcf9d84 100644
+--- a/net/netfilter/nf_conntrack_proto_tcp.c
++++ b/net/netfilter/nf_conntrack_proto_tcp.c
+@@ -480,37 +480,81 @@ static void tcp_init_sender(struct ip_ct_tcp_state *sender,
+ 	}
+ }
+ 
+-__printf(6, 7)
+-static enum nf_ct_tcp_action nf_tcp_log_invalid(const struct sk_buff *skb,
+-						const struct nf_conn *ct,
+-						const struct nf_hook_state *state,
+-						const struct ip_ct_tcp_state *sender,
+-						enum nf_ct_tcp_action ret,
+-						const char *fmt, ...)
++enum nf_tcp_invalid_log_type {
++	NF_TCP_LOG_NONE,
++	NF_TCP_LOG_OVERSHOT,
++	NF_TCP_LOG_SEQ_OVER,
++	NF_TCP_LOG_ACK_OVER,
++	NF_TCP_LOG_SEQ_UNDER,
++	NF_TCP_LOG_ACK_UNDER,
++};
++
++struct nf_tcp_invalid_log {
++	enum nf_tcp_invalid_log_type type;
++	u32 value;
++};
++
++static enum nf_ct_tcp_action
++nf_tcp_store_invalid(const struct nf_conn *ct,
++		     const struct ip_ct_tcp_state *sender,
++		     struct nf_tcp_invalid_log *log,
++		     enum nf_ct_tcp_action ret,
++		     enum nf_tcp_invalid_log_type type,
++		     u32 value)
+ {
+ 	const struct nf_tcp_net *tn = nf_tcp_pernet(nf_ct_net(ct));
+-	struct va_format vaf;
+-	va_list args;
+ 	bool be_liberal;
+ 
+ 	be_liberal = sender->flags & IP_CT_TCP_FLAG_BE_LIBERAL || tn->tcp_be_liberal;
+ 	if (be_liberal)
+ 		return NFCT_TCP_ACCEPT;
+ 
+-	va_start(args, fmt);
+-	vaf.fmt = fmt;
+-	vaf.va = &args;
+-	nf_ct_l4proto_log_invalid(skb, ct, state, "%pV", &vaf);
+-	va_end(args);
+-
++	log->type = type;
++	log->value = value;
+ 	return ret;
+ }
+ 
++static void nf_tcp_log_invalid(const struct sk_buff *skb,
++			       const struct nf_conn *ct,
++			       const struct nf_hook_state *state,
++			       const struct nf_tcp_invalid_log *log)
++{
++	switch (log->type) {
++	case NF_TCP_LOG_OVERSHOT:
++		nf_ct_l4proto_log_invalid(skb, ct, state,
++					  "%u bytes more than expected",
++					  log->value);
++		break;
++	case NF_TCP_LOG_SEQ_OVER:
++		nf_ct_l4proto_log_invalid(skb, ct, state,
++					  "SEQ is over upper bound %u (over the window of the receiver)",
++					  log->value);
++		break;
++	case NF_TCP_LOG_ACK_OVER:
++		nf_ct_l4proto_log_invalid(skb, ct, state,
++					  "ACK is over upper bound %u (ACKed data not seen yet)",
++					  log->value);
++		break;
++	case NF_TCP_LOG_SEQ_UNDER:
++		nf_ct_l4proto_log_invalid(skb, ct, state,
++					  "SEQ is under lower bound %u (already ACKed data retransmitted)",
++					  log->value);
++		break;
++	case NF_TCP_LOG_ACK_UNDER:
++		nf_ct_l4proto_log_invalid(skb, ct, state,
++					  "ignored ACK under lower bound %u (possible overly delayed)",
++					  log->value);
++		break;
++	case NF_TCP_LOG_NONE:
++		break;
++	}
++}
++
+ static enum nf_ct_tcp_action
+ tcp_in_window(struct nf_conn *ct, enum ip_conntrack_dir dir,
+ 	      unsigned int index, const struct sk_buff *skb,
+ 	      unsigned int dataoff, const struct tcphdr *tcph,
+-	      const struct nf_hook_state *hook_state)
++	      struct nf_tcp_invalid_log *log)
+ {
+ 	struct ip_ct_tcp *state = &ct->proto.tcp;
+ 	struct ip_ct_tcp_state *sender = &state->seen[dir];
+@@ -640,31 +684,29 @@ tcp_in_window(struct nf_conn *ct, enum ip_conntrack_dir dir,
+ 			sender->td_end = end;
+ 			sender->flags |= IP_CT_TCP_FLAG_DATA_UNACKNOWLEDGED;
+ 
+-			return nf_tcp_log_invalid(skb, ct, hook_state, sender, NFCT_TCP_IGNORE,
+-						  "%u bytes more than expected", overshot);
++			return nf_tcp_store_invalid(ct, sender, log, NFCT_TCP_IGNORE,
++				   NF_TCP_LOG_OVERSHOT, overshot);
+ 		}
+ 
+-		return nf_tcp_log_invalid(skb, ct, hook_state, sender, NFCT_TCP_INVALID,
+-					  "SEQ is over upper bound %u (over the window of the receiver)",
+-					  sender->td_maxend + 1);
++		return nf_tcp_store_invalid(ct, sender, log, NFCT_TCP_INVALID,
++				   NF_TCP_LOG_SEQ_OVER, sender->td_maxend + 1);
+ 	}
+ 
+ 	if (!before(sack, receiver->td_end + 1))
+-		return nf_tcp_log_invalid(skb, ct, hook_state, sender, NFCT_TCP_INVALID,
+-					  "ACK is over upper bound %u (ACKed data not seen yet)",
+-					  receiver->td_end + 1);
++		return nf_tcp_store_invalid(ct, sender, log, NFCT_TCP_INVALID,
++					   NF_TCP_LOG_ACK_OVER, receiver->td_end + 1);
+ 
+ 	/* Is the ending sequence in the receive window (if available)? */
+ 	in_recv_win = !receiver->td_maxwin ||
+ 		      after(end, sender->td_end - receiver->td_maxwin - 1);
+ 	if (!in_recv_win)
+-		return nf_tcp_log_invalid(skb, ct, hook_state, sender, NFCT_TCP_IGNORE,
+-					  "SEQ is under lower bound %u (already ACKed data retransmitted)",
+-					  sender->td_end - receiver->td_maxwin - 1);
++		return nf_tcp_store_invalid(ct, sender, log, NFCT_TCP_IGNORE,
++					   NF_TCP_LOG_SEQ_UNDER,
++					   sender->td_end - receiver->td_maxwin - 1);
+ 	if (!after(sack, receiver->td_end - MAXACKWINDOW(sender) - 1))
+-		return nf_tcp_log_invalid(skb, ct, hook_state, sender, NFCT_TCP_IGNORE,
+-					  "ignored ACK under lower bound %u (possible overly delayed)",
+-					  receiver->td_end - MAXACKWINDOW(sender) - 1);
++		return nf_tcp_store_invalid(ct, sender, log, NFCT_TCP_IGNORE,
++					   NF_TCP_LOG_ACK_UNDER,
++					   receiver->td_end - MAXACKWINDOW(sender) - 1);
+ 
+ 	/* Take into account window scaling (RFC 1323). */
+ 	if (!tcph->syn)
+@@ -719,11 +761,8 @@ tcp_in_window(struct nf_conn *ct, enum ip_conntrack_dir dir,
+ 	return NFCT_TCP_ACCEPT;
+ }
+ 
+-static void __cold nf_tcp_handle_invalid(struct nf_conn *ct,
+-					 enum ip_conntrack_dir dir,
+-					 int index,
+-					 const struct sk_buff *skb,
+-					 const struct nf_hook_state *hook_state)
++static bool __cold
++nf_tcp_handle_invalid(struct nf_conn *ct, enum ip_conntrack_dir dir, int index)
+ {
+ 	const unsigned int *timeouts;
+ 	const struct nf_tcp_net *tn;
+@@ -732,7 +771,7 @@ static void __cold nf_tcp_handle_invalid(struct nf_conn *ct,
+ 
+ 	if (!test_bit(IPS_ASSURED_BIT, &ct->status) ||
+ 	    test_bit(IPS_FIXED_TIMEOUT_BIT, &ct->status))
+-		return;
++		return false;
+ 
+ 	/* We don't want to have connections hanging around in ESTABLISHED
+ 	 * state for long time 'just because' conntrack deemed a FIN/RST
+@@ -747,7 +786,7 @@ static void __cold nf_tcp_handle_invalid(struct nf_conn *ct,
+ 	case TCP_FIN_SET:
+ 		break;
+ 	default:
+-		return;
++		return false;
+ 	}
+ 
+ 	if (ct->proto.tcp.last_dir != dir &&
+@@ -755,7 +794,7 @@ static void __cold nf_tcp_handle_invalid(struct nf_conn *ct,
+ 	     ct->proto.tcp.last_index == TCP_RST_SET)) {
+ 		expires = nf_ct_expires(ct);
+ 		if (expires < 120 * HZ)
+-			return;
++			return false;
+ 
+ 		tn = nf_tcp_pernet(nf_ct_net(ct));
+ 		timeouts = nf_ct_timeout_lookup(ct);
+@@ -764,16 +803,15 @@ static void __cold nf_tcp_handle_invalid(struct nf_conn *ct,
+ 
+ 		timeout = READ_ONCE(timeouts[TCP_CONNTRACK_UNACK]);
+ 		if (expires > timeout) {
+-			nf_ct_l4proto_log_invalid(skb, ct, hook_state,
+-					  "packet (index %d, dir %d) response for index %d lower timeout to %u",
+-					  index, dir, ct->proto.tcp.last_index, timeout);
+-
+ 			WRITE_ONCE(ct->timeout, timeout + nfct_time_stamp);
++			return true;
+ 		}
+ 	} else {
+ 		ct->proto.tcp.last_index = index;
+ 		ct->proto.tcp.last_dir = dir;
+ 	}
++
++	return false;
+ }
+ 
+ /* table of valid flag combinations - PUSH, ECE and CWR are always valid */
+@@ -968,7 +1006,9 @@ int nf_conntrack_tcp_packet(struct nf_conn *ct,
+ 	struct net *net = nf_ct_net(ct);
+ 	struct nf_tcp_net *tn = nf_tcp_pernet(net);
+ 	enum tcp_conntrack new_state, old_state;
++	struct nf_tcp_invalid_log log = {};
+ 	unsigned int index, *timeouts;
++	bool lowered_timeout = false;
+ 	enum nf_ct_tcp_action res;
+ 	enum ip_conntrack_dir dir;
+ 	const struct tcphdr *th;
+@@ -1251,14 +1291,18 @@ int nf_conntrack_tcp_packet(struct nf_conn *ct,
+ 	}
+ 
+ 	res = tcp_in_window(ct, dir, index,
+-			    skb, dataoff, th, state);
++			    skb, dataoff, th, &log);
+ 	switch (res) {
+ 	case NFCT_TCP_IGNORE:
+ 		spin_unlock_bh(&ct->lock);
++		nf_tcp_log_invalid(skb, ct, state, &log);
+ 		return NF_ACCEPT;
+ 	case NFCT_TCP_INVALID:
+-		nf_tcp_handle_invalid(ct, dir, index, skb, state);
++		lowered_timeout = nf_tcp_handle_invalid(ct, dir, index);
+ 		spin_unlock_bh(&ct->lock);
++		nf_tcp_log_invalid(skb, ct, state, &log);
++		if (lowered_timeout)
++			nf_ct_l4proto_log_invalid(skb, ct, state, "lowered timeout to UNACK");
+ 		return -NF_ACCEPT;
+ 	case NFCT_TCP_ACCEPT:
+ 		break;
+diff --git a/net/openvswitch/datapath.c b/net/openvswitch/datapath.c
+index fb5b72700d82b1..5706f2393fb707 100644
+--- a/net/openvswitch/datapath.c
++++ b/net/openvswitch/datapath.c
+@@ -1084,9 +1084,8 @@ static int ovs_flow_cmd_new(struct sk_buff *skb, struct genl_info *info)
+ 			error = -EEXIST;
+ 			goto err_unlock_ovs;
+ 		}
+-		/* The flow identifier has to be the same for flow updates.
+-		 * Look for any overlapping flow.
+-		 */
++
++		/* Look for any overlapping flow. */
+ 		if (unlikely(!ovs_flow_cmp(flow, &match))) {
+ 			if (ovs_identifier_is_key(&flow->id))
+ 				flow = ovs_flow_tbl_lookup_exact(&dp->table,
+@@ -1098,6 +1097,30 @@ static int ovs_flow_cmd_new(struct sk_buff *skb, struct genl_info *info)
+ 				goto err_unlock_ovs;
+ 			}
+ 		}
++
++		if (unlikely(reply)) {
++			size_t cur, req;
++
++			cur = ovs_flow_cmd_msg_size(acts, &new_flow->id,
++						    ufid_flags);
++			req = ovs_flow_cmd_msg_size(acts, &flow->id,
++						    ufid_flags);
++			if (cur < req) {
++				struct sk_buff *resized;
++
++				resized = ovs_flow_cmd_alloc_info(acts,
++								  &flow->id,
++								  info, false,
++								  ufid_flags);
++				if (IS_ERR(resized)) {
++					error = PTR_ERR(resized);
++					goto err_unlock_ovs;
++				}
++				kfree_skb(reply);
++				reply = resized;
++			}
++		}
++
+ 		/* Update actions. */
+ 		old_acts = ovsl_dereference(flow->sf_acts);
+ 		rcu_assign_pointer(flow->sf_acts, acts);
+diff --git a/net/openvswitch/flow.c b/net/openvswitch/flow.c
+index b80bd3a9077397..52e261ce91e8e9 100644
+--- a/net/openvswitch/flow.c
++++ b/net/openvswitch/flow.c
+@@ -893,8 +893,6 @@ static int key_extract_l3l4(struct sk_buff *skb, struct sw_flow_key *key)
+  * Ethernet header
+  * @key: output flow key
+  *
+- * The caller must ensure that skb->len >= ETH_HLEN.
+- *
+  * Initializes @skb header fields as follows:
+  *
+  *    - skb->mac_header: the L2 header.
+@@ -914,8 +912,6 @@ static int key_extract_l3l4(struct sk_buff *skb, struct sw_flow_key *key)
+  */
+ static int key_extract(struct sk_buff *skb, struct sw_flow_key *key)
+ {
+-	struct ethhdr *eth;
+-
+ 	/* Flags are always used as part of stats */
+ 	key->tp.flags = 0;
+ 
+@@ -930,6 +926,13 @@ static int key_extract(struct sk_buff *skb, struct sw_flow_key *key)
+ 		skb_reset_network_header(skb);
+ 		key->eth.type = skb->protocol;
+ 	} else {
++		struct ethhdr *eth;
++		int err;
++
++		err = check_header(skb, ETH_HLEN);
++		if (unlikely(err))
++			return err;
++
+ 		eth = eth_hdr(skb);
+ 		ether_addr_copy(key->eth.src, eth->h_source);
+ 		ether_addr_copy(key->eth.dst, eth->h_dest);
+diff --git a/net/packet/af_packet.c b/net/packet/af_packet.c
+index d435a48bc0e3b7..493a167a7c85b0 100644
+--- a/net/packet/af_packet.c
++++ b/net/packet/af_packet.c
+@@ -1367,13 +1367,25 @@ static int packet_rcv_has_room(struct packet_sock *po, struct sk_buff *skb)
+ 	return ret;
+ }
+ 
+-static void packet_rcv_try_clear_pressure(struct packet_sock *po)
++static void __packet_rcv_try_clear_pressure(struct packet_sock *po)
+ {
+ 	if (packet_sock_flag(po, PACKET_SOCK_PRESSURE) &&
+ 	    __packet_rcv_has_room(po, NULL) == ROOM_NORMAL)
+ 		packet_sock_flag_set(po, PACKET_SOCK_PRESSURE, false);
+ }
+ 
++static void packet_rcv_try_clear_pressure(struct packet_sock *po)
++{
++	struct sock *sk = &po->sk;
++
++	if (!packet_sock_flag(po, PACKET_SOCK_PRESSURE))
++		return;
++
++	spin_lock_bh(&sk->sk_receive_queue.lock);
++	__packet_rcv_try_clear_pressure(po);
++	spin_unlock_bh(&sk->sk_receive_queue.lock);
++}
++
+ static void packet_sock_destruct(struct sock *sk)
+ {
+ 	skb_queue_purge(&sk->sk_error_queue);
+@@ -1976,11 +1988,12 @@ static void packet_parse_headers(struct sk_buff *skb, struct socket *sock)
+ {
+ 	int depth;
+ 
++	/* On TX skb->data is the L2 header; anchor it for all socket types. */
++	skb_reset_mac_header(skb);
++
+ 	if ((!skb->protocol || skb->protocol == htons(ETH_P_ALL)) &&
+-	    sock->type == SOCK_RAW) {
+-		skb_reset_mac_header(skb);
++	    sock->type == SOCK_RAW)
+ 		skb->protocol = dev_parse_header_protocol(skb);
+-	}
+ 
+ 	/* Move network header to the right position for VLAN tagged packets */
+ 	if (likely(skb->dev->type == ARPHRD_ETHER) &&
+@@ -2005,8 +2018,9 @@ static int packet_sendmsg_spkt(struct socket *sock, struct msghdr *msg,
+ 	struct net_device *dev;
+ 	struct sockcm_cookie sockc;
+ 	__be16 proto = 0;
+-	int err;
++	int hard_header_len;
+ 	int extra_len = 0;
++	int err;
+ 
+ 	/*
+ 	 *	Get and verify the address.
+@@ -2049,14 +2063,18 @@ retry:
+ 		extra_len = 4; /* We're doing our own CRC */
+ 	}
+ 
++	/* Keep the allocation-time header length across retry. */
++	if (!skb)
++		hard_header_len = READ_ONCE(dev->hard_header_len);
++
+ 	err = -EMSGSIZE;
+-	if (len > dev->mtu + dev->hard_header_len + VLAN_HLEN + extra_len)
++	if (len > dev->mtu + hard_header_len + VLAN_HLEN + extra_len)
+ 		goto out_unlock;
+ 
+ 	if (!skb) {
+-		size_t reserved = LL_RESERVED_SPACE(dev);
++		size_t reserved = LL_RESERVED_SPACE_EX(dev, hard_header_len);
+ 		int tlen = dev->needed_tailroom;
+-		unsigned int hhlen = dev->header_ops ? dev->hard_header_len : 0;
++		unsigned int hhlen = dev->header_ops ? hard_header_len : 0;
+ 
+ 		rcu_read_unlock();
+ 		skb = sock_wmalloc(sk, len + reserved + tlen, 0, GFP_KERNEL);
+@@ -2086,7 +2104,7 @@ retry:
+ 		err = -EINVAL;
+ 		goto out_unlock;
+ 	}
+-	if (len > (dev->mtu + dev->hard_header_len + extra_len) &&
++	if (len > (dev->mtu + hard_header_len + extra_len) &&
+ 	    !packet_extra_vlan_len_allowed(dev, skb)) {
+ 		err = -EMSGSIZE;
+ 		goto out_unlock;
+@@ -2628,6 +2646,7 @@ static int packet_snd_vnet_parse(struct msghdr *msg, size_t *len,
+ static int tpacket_fill_skb(struct packet_sock *po, struct sk_buff *skb,
+ 		void *frame, struct net_device *dev, void *data, int tp_len,
+ 		__be16 proto, unsigned char *addr, int hlen, int copylen,
++		int hard_header_len,
+ 		const struct sockcm_cookie *sockc)
+ {
+ 	union tpacket_uhdr ph;
+@@ -2659,8 +2678,8 @@ static int tpacket_fill_skb(struct packet_sock *po, struct sk_buff *skb,
+ 	} else if (copylen) {
+ 		int hdrlen = min_t(int, copylen, tp_len);
+ 
+-		skb_push(skb, dev->hard_header_len);
+-		skb_put(skb, copylen - dev->hard_header_len);
++		skb_push(skb, hard_header_len);
++		skb_put(skb, copylen - hard_header_len);
+ 		err = skb_store_bits(skb, 0, data, hdrlen);
+ 		if (unlikely(err))
+ 			return err;
+@@ -2791,7 +2810,7 @@ static int tpacket_snd(struct packet_sock *po, struct msghdr *msg)
+ 	void *data;
+ 	int len_sum = 0;
+ 	int status = TP_STATUS_AVAILABLE;
+-	int hlen, tlen, copylen = 0;
++	int hard_header_len, hlen, tlen, copylen = 0;
+ 	long timeo;
+ 
+ 	mutex_lock(&po->pg_vec_lock);
+@@ -2838,8 +2857,9 @@ static int tpacket_snd(struct packet_sock *po, struct msghdr *msg)
+ 			goto out_put;
+ 	}
+ 
++	hard_header_len = READ_ONCE(dev->hard_header_len);
+ 	if (po->sk.sk_socket->type == SOCK_RAW)
+-		reserve = dev->hard_header_len;
++		reserve = hard_header_len;
+ 	size_max = po->tx_ring.frame_size
+ 		- (po->tp_hdrlen - sizeof(struct sockaddr_ll));
+ 
+@@ -2876,7 +2896,7 @@ static int tpacket_snd(struct packet_sock *po, struct msghdr *msg)
+ 			goto tpacket_error;
+ 
+ 		status = TP_STATUS_SEND_REQUEST;
+-		hlen = LL_RESERVED_SPACE(dev);
++		hlen = LL_RESERVED_SPACE_EX(dev, hard_header_len);
+ 		tlen = dev->needed_tailroom;
+ 		if (vnet_hdr_sz) {
+ 			data += vnet_hdr_sz;
+@@ -2894,10 +2914,10 @@ static int tpacket_snd(struct packet_sock *po, struct msghdr *msg)
+ 						    vnet_hdr.hdr_len);
+ 			has_vnet_hdr = true;
+ 		}
+-		copylen = max_t(int, copylen, dev->hard_header_len);
++		copylen = max_t(int, copylen, hard_header_len);
+ 		skb = sock_alloc_send_skb(&po->sk,
+ 				hlen + tlen + sizeof(struct sockaddr_ll) +
+-				(copylen - dev->hard_header_len),
++				(copylen - hard_header_len),
+ 				!need_wait, &err);
+ 
+ 		if (unlikely(skb == NULL)) {
+@@ -2907,7 +2927,8 @@ static int tpacket_snd(struct packet_sock *po, struct msghdr *msg)
+ 			goto out_status;
+ 		}
+ 		tp_len = tpacket_fill_skb(po, skb, ph, dev, data, tp_len, proto,
+-					  addr, hlen, copylen, &sockc);
++					  addr, hlen, copylen, hard_header_len,
++					  &sockc);
+ 		if (likely(tp_len >= 0) &&
+ 		    tp_len > dev->mtu + reserve &&
+ 		    !vnet_hdr_sz &&
+@@ -3015,7 +3036,7 @@ static int packet_snd(struct socket *sock, struct msghdr *msg, size_t len)
+ 	int offset = 0;
+ 	struct packet_sock *po = pkt_sk(sk);
+ 	int vnet_hdr_sz = READ_ONCE(po->vnet_hdr_sz);
+-	int hlen, tlen, linear;
++	int hard_header_len, hlen, tlen, linear;
+ 	int extra_len = 0;
+ 
+ 	/*
+@@ -3056,8 +3077,9 @@ static int packet_snd(struct socket *sock, struct msghdr *msg, size_t len)
+ 			goto out_unlock;
+ 	}
+ 
++	hard_header_len = READ_ONCE(dev->hard_header_len);
+ 	if (sock->type == SOCK_RAW)
+-		reserve = dev->hard_header_len;
++		reserve = hard_header_len;
+ 	if (vnet_hdr_sz) {
+ 		err = packet_snd_vnet_parse(msg, &len, &vnet_hdr, vnet_hdr_sz);
+ 		if (err)
+@@ -3078,10 +3100,10 @@ static int packet_snd(struct socket *sock, struct msghdr *msg, size_t len)
+ 		goto out_unlock;
+ 
+ 	err = -ENOBUFS;
+-	hlen = LL_RESERVED_SPACE(dev);
++	hlen = LL_RESERVED_SPACE_EX(dev, hard_header_len);
+ 	tlen = dev->needed_tailroom;
+ 	linear = __virtio16_to_cpu(vio_le(), vnet_hdr.hdr_len);
+-	linear = max(linear, min_t(int, len, dev->hard_header_len));
++	linear = max(linear, min_t(int, len, hard_header_len));
+ 	skb = packet_alloc_skb(sk, hlen + tlen, hlen, len, linear,
+ 			       msg->msg_flags & MSG_DONTWAIT, &err);
+ 	if (skb == NULL)
+@@ -3097,7 +3119,7 @@ static int packet_snd(struct socket *sock, struct msghdr *msg, size_t len)
+ 	} else if (reserve) {
+ 		skb_reserve(skb, -reserve);
+ 		if (len < reserve + sizeof(struct ipv6hdr) &&
+-		    dev->min_header_len != dev->hard_header_len)
++		    dev->min_header_len != hard_header_len)
+ 			skb_reset_network_header(skb);
+ 	}
+ 
+@@ -4351,7 +4373,7 @@ static __poll_t packet_poll(struct file *file, struct socket *sock,
+ 			TP_STATUS_KERNEL))
+ 			mask |= EPOLLIN | EPOLLRDNORM;
+ 	}
+-	packet_rcv_try_clear_pressure(po);
++	__packet_rcv_try_clear_pressure(po);
+ 	spin_unlock_bh(&sk->sk_receive_queue.lock);
+ 	spin_lock_bh(&sk->sk_write_queue.lock);
+ 	if (po->tx_ring.pg_vec) {
+@@ -4591,14 +4613,14 @@ static int packet_set_ring(struct sock *sk, union tpacket_req_u *req_u,
+ 		rb->frame_max = (req->tp_frame_nr - 1);
+ 		rb->head = 0;
+ 		rb->frame_size = req->tp_frame_size;
++		po->prot_hook.func = (po->rx_ring.pg_vec) ?
++						tpacket_rcv : packet_rcv;
+ 		spin_unlock_bh(&rb_queue->lock);
+ 
+ 		swap(rb->pg_vec_order, order);
+ 		swap(rb->pg_vec_len, req->tp_block_nr);
+ 
+ 		rb->pg_vec_pages = req->tp_block_size/PAGE_SIZE;
+-		po->prot_hook.func = (po->rx_ring.pg_vec) ?
+-						tpacket_rcv : packet_rcv;
+ 		skb_queue_purge(rb_queue);
+ 		if (atomic_long_read(&po->mapped))
+ 			pr_err("packet_mmap: vma is busy: %ld\n",
+diff --git a/net/sched/act_ct.c b/net/sched/act_ct.c
+index 287e2559341283..7a0dff24c5d157 100644
+--- a/net/sched/act_ct.c
++++ b/net/sched/act_ct.c
+@@ -841,8 +841,15 @@ static int tcf_ct_ipv6_is_fragment(struct sk_buff *skb, bool *frag)
+ 	return 0;
+ }
+ 
++/* On error, tells the caller whether it still owns @skb and must free it
++ * itself.  @skb is ours only when the header checks below reject the packet
++ * before it is handed to the defragmentation engine; once nf_ct_handle_
++ * fragments() has been called the skb is either queued (-EINPROGRESS) or has
++ * already been freed by it.
++ */
+ static int tcf_ct_handle_fragments(struct net *net, struct sk_buff *skb,
+-				   u8 family, u16 zone, bool *defrag)
++				   u8 family, u16 zone, bool *defrag,
++				   bool *skb_is_ours)
+ {
+ 	enum ip_conntrack_info ctinfo;
+ 	struct tc_skb_cb cb;
+@@ -860,8 +867,12 @@ static int tcf_ct_handle_fragments(struct net *net, struct sk_buff *skb,
+ 		err = tcf_ct_ipv4_is_fragment(skb, &frag);
+ 	else
+ 		err = tcf_ct_ipv6_is_fragment(skb, &frag);
+-	if (err || !frag)
++	if (err) {
++		*skb_is_ours = true;
+ 		return err;
++	}
++	if (!frag)
++		return 0;
+ 
+ 	cb = *tc_skb_cb(skb);
+ 	err = nf_ct_handle_fragments(net, skb, zone, family, &proto, &cb.mru);
+@@ -971,6 +982,7 @@ TC_INDIRECT_SCOPE int tcf_ct_act(struct sk_buff *skb, const struct tc_action *a,
+ 	int nh_ofs, err, retval;
+ 	struct tcf_ct_params *p;
+ 	bool add_helper = false;
++	bool skb_is_ours = false;
+ 	bool skip_add = false;
+ 	bool defrag = false;
+ 	struct nf_conn *ct;
+@@ -1006,9 +1018,18 @@ TC_INDIRECT_SCOPE int tcf_ct_act(struct sk_buff *skb, const struct tc_action *a,
+ 	 */
+ 	nh_ofs = skb_network_offset(skb);
+ 	skb_pull_rcsum(skb, nh_ofs);
+-	err = tcf_ct_handle_fragments(net, skb, family, p->zone, &defrag);
+-	if (err)
++	err = tcf_ct_handle_fragments(net, skb, family, p->zone, &defrag,
++				      &skb_is_ours);
++	if (err) {
++		/* The skb is still ours only when the header checks rejected
++		 * it; returning TC_ACT_CONSUMED for such a packet would leak
++		 * it, since no caller frees an skb it was told it no longer
++		 * owns.
++		 */
++		if (skb_is_ours)
++			goto drop;
+ 		goto out_frag;
++	}
+ 
+ 	err = nf_ct_skb_network_trim(skb, family);
+ 	if (err)
+diff --git a/net/sched/act_gact.c b/net/sched/act_gact.c
+index 904ab3d457ef8b..13de33761e06db 100644
+--- a/net/sched/act_gact.c
++++ b/net/sched/act_gact.c
+@@ -89,6 +89,11 @@ static int tcf_gact_init(struct net *net, struct nlattr *nla,
+ 		p_parm = nla_data(tb[TCA_GACT_PROB]);
+ 		if (p_parm->ptype >= MAX_RAND)
+ 			return -EINVAL;
++		if (!tcf_action_valid(p_parm->paction)) {
++			NL_SET_ERR_MSG(extack,
++				       "invalid fallback control action");
++			return -EINVAL;
++		}
+ 		if (TC_ACT_EXT_CMP(p_parm->paction, TC_ACT_GOTO_CHAIN)) {
+ 			NL_SET_ERR_MSG(extack,
+ 				       "goto chain not allowed on fallback");
+diff --git a/net/sched/act_police.c b/net/sched/act_police.c
+index f3121c5a85e9f7..7fc57d7fe66d52 100644
+--- a/net/sched/act_police.c
++++ b/net/sched/act_police.c
+@@ -128,6 +128,12 @@ static int tcf_police_init(struct net *net, struct nlattr *nla,
+ 
+ 	if (tb[TCA_POLICE_RESULT]) {
+ 		tcfp_result = nla_get_u32(tb[TCA_POLICE_RESULT]);
++		if (!tcf_action_valid(tcfp_result)) {
++			NL_SET_ERR_MSG(extack,
++				       "invalid fallback control action");
++			err = -EINVAL;
++			goto failure;
++		}
+ 		if (TC_ACT_EXT_CMP(tcfp_result, TC_ACT_GOTO_CHAIN)) {
+ 			NL_SET_ERR_MSG(extack,
+ 				       "goto chain not allowed on fallback");
+diff --git a/net/sched/cls_api.c b/net/sched/cls_api.c
+index e259ec6ed145de..ff6af03cb855d7 100644
+--- a/net/sched/cls_api.c
++++ b/net/sched/cls_api.c
+@@ -390,6 +390,7 @@ static struct tcf_proto *tcf_proto_create(const char *kind, u32 protocol,
+ 	tp->protocol = protocol;
+ 	tp->prio = prio;
+ 	tp->chain = chain;
++	tp->usesw = !tp->ops->reoffload;
+ 	spin_lock_init(&tp->lock);
+ 	refcount_set(&tp->refcnt, 1);
+ 
+@@ -410,12 +411,55 @@ static void tcf_proto_get(struct tcf_proto *tp)
+ 	refcount_inc(&tp->refcnt);
+ }
+ 
++static void tcf_proto_count_usesw(struct tcf_proto *tp, bool add)
++{
++#ifdef CONFIG_NET_CLS_ACT
++	struct tcf_block *block = tp->chain->block;
++	bool counted = false;
++
++	if (!add) {
++		if (tp->usesw && tp->counted) {
++			if (!atomic_dec_return(&block->useswcnt))
++				static_branch_dec(&tcf_sw_enabled_key);
++			tp->counted = false;
++		}
++		return;
++	}
++
++	spin_lock(&tp->lock);
++	if (tp->usesw && !tp->counted) {
++		counted = true;
++		tp->counted = true;
++	}
++	spin_unlock(&tp->lock);
++
++	if (counted && atomic_inc_return(&block->useswcnt) == 1)
++		static_branch_inc(&tcf_sw_enabled_key);
++#endif
++}
++
+ static void tcf_chain_put(struct tcf_chain *chain);
+ 
+ static void tcf_proto_destroy(struct tcf_proto *tp, bool rtnl_held,
+ 			      bool sig_destroy, struct netlink_ext_ack *extack)
+ {
+-	tp->ops->destroy(tp, rtnl_held, extack);
++	/* A locked classifier's destroy callback (e.g. u32_destroy) uses
++	 * rtnl_dereference() and mutates shared structures (e.g. the
++	 * tc_u_common hash list) that are only safe under rtnl_lock. When an
++	 * unlocked classifier's request (e.g. flower on ingress) loses the
++	 * tcf_chain_tp_insert_unique() race and ends up dropping the last
++	 * reference on a locked classifier's proto, destroy() would run
++	 * without rtnl held. Take it here in that case.
++	 */
++	bool not_lockless = !rtnl_held &&
++		!(tp->ops->flags & TCF_PROTO_OPS_DOIT_UNLOCKED);
++
++	if (not_lockless)
++		rtnl_lock();
++	tp->ops->destroy(tp, rtnl_held || not_lockless, extack);
++	if (not_lockless)
++		rtnl_unlock();
++	tcf_proto_count_usesw(tp, false);
+ 	if (sig_destroy)
+ 		tcf_proto_signal_destroyed(tp->chain, tp);
+ 	tcf_chain_put(tp->chain);
+@@ -2357,6 +2401,7 @@ replay:
+ 		tfilter_notify(net, skb, n, tp, block, q, parent, fh,
+ 			       RTM_NEWTFILTER, false, rtnl_held, extack);
+ 		tfilter_put(tp, fh);
++		tcf_proto_count_usesw(tp, true);
+ 		/* q pointer is NULL for shared blocks */
+ 		if (q)
+ 			q->flags &= ~TCQ_F_CAN_BYPASS;
+diff --git a/net/sched/cls_bpf.c b/net/sched/cls_bpf.c
+index d5a5dffcd6f9b5..cede21257d27ca 100644
+--- a/net/sched/cls_bpf.c
++++ b/net/sched/cls_bpf.c
+@@ -509,6 +509,8 @@ static int cls_bpf_change(struct net *net, struct sk_buff *in_skb,
+ 	if (!tc_in_hw(prog->gen_flags))
+ 		prog->gen_flags |= TCA_CLS_FLAGS_NOT_IN_HW;
+ 
++	tcf_proto_update_usesw(tp, prog->gen_flags);
++
+ 	if (oldprog) {
+ 		idr_replace(&head->handle_idr, prog, handle);
+ 		list_replace_rcu(&oldprog->link, &prog->link);
+diff --git a/net/sched/cls_flower.c b/net/sched/cls_flower.c
+index b00e491e8130d7..4fc59af6696ea7 100644
+--- a/net/sched/cls_flower.c
++++ b/net/sched/cls_flower.c
+@@ -2374,6 +2374,8 @@ static int fl_change(struct net *net, struct sk_buff *in_skb,
+ 	if (!tc_in_hw(fnew->flags))
+ 		fnew->flags |= TCA_CLS_FLAGS_NOT_IN_HW;
+ 
++	tcf_proto_update_usesw(tp, fnew->flags);
++
+ 	spin_lock(&tp->lock);
+ 
+ 	/* tp was deleted concurrently. -EAGAIN will cause caller to lookup
+diff --git a/net/sched/cls_matchall.c b/net/sched/cls_matchall.c
+index c4ed11df62548c..e8353b27c8c4da 100644
+--- a/net/sched/cls_matchall.c
++++ b/net/sched/cls_matchall.c
+@@ -228,6 +228,8 @@ static int mall_change(struct net *net, struct sk_buff *in_skb,
+ 	if (!tc_in_hw(new->flags))
+ 		new->flags |= TCA_CLS_FLAGS_NOT_IN_HW;
+ 
++	tcf_proto_update_usesw(tp, new->flags);
++
+ 	*arg = head;
+ 	rcu_assign_pointer(tp->root, new);
+ 	return 0;
+diff --git a/net/sched/cls_route.c b/net/sched/cls_route.c
+index 1e20bbd687f1df..fd72ab9d19eac0 100644
+--- a/net/sched/cls_route.c
++++ b/net/sched/cls_route.c
+@@ -52,6 +52,7 @@ struct route4_filter {
+ 	struct tcf_result	res;
+ 	struct tcf_exts		exts;
+ 	u32			handle;
++	bool			dying;
+ 	struct route4_bucket	*bkt;
+ 	struct tcf_proto	*tp;
+ 	struct rcu_work		rwork;
+@@ -66,9 +67,11 @@ static inline int route4_fastmap_hash(u32 id, int iif)
+ 
+ static DEFINE_SPINLOCK(fastmap_lock);
+ static void
+-route4_reset_fastmap(struct route4_head *head)
++route4_reset_fastmap(struct route4_head *head, struct route4_filter *f)
+ {
+ 	spin_lock_bh(&fastmap_lock);
++	if (f)
++		f->dying = true;
+ 	memset(head->fastmap, 0, sizeof(head->fastmap));
+ 	spin_unlock_bh(&fastmap_lock);
+ }
+@@ -81,9 +84,11 @@ route4_set_fastmap(struct route4_head *head, u32 id, int iif,
+ 
+ 	/* fastmap updates must look atomic to aling id, iff, filter */
+ 	spin_lock_bh(&fastmap_lock);
+-	head->fastmap[h].id = id;
+-	head->fastmap[h].iif = iif;
+-	head->fastmap[h].filter = f;
++	if (f == ROUTE4_FAILURE || !f->dying) {
++		head->fastmap[h].id = id;
++		head->fastmap[h].iif = iif;
++		head->fastmap[h].filter = f;
++	}
+ 	spin_unlock_bh(&fastmap_lock);
+ }
+ 
+@@ -297,6 +302,13 @@ static void route4_destroy(struct tcf_proto *tp, bool rtnl_held,
+ 					next = rtnl_dereference(f->next);
+ 					RCU_INIT_POINTER(b->ht[h2], next);
+ 					tcf_unbind_filter(tp, &f->res);
++					/* Mark the filter dying under fastmap_lock so
++					 * any in-flight reader that still holds it
++					 * will skip the republish in route4_set_fastmap().
++					 */
++					spin_lock_bh(&fastmap_lock);
++					f->dying = true;
++					spin_unlock_bh(&fastmap_lock);
+ 					if (tcf_exts_get_net(&f->exts))
+ 						route4_queue_work(f);
+ 					else
+@@ -307,6 +319,11 @@ static void route4_destroy(struct tcf_proto *tp, bool rtnl_held,
+ 			kfree_rcu(b, rcu);
+ 		}
+ 	}
++
++	/* All filters are unlinked and marked dying, so no in-flight
++	 * reader can republish a stale entry after this reset.
++	 */
++	route4_reset_fastmap(head, NULL);
+ 	kfree_rcu(head, rcu);
+ }
+ 
+@@ -334,11 +351,11 @@ static int route4_delete(struct tcf_proto *tp, void *arg, bool *last,
+ 			/* unlink it */
+ 			RCU_INIT_POINTER(*fp, rtnl_dereference(f->next));
+ 
+-			/* Remove any fastmap lookups that might ref filter
+-			 * notice we unlink'd the filter so we can't get it
+-			 * back in the fastmap.
++			/* Clear any fastmap entries that may ref this filter and
++			 * mark it dying so in-flight readers can't republish it
++			 * after the reset.
+ 			 */
+-			route4_reset_fastmap(head);
++			route4_reset_fastmap(head, f);
+ 
+ 			/* Delete it */
+ 			tcf_unbind_filter(tp, &f->res);
+@@ -553,7 +570,7 @@ static int route4_change(struct net *net, struct sk_buff *in_skb,
+ 		}
+ 	}
+ 
+-	route4_reset_fastmap(head);
++	route4_reset_fastmap(head, fold);
+ 	*arg = f;
+ 	if (fold) {
+ 		tcf_unbind_filter(tp, &fold->res);
+diff --git a/net/sched/cls_u32.c b/net/sched/cls_u32.c
+index 1338d9b4c03a44..9829df127d054f 100644
+--- a/net/sched/cls_u32.c
++++ b/net/sched/cls_u32.c
+@@ -950,6 +950,8 @@ static int u32_change(struct net *net, struct sk_buff *in_skb,
+ 		if (!tc_in_hw(new->flags))
+ 			new->flags |= TCA_CLS_FLAGS_NOT_IN_HW;
+ 
++		tcf_proto_update_usesw(tp, new->flags);
++
+ 		u32_replace_knode(tp, tp_c, new);
+ 		tcf_unbind_filter(tp, &n->res);
+ 		tcf_exts_get_net(&n->exts);
+@@ -1163,6 +1165,8 @@ static int u32_change(struct net *net, struct sk_buff *in_skb,
+ 		if (!tc_in_hw(n->flags))
+ 			n->flags |= TCA_CLS_FLAGS_NOT_IN_HW;
+ 
++		tcf_proto_update_usesw(tp, n->flags);
++
+ 		ins = &ht->ht[TC_U32_HASH(handle)];
+ 		for (pins = rtnl_dereference(*ins); pins;
+ 		     ins = &pins->next, pins = rtnl_dereference(*ins))
+diff --git a/net/sched/sch_api.c b/net/sched/sch_api.c
+index b20dc987b907fc..2047b9c1ae3f7a 100644
+--- a/net/sched/sch_api.c
++++ b/net/sched/sch_api.c
+@@ -1066,6 +1066,9 @@ static int qdisc_graft(struct net_device *dev, struct Qdisc *parent,
+ 		unsigned int i, num_q, ingress;
+ 		struct netdev_queue *dev_queue;
+ 
++		if (new)
++			new->depth = 0;
++
+ 		ingress = 0;
+ 		num_q = dev->num_tx_queues;
+ 		if ((q && q->flags & TCQ_F_INGRESS) ||
+@@ -1163,9 +1166,15 @@ skip:
+ 			NL_SET_ERR_MSG(extack, "STAB not supported on a non root");
+ 			return -EINVAL;
+ 		}
++		if (new && parent->depth >= 7) {
++			NL_SET_ERR_MSG(extack, "Qdisc hierarchy is too deep");
++			return -E2BIG;
++		}
+ 		err = cops->graft(parent, cl, new, &old, extack);
+ 		if (err)
+ 			return err;
++		if (new)
++			new->depth = parent->depth + 1;
+ 		notify_and_destroy(net, skb, n, classid, old, new, extack);
+ 	}
+ 	return 0;
+diff --git a/net/sched/sch_cake.c b/net/sched/sch_cake.c
+index ce9ee43e9ee2bc..4331097f813ecd 100644
+--- a/net/sched/sch_cake.c
++++ b/net/sched/sch_cake.c
+@@ -1282,7 +1282,6 @@ static struct sk_buff *cake_ack_filter(struct cake_sched_data *q,
+ 
+ 			seglen = ntohs(ipv6h_check->payload_len);
+ 		} else {
+-			WARN_ON(1);  /* shouldn't happen */
+ 			continue;
+ 		}
+ 
+diff --git a/net/sctp/associola.c b/net/sctp/associola.c
+index 44f06c5f1f2560..f409b9f6b228f5 100644
+--- a/net/sctp/associola.c
++++ b/net/sctp/associola.c
+@@ -543,6 +543,9 @@ void sctp_assoc_rm_peer(struct sctp_association *asoc,
+ 	    asoc->addip_last_asconf->transport == peer)
+ 		asoc->addip_last_asconf->transport = NULL;
+ 
++	if (asoc->new_transport == peer)
++		asoc->new_transport = NULL;
++
+ 	/* If we have something on the transmitted list, we have to
+ 	 * save it off.  The best place is the active path.
+ 	 */
+@@ -573,6 +576,10 @@ void sctp_assoc_rm_peer(struct sctp_association *asoc,
+ 		if (ch->transport == peer)
+ 			ch->transport = NULL;
+ 
++	list_for_each_entry(ch, &asoc->outqueue.control_chunk_list, list)
++		if (ch->transport == peer)
++			ch->transport = NULL;
++
+ 	asoc->peer.transport_count--;
+ 
+ 	sctp_ulpevent_notify_peer_addr_change(peer, SCTP_ADDR_REMOVED, 0);
+@@ -1727,6 +1734,8 @@ void sctp_asconf_queue_teardown(struct sctp_association *asoc)
+ 	sctp_assoc_free_asconf_queue(asoc);
+ 
+ 	/* Free any cached ASCONF chunk. */
+-	if (asoc->addip_last_asconf)
++	if (asoc->addip_last_asconf) {
+ 		sctp_chunk_free(asoc->addip_last_asconf);
++		asoc->addip_last_asconf = NULL;
++	}
+ }
+diff --git a/net/sctp/outqueue.c b/net/sctp/outqueue.c
+index 0dc6b8ab996317..242282a2642521 100644
+--- a/net/sctp/outqueue.c
++++ b/net/sctp/outqueue.c
+@@ -650,6 +650,7 @@ static int __sctp_outq_flush_rtx(struct sctp_outq *q, struct sctp_packet *pkt,
+ 		if (chunk->tsn_gap_acked) {
+ 			list_move_tail(&chunk->transmitted_list,
+ 				       &transport->transmitted);
++			chunk->transport = transport;
+ 			continue;
+ 		}
+ 
+diff --git a/net/sctp/sm_make_chunk.c b/net/sctp/sm_make_chunk.c
+index 0f03560fcab440..1a614560223ef5 100644
+--- a/net/sctp/sm_make_chunk.c
++++ b/net/sctp/sm_make_chunk.c
+@@ -3354,12 +3354,11 @@ struct sctp_chunk *sctp_process_asconf(struct sctp_association *asoc,
+ 			goto done;
+ 	}
+ done:
+-	asoc->peer.addip_serial++;
+-
+ 	/* If we are sending a new ASCONF_ACK hold a reference to it in assoc
+ 	 * after freeing the reference to old asconf ack if any.
+ 	 */
+ 	if (asconf_ack) {
++		asoc->peer.addip_serial++;
+ 		sctp_chunk_hold(asconf_ack);
+ 		list_add_tail(&asconf_ack->transmitted_list,
+ 			      &asoc->asconf_ack_list);
+diff --git a/net/sctp/sm_statefuns.c b/net/sctp/sm_statefuns.c
+index ce0b5d6b4c5239..0a44a581900a0a 100644
+--- a/net/sctp/sm_statefuns.c
++++ b/net/sctp/sm_statefuns.c
+@@ -6109,8 +6109,12 @@ enum sctp_disposition sctp_sf_t4_timer_expire(
+ 					struct sctp_cmd_seq *commands)
+ {
+ 	struct sctp_chunk *chunk = asoc->addip_last_asconf;
+-	struct sctp_transport *transport = chunk->transport;
++	struct sctp_transport *transport;
++
++	if (!chunk)
++		return SCTP_DISPOSITION_CONSUME;
+ 
++	transport = chunk->transport;
+ 	SCTP_INC_STATS(net, SCTP_MIB_T4_RTO_EXPIREDS);
+ 
+ 	/* ADDIP 4.1 B1) Increment the error counters and perform path failure
+diff --git a/net/smc/af_smc.c b/net/smc/af_smc.c
+index e5e07160e57190..087102ff3c640b 100644
+--- a/net/smc/af_smc.c
++++ b/net/smc/af_smc.c
+@@ -1921,11 +1921,12 @@ static void smc_listen_out(struct smc_sock *new_smc)
+ 		atomic_dec(&lsmc->queued_smc_hs);
+ 
+ 	release_sock(newsmcsk); /* lock in smc_listen_work() */
++	lock_sock_nested(&lsmc->sk, SINGLE_DEPTH_NESTING);
+ 	if (lsmc->sk.sk_state == SMC_LISTEN) {
+-		lock_sock_nested(&lsmc->sk, SINGLE_DEPTH_NESTING);
+ 		smc_accept_enqueue(&lsmc->sk, newsmcsk);
+ 		release_sock(&lsmc->sk);
+ 	} else { /* no longer listening */
++		release_sock(&lsmc->sk);
+ 		smc_close_non_accepted(newsmcsk);
+ 	}
+ 
+diff --git a/net/smc/smc_llc.c b/net/smc/smc_llc.c
+index 018ce8133b0265..149d63cff667ee 100644
+--- a/net/smc/smc_llc.c
++++ b/net/smc/smc_llc.c
+@@ -1918,7 +1918,8 @@ static void smc_llc_event_handler(struct smc_llc_qentry *qentry)
+ 		return;
+ 	case SMC_LLC_CONFIRM_LINK:
+ 	case SMC_LLC_ADD_LINK_CONT:
+-		if (lgr->llc_flow_lcl.type != SMC_LLC_FLOW_NONE) {
++		if (lgr->llc_flow_lcl.type != SMC_LLC_FLOW_NONE &&
++		    !lgr->llc_flow_lcl.qentry) {
+ 			/* a flow is waiting for this message */
+ 			smc_llc_flow_qentry_set(&lgr->llc_flow_lcl, qentry);
+ 			wake_up(&lgr->llc_msg_waiter);
+diff --git a/net/smc/smc_rx.c b/net/smc/smc_rx.c
+index a48f8c93f4b63f..05229a0a07e426 100644
+--- a/net/smc/smc_rx.c
++++ b/net/smc/smc_rx.c
+@@ -150,7 +150,12 @@ static const struct pipe_buf_operations smc_pipe_ops = {
+ static void smc_rx_spd_release(struct splice_pipe_desc *spd,
+ 			       unsigned int i)
+ {
++	struct smc_spd_priv *priv = (struct smc_spd_priv *)spd->partial[i].private;
++	struct sock *sk = &priv->smc->sk;
++
++	kfree(priv);
+ 	put_page(spd->pages[i]);
++	sock_put(sk);
+ }
+ 
+ static int smc_rx_splice(struct pipe_inode_info *pipe, char *src, size_t len,
+@@ -209,6 +214,10 @@ static int smc_rx_splice(struct pipe_inode_info *pipe, char *src, size_t len,
+ 			offset = 0;
+ 		}
+ 	}
++	for (i = 0; i < nr_pages; i++) {
++		get_page(pages[i]);
++		sock_hold(&smc->sk);
++	}
+ 	spd.nr_pages_max = nr_pages;
+ 	spd.nr_pages = nr_pages;
+ 	spd.pages = pages;
+@@ -217,16 +226,8 @@ static int smc_rx_splice(struct pipe_inode_info *pipe, char *src, size_t len,
+ 	spd.spd_release = smc_rx_spd_release;
+ 
+ 	bytes = splice_to_pipe(pipe, &spd);
+-	if (bytes > 0) {
+-		sock_hold(&smc->sk);
+-		if (!lgr->is_smcd && smc->conn.rmb_desc->is_vm) {
+-			for (i = 0; i < PAGE_ALIGN(bytes + offset) / PAGE_SIZE; i++)
+-				get_page(pages[i]);
+-		} else {
+-			get_page(smc->conn.rmb_desc->pages);
+-		}
++	if (bytes > 0)
+ 		atomic_add(bytes, &smc->conn.splice_pending);
+-	}
+ 	kfree(priv);
+ 	kfree(partial);
+ 	kfree(pages);
+diff --git a/net/tipc/node.c b/net/tipc/node.c
+index 97b5ce4c678f8e..f4a25ae7dc1b39 100644
+--- a/net/tipc/node.c
++++ b/net/tipc/node.c
+@@ -1063,18 +1063,23 @@ static void __tipc_node_link_down(struct tipc_node *n, int *bearer_id,
+ 
+ static void tipc_node_link_down(struct tipc_node *n, int bearer_id, bool delete)
+ {
+-	struct tipc_link_entry *le = &n->links[bearer_id];
+ 	struct tipc_media_addr *maddr = NULL;
+-	struct tipc_link *l = le->link;
+ 	int old_bearer_id = bearer_id;
++	struct tipc_link_entry *le;
+ 	struct sk_buff_head xmitq;
+-
+-	if (!l)
+-		return;
++	struct tipc_link *l;
+ 
+ 	__skb_queue_head_init(&xmitq);
+ 
++	/* Synchronize the link lookup with bearer teardown. */
+ 	tipc_node_write_lock(n);
++	le = &n->links[bearer_id];
++	l = le->link;
++	if (!l) {
++		tipc_node_write_unlock_fast(n);
++		return;
++	}
++
+ 	if (!tipc_link_is_establishing(l)) {
+ 		__tipc_node_link_down(n, &bearer_id, &xmitq, &maddr);
+ 	} else {
+diff --git a/net/tls/tls_sw.c b/net/tls/tls_sw.c
+index 39021fab3c5965..ac168ccd1fcb3a 100644
+--- a/net/tls/tls_sw.c
++++ b/net/tls/tls_sw.c
+@@ -458,7 +458,7 @@ int tls_tx_records(struct sock *sk, int flags)
+ 	}
+ 
+ tx_err:
+-	if (rc < 0 && rc != -EAGAIN)
++	if (rc < 0 && rc != -EAGAIN && rc != -EINTR && rc != -ERESTARTSYS)
+ 		tls_err_abort(sk, rc);
+ 
+ 	return rc;
+@@ -1116,6 +1116,14 @@ static int tls_sw_sendmsg_locked(struct sock *sk, struct msghdr *msg,
+ 		if (!sk_stream_memory_free(sk))
+ 			goto wait_for_sndbuf;
+ 
++		/* open record may be full if we couldn't push it in the last sendmsg call */
++		if (sk_msg_full(msg_pl)) {
++			full_record = true;
++			sk_msg_trim(sk, msg_en,
++				    msg_pl->sg.size + prot->overhead_size);
++			goto copied;
++		}
++
+ alloc_encrypted:
+ 		ret = tls_alloc_encrypted_msg(sk, required_size);
+ 		if (ret) {
+@@ -1216,6 +1224,12 @@ fallback_to_reg_send:
+ 						       msg_pl, try_to_copy);
+ 			if (ret < 0)
+ 				goto trim_sgl;
++
++			if (sk_msg_full(msg_pl)) {
++				full_record = true;
++				sk_msg_trim(sk, msg_en,
++					    msg_pl->sg.size + prot->overhead_size);
++			}
+ 		}
+ 
+ 		/* Open records defined only if successfully copied, otherwise
+diff --git a/net/vmw_vsock/virtio_transport.c b/net/vmw_vsock/virtio_transport.c
+index e1d7ce8dac082e..70db737c52daf9 100644
+--- a/net/vmw_vsock/virtio_transport.c
++++ b/net/vmw_vsock/virtio_transport.c
+@@ -257,12 +257,13 @@ static void virtio_transport_tx_work(struct work_struct *work)
+ 	struct virtqueue *vq;
+ 	bool added = false;
+ 
+-	vq = vsock->vqs[VSOCK_VQ_TX];
+ 	mutex_lock(&vsock->tx_lock);
+ 
+ 	if (!vsock->tx_run)
+ 		goto out;
+ 
++	vq = vsock->vqs[VSOCK_VQ_TX];
++
+ 	do {
+ 		struct sk_buff *skb;
+ 		unsigned int len;
+@@ -362,13 +363,13 @@ static void virtio_transport_event_work(struct work_struct *work)
+ 		container_of(work, struct virtio_vsock, event_work);
+ 	struct virtqueue *vq;
+ 
+-	vq = vsock->vqs[VSOCK_VQ_EVENT];
+-
+ 	mutex_lock(&vsock->event_lock);
+ 
+ 	if (!vsock->event_run)
+ 		goto out;
+ 
++	vq = vsock->vqs[VSOCK_VQ_EVENT];
++
+ 	do {
+ 		struct virtio_vsock_event *event;
+ 		unsigned int len;
+@@ -487,12 +488,12 @@ static void virtio_transport_rx_work(struct work_struct *work)
+ 		container_of(work, struct virtio_vsock, rx_work);
+ 	struct virtqueue *vq;
+ 
+-	vq = vsock->vqs[VSOCK_VQ_RX];
+-
+ 	mutex_lock(&vsock->rx_lock);
+ 
+ 	if (!vsock->rx_run)
+-		goto out;
++		goto out_nofill;
++
++	vq = vsock->vqs[VSOCK_VQ_RX];
+ 
+ 	do {
+ 		virtqueue_disable_cb(vq);
+@@ -538,6 +539,7 @@ static void virtio_transport_rx_work(struct work_struct *work)
+ out:
+ 	if (vsock->rx_buf_nr < vsock->rx_buf_max_nr / 2)
+ 		virtio_vsock_rx_fill(vsock);
++out_nofill:
+ 	mutex_unlock(&vsock->rx_lock);
+ }
+ 
+diff --git a/scripts/remove-stale-files b/scripts/remove-stale-files
+index 8b1a636f854342..38eb84eb605b64 100755
+--- a/scripts/remove-stale-files
++++ b/scripts/remove-stale-files
+@@ -39,3 +39,5 @@ rm -rf include/ksym
+ find . -name '*.usyms' | xargs rm -f
+ 
+ rm -f binkernel.spec
++
++rm -f lib/test_fortify.log
+diff --git a/security/integrity/ima/ima_appraise.c b/security/integrity/ima/ima_appraise.c
+index 0acf7d6baa37fb..919133dc8ef298 100644
+--- a/security/integrity/ima/ima_appraise.c
++++ b/security/integrity/ima/ima_appraise.c
+@@ -304,8 +304,13 @@ static int xattr_verify(enum ima_hooks func, struct integrity_iint_cache *iint,
+ 		} else {
+ 			set_bit(IMA_DIGSIG, &iint->atomic_flags);
+ 		}
+-		if (xattr_len - sizeof(xattr_value->type) - hash_start >=
+-				iint->ima_hash->length)
++		/*
++		 * Use addition, not subtraction: sizeof() forces unsigned
++		 * math and a short xattr_len would wrap around, bypassing
++		 * this bounds check.
++		 */
++		if (xattr_len >= (int)sizeof(xattr_value->type) + hash_start +
++				(int)iint->ima_hash->length)
+ 			/*
+ 			 * xattr length may be longer. md5 hash in previous
+ 			 * version occupied 20 bytes in xattr, instead of 16
+diff --git a/sound/usb/endpoint.c b/sound/usb/endpoint.c
+index 59e3584b24a091..c393a9125b9b34 100644
+--- a/sound/usb/endpoint.c
++++ b/sound/usb/endpoint.c
+@@ -388,13 +388,15 @@ static int prepare_inbound_urb(struct snd_usb_endpoint *ep,
+ 	case SND_USB_ENDPOINT_TYPE_DATA:
+ 		offs = 0;
+ 		for (i = 0; i < urb_ctx->packets; i++) {
++			if (offs + ep->curpacksize > urb_ctx->buffer_size)
++				break;
+ 			urb->iso_frame_desc[i].offset = offs;
+ 			urb->iso_frame_desc[i].length = ep->curpacksize;
+ 			offs += ep->curpacksize;
+ 		}
+ 
+ 		urb->transfer_buffer_length = offs;
+-		urb->number_of_packets = urb_ctx->packets;
++		urb->number_of_packets = i;
+ 		break;
+ 
+ 	case SND_USB_ENDPOINT_TYPE_SYNC:
+@@ -1260,10 +1262,10 @@ static int data_ep_set_params(struct snd_usb_endpoint *ep)
+ 		u->index = i;
+ 		u->ep = ep;
+ 		u->packets = urb_packs;
+-		u->buffer_size = maxsize * u->packets;
+ 
+ 		if (fmt->fmt_type == UAC_FORMAT_TYPE_II)
+ 			u->packets++; /* for transfer delimiter */
++		u->buffer_size = maxsize * u->packets;
+ 		u->urb = usb_alloc_urb(u->packets, GFP_KERNEL);
+ 		if (!u->urb)
+ 			goto out_of_memory;
+diff --git a/sound/usb/midi2.c b/sound/usb/midi2.c
+index f70e5ec66edb14..f8653958563ba5 100644
+--- a/sound/usb/midi2.c
++++ b/sound/usb/midi2.c
+@@ -695,6 +695,14 @@ static int parse_midi_2_0_endpoints(struct snd_usb_midi2_interface *umidi)
+ 	return 0;
+ }
+ 
++static void free_ump_private_data(struct snd_ump_endpoint *ump)
++{
++	struct snd_usb_midi2_ump *rmidi = ump->private_data;
++
++	if (rmidi)
++		rmidi->ump = NULL;
++}
++
+ static void free_all_midi2_umps(struct snd_usb_midi2_interface *umidi)
+ {
+ 	struct snd_usb_midi2_ump *rmidi;
+@@ -745,6 +753,7 @@ static int create_midi2_ump(struct snd_usb_midi2_interface *umidi,
+ 
+ 	ump->private_data = rmidi;
+ 	ump->ops = &snd_usb_midi_v2_ump_ops;
++	ump->private_free = free_ump_private_data;
+ 
+ 	rmidi->eps[STR_IN] = ep_in;
+ 	rmidi->eps[STR_OUT] = ep_out;
+diff --git a/sound/usb/usx2y/usX2Yhwdep.c b/sound/usb/usx2y/usX2Yhwdep.c
+index 4937ede0b5d70b..34421b85838af3 100644
+--- a/sound/usb/usx2y/usX2Yhwdep.c
++++ b/sound/usb/usx2y/usX2Yhwdep.c
+@@ -29,6 +29,8 @@ static vm_fault_t snd_us428ctls_vm_fault(struct vm_fault *vmf)
+ 		   vmf->pgoff);
+ 
+ 	offset = vmf->pgoff << PAGE_SHIFT;
++	if (offset >= US428_SHAREDMEM_PAGES)
++		return VM_FAULT_SIGBUS;
+ 	vaddr = (char *)((struct usx2ydev *)vmf->vma->vm_private_data)->us428ctls_sharedmem + offset;
+ 	page = virt_to_page(vaddr);
+ 	get_page(page);
+diff --git a/sound/usb/usx2y/usx2yhwdeppcm.c b/sound/usb/usx2y/usx2yhwdeppcm.c
+index 36f2e31168fb0f..54290caa9fadc9 100644
+--- a/sound/usb/usx2y/usx2yhwdeppcm.c
++++ b/sound/usb/usx2y/usx2yhwdeppcm.c
+@@ -676,6 +676,8 @@ static vm_fault_t snd_usx2y_hwdep_pcm_vm_fault(struct vm_fault *vmf)
+ 	void *vaddr;
+ 
+ 	offset = vmf->pgoff << PAGE_SHIFT;
++	if (offset >= USX2Y_HWDEP_PCM_PAGES)
++		return VM_FAULT_SIGBUS;
+ 	vaddr = (char *)((struct usx2ydev *)vmf->vma->vm_private_data)->hwdep_pcm_shm + offset;
+ 	vmf->page = virt_to_page(vaddr);
+ 	get_page(vmf->page);
+diff --git a/tools/testing/selftests/bpf/prog_tests/sockmap_listen.c b/tools/testing/selftests/bpf/prog_tests/sockmap_listen.c
+index a6d8aa8c2a9ac9..6386d6069b9db2 100644
+--- a/tools/testing/selftests/bpf/prog_tests/sockmap_listen.c
++++ b/tools/testing/selftests/bpf/prog_tests/sockmap_listen.c
+@@ -51,8 +51,8 @@ static void test_insert_opened(struct test_sockmap_listen *skel __always_unused,
+ 			       int family, int sotype, int mapfd)
+ {
+ 	u32 key = 0;
+-	u64 value;
+ 	int err, s;
++	u64 value;
+ 
+ 	s = xsocket(family, sotype, 0);
+ 	if (s == -1)
+@@ -61,11 +61,8 @@ static void test_insert_opened(struct test_sockmap_listen *skel __always_unused,
+ 	errno = 0;
+ 	value = s;
+ 	err = bpf_map_update_elem(mapfd, &key, &value, BPF_NOEXIST);
+-	if (sotype == SOCK_STREAM) {
+-		if (!err || errno != EOPNOTSUPP)
+-			FAIL_ERRNO("map_update: expected EOPNOTSUPP");
+-	} else if (err)
+-		FAIL_ERRNO("map_update: expected success");
++	ASSERT_ERR(err, "map_update");
++	ASSERT_EQ(errno, EOPNOTSUPP, "errno");
+ 	xclose(s);
+ }
+ 
+@@ -75,8 +72,8 @@ static void test_insert_bound(struct test_sockmap_listen *skel __always_unused,
+ 	struct sockaddr_storage addr;
+ 	socklen_t len;
+ 	u32 key = 0;
+-	u64 value;
+ 	int err, s;
++	u64 value;
+ 
+ 	init_addr_loopback(family, &addr, &len);
+ 
+@@ -91,8 +88,12 @@ static void test_insert_bound(struct test_sockmap_listen *skel __always_unused,
+ 	errno = 0;
+ 	value = s;
+ 	err = bpf_map_update_elem(mapfd, &key, &value, BPF_NOEXIST);
+-	if (!err || errno != EOPNOTSUPP)
+-		FAIL_ERRNO("map_update: expected EOPNOTSUPP");
++	if (sotype == SOCK_STREAM) {
++		ASSERT_ERR(err, "map_update");
++		ASSERT_EQ(errno, EOPNOTSUPP, "errno");
++	} else {
++		ASSERT_OK(err, "map_update");
++	}
+ close:
+ 	xclose(s);
+ }
+@@ -1261,7 +1262,7 @@ static void test_ops(struct test_sockmap_listen *skel, struct bpf_map *map,
+ 		/* insert */
+ 		TEST(test_insert_invalid),
+ 		TEST(test_insert_opened),
+-		TEST(test_insert_bound, SOCK_STREAM),
++		TEST(test_insert_bound),
+ 		TEST(test_insert),
+ 		/* delete */
+ 		TEST(test_delete_after_insert),
+diff --git a/tools/testing/selftests/bpf/test_maps.c b/tools/testing/selftests/bpf/test_maps.c
+index e0dd101c9f2bd4..f2a27143edc341 100644
+--- a/tools/testing/selftests/bpf/test_maps.c
++++ b/tools/testing/selftests/bpf/test_maps.c
+@@ -752,16 +752,15 @@ static void test_sockmap(unsigned int tasks, void *data)
+ 		goto out_sockmap;
+ 	}
+ 
+-	/* Test update with unsupported UDP socket */
++	/* Test update with unsupported unbound UDP socket */
+ 	udp = socket(AF_INET, SOCK_DGRAM, 0);
+-	i = 0;
+-	err = bpf_map_update_elem(fd, &i, &udp, BPF_ANY);
+-	if (err) {
+-		printf("Failed socket update SOCK_DGRAM '%i:%i'\n",
+-		       i, udp);
++	CHECK(udp < 0, "socket(AF_INET, SOCK_DGRAM)", "errno:%d\n", errno);
++	err = bpf_map_update_elem(fd, &(int){0}, &udp, BPF_ANY);
++	close(udp);
++	if (!err) {
++		printf("Unexpectedly succeeded unbound UDP update '0:%i'\n", udp);
+ 		goto out_sockmap;
+ 	}
+-	close(udp);
+ 
+ 	/* Test update without programs */
+ 	for (i = 0; i < 6; i++) {
+diff --git a/tools/testing/selftests/ftrace/test.d/dynevent/add_remove_eprobe.tc b/tools/testing/selftests/ftrace/test.d/dynevent/add_remove_eprobe.tc
+index c300eb0202620c..e2322693d0c320 100644
+--- a/tools/testing/selftests/ftrace/test.d/dynevent/add_remove_eprobe.tc
++++ b/tools/testing/selftests/ftrace/test.d/dynevent/add_remove_eprobe.tc
+@@ -1,16 +1,16 @@
+ #!/bin/sh
+ # SPDX-License-Identifier: GPL-2.0
+ # description: Generic dynamic event - add/remove eprobe events
+-# requires: dynamic_events events/syscalls/sys_enter_openat "<attached-group>.<attached-event> [<args>]":README
++# requires: dynamic_events events/syscalls/sys_enter_chdir "<attached-group>.<attached-event> [<args>]":README
+ 
+ echo 0 > events/enable
+ 
+ clear_dynamic_events
+ 
+ SYSTEM="syscalls"
+-EVENT="sys_enter_openat"
++EVENT="sys_enter_chdir"
+ FIELD="filename"
+-EPROBE="eprobe_open"
++EPROBE="eprobe_chdir"
+ OPTIONS="file=+0(\$filename):ustring"
+ echo "e:$EPROBE $SYSTEM/$EVENT $OPTIONS" >> dynamic_events
+ 
+@@ -18,20 +18,14 @@ grep -q "$EPROBE" dynamic_events
+ test -d events/eprobes/$EPROBE
+ 
+ echo 1 > events/eprobes/$EPROBE/enable
+-ls
++cd /sys/kernel/tracing
+ echo 0 > events/eprobes/$EPROBE/enable
+ 
+-content=`grep '^ *ls-' trace | grep 'file='`
+-nocontent=`grep '^ *ls-' trace | grep 'file=' | grep -v -e '"/' -e '"."' -e '(fault)' ` || true
+-
++content=`grep -e 'file="/sys/kernel/tracing"\|(fault)' trace`
+ if [ -z "$content" ]; then
+ 	exit_fail
+ fi
+ 
+-if [ ! -z "$nocontent" ]; then
+-	exit_fail
+-fi
+-
+ echo "-:$EPROBE" >> dynamic_events
+ 
+ ! grep -q "$EPROBE" dynamic_events

--- a/patch/kernel/archive/odroidxu4-6.6/patch-6.6.152-153.patch
+++ b/patch/kernel/archive/odroidxu4-6.6/patch-6.6.152-153.patch
@@ -1,0 +1,7256 @@
+diff --git a/Makefile b/Makefile
+index 13d82f5eefd264..0633c724af10c2 100644
+--- a/Makefile
++++ b/Makefile
+@@ -1,7 +1,7 @@
+ # SPDX-License-Identifier: GPL-2.0
+ VERSION = 6
+ PATCHLEVEL = 6
+-SUBLEVEL = 152
++SUBLEVEL = 153
+ EXTRAVERSION =
+ NAME = Pinguïn Aangedreven
+ 
+diff --git a/arch/arm/Kconfig b/arch/arm/Kconfig
+index be3b0f83eee577..f254900f0ddd46 100644
+--- a/arch/arm/Kconfig
++++ b/arch/arm/Kconfig
+@@ -8,6 +8,7 @@ config ARM
+ 	select ARCH_HAS_CPU_FINALIZE_INIT if MMU
+ 	select ARCH_HAS_CURRENT_STACK_POINTER
+ 	select ARCH_HAS_DEBUG_VIRTUAL if MMU
++	select ARCH_HAS_DMA_ALLOC if MMU
+ 	select ARCH_HAS_DMA_WRITE_COMBINE if !ARM_DMA_MEM_BUFFERABLE
+ 	select ARCH_HAS_ELF_RANDOMIZE
+ 	select ARCH_HAS_FORTIFY_SOURCE
+diff --git a/arch/arm64/boot/dts/nvidia/tegra194.dtsi b/arch/arm64/boot/dts/nvidia/tegra194.dtsi
+index c3695077478514..45d0606bd5444d 100644
+--- a/arch/arm64/boot/dts/nvidia/tegra194.dtsi
++++ b/arch/arm64/boot/dts/nvidia/tegra194.dtsi
+@@ -3161,6 +3161,8 @@
+ 			     <GIC_PPI 11
+ 				(GIC_CPU_MASK_SIMPLE(4) | IRQ_TYPE_LEVEL_LOW)>,
+ 			     <GIC_PPI 10
++				(GIC_CPU_MASK_SIMPLE(4) | IRQ_TYPE_LEVEL_LOW)>,
++			     <GIC_PPI 15
+ 				(GIC_CPU_MASK_SIMPLE(4) | IRQ_TYPE_LEVEL_LOW)>;
+ 		interrupt-parent = <&gic>;
+ 		always-on;
+diff --git a/arch/m68k/Kconfig b/arch/m68k/Kconfig
+index 3e318bf9504c5b..50ada24dfbbadf 100644
+--- a/arch/m68k/Kconfig
++++ b/arch/m68k/Kconfig
+@@ -6,15 +6,16 @@ config M68K
+ 	select ARCH_HAS_BINFMT_FLAT
+ 	select ARCH_HAS_CPU_FINALIZE_INIT if MMU
+ 	select ARCH_HAS_CURRENT_STACK_POINTER
+-	select ARCH_HAS_DMA_PREP_COHERENT if HAS_DMA && MMU && !COLDFIRE
+-	select ARCH_HAS_SYNC_DMA_FOR_DEVICE if HAS_DMA
++	select ARCH_HAS_DMA_ALLOC if M68K_NONCOHERENT_DMA && COLDFIRE
++	select ARCH_HAS_DMA_PREP_COHERENT if M68K_NONCOHERENT_DMA && !COLDFIRE
++	select ARCH_HAS_SYNC_DMA_FOR_DEVICE if M68K_NONCOHERENT_DMA
+ 	select ARCH_HAVE_NMI_SAFE_CMPXCHG if RMW_INSNS
+ 	select ARCH_MIGHT_HAVE_PC_PARPORT if ISA
+ 	select ARCH_NO_PREEMPT if !COLDFIRE
+ 	select ARCH_USE_MEMTEST if MMU_MOTOROLA
+ 	select ARCH_WANT_IPC_PARSE_VERSION
+ 	select BINFMT_FLAT_ARGVP_ENVP_ON_STACK
+-	select DMA_DIRECT_REMAP if HAS_DMA && MMU && !COLDFIRE
++	select DMA_DIRECT_REMAP if M68K_NONCOHERENT_DMA && !COLDFIRE
+ 	select GENERIC_ATOMIC64
+ 	select GENERIC_CPU_DEVICES
+ 	select GENERIC_IOMAP
+diff --git a/arch/m68k/Kconfig.cpu b/arch/m68k/Kconfig.cpu
+index b826e9c677b2ae..3bae9f61f198fb 100644
+--- a/arch/m68k/Kconfig.cpu
++++ b/arch/m68k/Kconfig.cpu
+@@ -535,3 +535,19 @@ config CACHE_COPYBACK
+ 	  The ColdFire CPU cache is set into Copy-back mode.
+ endchoice
+ endif # HAVE_CACHE_CB
++
++config NR_CPUS
++	int
++	default "1"
++
++# Coldfire cores that do not have a data cache configured can do coherent DMA.
++config COLDFIRE_COHERENT_DMA
++	bool
++	default y
++	depends on COLDFIRE
++	depends on !HAVE_CACHE_CB && !CACHE_D && !CACHE_BOTH
++
++config M68K_NONCOHERENT_DMA
++	bool
++	default y
++	depends on HAS_DMA && !COLDFIRE_COHERENT_DMA
+diff --git a/arch/m68k/kernel/Makefile b/arch/m68k/kernel/Makefile
+index af015447dfb4c1..01fb69a5095f43 100644
+--- a/arch/m68k/kernel/Makefile
++++ b/arch/m68k/kernel/Makefile
+@@ -23,7 +23,7 @@ obj-$(CONFIG_MMU_MOTOROLA) += ints.o vectors.o
+ obj-$(CONFIG_MMU_SUN3) += ints.o vectors.o
+ obj-$(CONFIG_PCI) += pcibios.o
+ 
+-obj-$(CONFIG_HAS_DMA)	+= dma.o
++obj-$(CONFIG_M68K_NONCOHERENT_DMA) += dma.o
+ 
+ obj-$(CONFIG_KEXEC)		+= machine_kexec.o relocate_kernel.o
+ obj-$(CONFIG_BOOTINFO_PROC)	+= bootinfo_proc.o
+diff --git a/arch/m68k/kernel/dma.c b/arch/m68k/kernel/dma.c
+index 2e192a5df949bb..f83870cfa79b37 100644
+--- a/arch/m68k/kernel/dma.c
++++ b/arch/m68k/kernel/dma.c
+@@ -17,7 +17,7 @@
+ 
+ #include <asm/cacheflush.h>
+ 
+-#if defined(CONFIG_MMU) && !defined(CONFIG_COLDFIRE)
++#ifndef CONFIG_COLDFIRE
+ void arch_dma_prep_coherent(struct page *page, size_t size)
+ {
+ 	cache_push(page_to_phys(page), size);
+diff --git a/arch/openrisc/include/asm/processor.h b/arch/openrisc/include/asm/processor.h
+index 3b736e74e6eddc..ad268dee0b5843 100644
+--- a/arch/openrisc/include/asm/processor.h
++++ b/arch/openrisc/include/asm/processor.h
+@@ -26,6 +26,8 @@
+ 		   | SPR_SR_DCE | SPR_SR_SM)
+ #define USER_SR   (SPR_SR_DME | SPR_SR_IME | SPR_SR_ICE \
+ 		   | SPR_SR_DCE | SPR_SR_IEE | SPR_SR_TEE)
++/* SR bits user space may change via sigreturn, the rest stay kernel owned */
++#define SPR_SR_USER_MASK  (SPR_SR_F | SPR_SR_CY | SPR_SR_OV)
+ 
+ /*
+  * User space process size. This is hardcoded into a few places,
+diff --git a/arch/openrisc/kernel/dma.c b/arch/openrisc/kernel/dma.c
+index b3edbb33b621d0..0b4c20cc76cb7b 100644
+--- a/arch/openrisc/kernel/dma.c
++++ b/arch/openrisc/kernel/dma.c
+@@ -75,7 +75,7 @@ void *arch_dma_set_uncached(void *cpu_addr, size_t size)
+ 	 * them and setting the cache-inhibit bit.
+ 	 */
+ 	mmap_write_lock(&init_mm);
+-	error = walk_page_range_novma(&init_mm, va, va + size,
++	error = walk_kernel_page_table_range(va, va + size,
+ 			&set_nocache_walk_ops, NULL, NULL);
+ 	mmap_write_unlock(&init_mm);
+ 
+@@ -90,7 +90,7 @@ void arch_dma_clear_uncached(void *cpu_addr, size_t size)
+ 
+ 	mmap_write_lock(&init_mm);
+ 	/* walk_page_range shouldn't be able to fail here */
+-	WARN_ON(walk_page_range_novma(&init_mm, va, va + size,
++	WARN_ON(walk_kernel_page_table_range(va, va + size,
+ 			&clear_nocache_walk_ops, NULL, NULL));
+ 	mmap_write_unlock(&init_mm);
+ }
+diff --git a/arch/openrisc/kernel/signal.c b/arch/openrisc/kernel/signal.c
+index e2f21a5d8ad9a9..7333d3e2343de5 100644
+--- a/arch/openrisc/kernel/signal.c
++++ b/arch/openrisc/kernel/signal.c
+@@ -42,6 +42,7 @@ asmlinkage int do_work_pending(struct pt_regs *regs, unsigned int thread_flags,
+ static int restore_sigcontext(struct pt_regs *regs,
+ 			      struct sigcontext __user *sc)
+ {
++	unsigned long old_sr = regs->sr;
+ 	int err = 0;
+ 
+ 	/* Always make any pending restarted system calls return -EINTR */
+@@ -57,8 +58,8 @@ static int restore_sigcontext(struct pt_regs *regs,
+ 	err |= __copy_from_user(&regs->sr, &sc->regs.sr, sizeof(unsigned long));
+ 	err |= __copy_from_user(&regs->fpcsr, &sc->fpcsr, sizeof(unsigned long));
+ 
+-	/* make sure the SM-bit is cleared so user-mode cannot fool us */
+-	regs->sr &= ~SPR_SR_SM;
++	/* keep the privileged SR bits kernel owned, restore only user flags */
++	regs->sr = (old_sr & ~SPR_SR_USER_MASK) | (regs->sr & SPR_SR_USER_MASK);
+ 
+ 	regs->orig_gpr11 = -1;	/* Avoid syscall restart checks */
+ 
+diff --git a/arch/parisc/Kconfig b/arch/parisc/Kconfig
+index a077e6bf9475f5..536d76f9f7e289 100644
+--- a/arch/parisc/Kconfig
++++ b/arch/parisc/Kconfig
+@@ -8,6 +8,7 @@ config PARISC
+ 	select HAVE_FUNCTION_GRAPH_TRACER
+ 	select HAVE_SYSCALL_TRACEPOINTS
+ 	select ARCH_WANT_FRAME_POINTERS
++	select ARCH_HAS_DMA_ALLOC if PA11
+ 	select ARCH_HAS_ELF_RANDOMIZE
+ 	select ARCH_HAS_STRICT_KERNEL_RWX
+ 	select ARCH_HAS_STRICT_MODULE_RWX
+diff --git a/arch/powerpc/platforms/pseries/lparcfg.c b/arch/powerpc/platforms/pseries/lparcfg.c
+index 11d5208817b9d4..d266cf0203e2b1 100644
+--- a/arch/powerpc/platforms/pseries/lparcfg.c
++++ b/arch/powerpc/platforms/pseries/lparcfg.c
+@@ -673,7 +673,7 @@ static ssize_t lparcfg_write(struct file *file, const char __user * buf,
+ 	if (!firmware_has_feature(FW_FEATURE_SPLPAR))
+ 		return -EINVAL;
+ 
+-	if (count > sizeof(kbuf))
++	if (count == 0 || count > sizeof(kbuf))
+ 		return -EINVAL;
+ 
+ 	if (copy_from_user(kbuf, buf, count))
+diff --git a/arch/powerpc/platforms/pseries/pci.c b/arch/powerpc/platforms/pseries/pci.c
+index 1772ae3d193d03..d28e89c94be516 100644
+--- a/arch/powerpc/platforms/pseries/pci.c
++++ b/arch/powerpc/platforms/pseries/pci.c
+@@ -159,7 +159,7 @@ static int pseries_pci_sriov_enable(struct pci_dev *pdev, u16 num_vfs)
+ 
+ 	/* First integer stores max config */
+ 	max_config_vfs = of_read_number(&max_vfs[0], 1);
+-	if (max_config_vfs < num_vfs && num_vfs > MAX_VFS_FOR_MAP_PE) {
++	if (max_config_vfs < num_vfs || num_vfs > MAX_VFS_FOR_MAP_PE) {
+ 		dev_err(&pdev->dev,
+ 			"Num VFs %x > %x Configurable VFs\n",
+ 			num_vfs, (num_vfs > MAX_VFS_FOR_MAP_PE) ?
+diff --git a/arch/riscv/include/asm/pgtable-32.h b/arch/riscv/include/asm/pgtable-32.h
+index 59ba1fbaf78493..00f3369570a836 100644
+--- a/arch/riscv/include/asm/pgtable-32.h
++++ b/arch/riscv/include/asm/pgtable-32.h
+@@ -33,4 +33,7 @@
+ 					  _PAGE_WRITE | _PAGE_EXEC |	\
+ 					  _PAGE_USER | _PAGE_GLOBAL))
+ 
++static const __maybe_unused int pgtable_l4_enabled;
++static const __maybe_unused int pgtable_l5_enabled;
++
+ #endif /* _ASM_RISCV_PGTABLE_32_H */
+diff --git a/arch/riscv/include/asm/pgtable.h b/arch/riscv/include/asm/pgtable.h
+index 987cfe87e78252..13c331c9cbca4b 100644
+--- a/arch/riscv/include/asm/pgtable.h
++++ b/arch/riscv/include/asm/pgtable.h
+@@ -905,7 +905,6 @@ extern uintptr_t _dtb_early_pa;
+ #define dtb_early_pa	_dtb_early_pa
+ #endif /* CONFIG_XIP_KERNEL */
+ extern u64 satp_mode;
+-extern bool pgtable_l4_enabled;
+ 
+ void paging_init(void);
+ void misc_mem_init(void);
+diff --git a/arch/riscv/mm/init.c b/arch/riscv/mm/init.c
+index bdf8ac6c7e309d..70d06dfa2a8687 100644
+--- a/arch/riscv/mm/init.c
++++ b/arch/riscv/mm/init.c
+@@ -50,10 +50,12 @@ u64 satp_mode __ro_after_init = SATP_MODE_32;
+ #endif
+ EXPORT_SYMBOL(satp_mode);
+ 
++#ifdef CONFIG_64BIT
+ bool pgtable_l4_enabled = IS_ENABLED(CONFIG_64BIT) && !IS_ENABLED(CONFIG_XIP_KERNEL);
+ bool pgtable_l5_enabled = IS_ENABLED(CONFIG_64BIT) && !IS_ENABLED(CONFIG_XIP_KERNEL);
+ EXPORT_SYMBOL(pgtable_l4_enabled);
+ EXPORT_SYMBOL(pgtable_l5_enabled);
++#endif
+ 
+ phys_addr_t phys_ram_base __ro_after_init;
+ EXPORT_SYMBOL(phys_ram_base);
+diff --git a/arch/riscv/mm/pageattr.c b/arch/riscv/mm/pageattr.c
+index 271d01a5ba4da1..a35edf662d7eab 100644
+--- a/arch/riscv/mm/pageattr.c
++++ b/arch/riscv/mm/pageattr.c
+@@ -299,7 +299,7 @@ static int __set_memory(unsigned long addr, int numpages, pgprot_t set_mask,
+ 			if (ret)
+ 				goto unlock;
+ 
+-			ret = walk_page_range_novma(&init_mm, lm_start, lm_end,
++			ret = walk_kernel_page_table_range(lm_start, lm_end,
+ 						    &pageattr_ops, NULL, &masks);
+ 			if (ret)
+ 				goto unlock;
+@@ -317,13 +317,13 @@ static int __set_memory(unsigned long addr, int numpages, pgprot_t set_mask,
+ 		if (ret)
+ 			goto unlock;
+ 
+-		ret = walk_page_range_novma(&init_mm, lm_start, lm_end,
++		ret = walk_kernel_page_table_range(lm_start, lm_end,
+ 					    &pageattr_ops, NULL, &masks);
+ 		if (ret)
+ 			goto unlock;
+ 	}
+ 
+-	ret =  walk_page_range_novma(&init_mm, start, end, &pageattr_ops, NULL,
++	ret =  walk_kernel_page_table_range(start, end, &pageattr_ops, NULL,
+ 				     &masks);
+ 
+ unlock:
+@@ -335,7 +335,7 @@ unlock:
+ 	 */
+ 	flush_tlb_all();
+ #else
+-	ret =  walk_page_range_novma(&init_mm, start, end, &pageattr_ops, NULL,
++	ret =  walk_kernel_page_table_range(start, end, &pageattr_ops, NULL,
+ 				     &masks);
+ 
+ 	mmap_write_unlock(&init_mm);
+diff --git a/arch/x86/kvm/svm/sev.c b/arch/x86/kvm/svm/sev.c
+index afa3d9d8823aa8..0ba286bd50c277 100644
+--- a/arch/x86/kvm/svm/sev.c
++++ b/arch/x86/kvm/svm/sev.c
+@@ -68,6 +68,8 @@ module_param_named(debug_swap, sev_es_debug_swap_enabled, bool, 0444);
+ static u8 sev_enc_bit;
+ static DECLARE_RWSEM(sev_deactivate_lock);
+ static DEFINE_MUTEX(sev_bitmap_lock);
++/* Protects kvm_sev_info's enc_context_owner, mirror_vms and mirror_entry.  */
++static DEFINE_MUTEX(sev_mirror_lock);
+ unsigned int max_sev_asid;
+ static unsigned int min_sev_asid;
+ static unsigned long sev_me_mask;
+@@ -1713,18 +1715,18 @@ static void sev_migrate_from(struct kvm *dst_kvm, struct kvm *src_kvm)
+ 	dst->asid = src->asid;
+ 	dst->handle = src->handle;
+ 	dst->pages_locked = src->pages_locked;
+-	dst->enc_context_owner = src->enc_context_owner;
+ 	dst->es_active = src->es_active;
+ 
+ 	src->asid = 0;
+ 	src->active = false;
+ 	src->handle = 0;
+ 	src->pages_locked = 0;
+-	src->enc_context_owner = NULL;
+ 	src->es_active = false;
+ 
+ 	list_cut_before(&dst->regions_list, &src->regions_list, &src->regions_list);
+ 
++	mutex_lock(&sev_mirror_lock);
++
+ 	/*
+ 	 * If this VM has mirrors, "transfer" each mirror's refcount of the
+ 	 * source to the destination (this KVM).  The caller holds a reference
+@@ -1741,13 +1743,16 @@ static void sev_migrate_from(struct kvm *dst_kvm, struct kvm *src_kvm)
+ 	 * If this VM is a mirror, remove the old mirror from the owners list
+ 	 * and add the new mirror to the list.
+ 	 */
+-	if (is_mirroring_enc_context(dst_kvm)) {
++	if (is_mirroring_enc_context(src_kvm)) {
+ 		struct kvm_sev_info *owner_sev_info =
+-			&to_kvm_svm(dst->enc_context_owner)->sev_info;
++			&to_kvm_svm(src->enc_context_owner)->sev_info;
+ 
++		dst->enc_context_owner = src->enc_context_owner;
++		src->enc_context_owner = NULL;
+ 		list_del(&src->mirror_entry);
+ 		list_add_tail(&dst->mirror_entry, &owner_sev_info->mirror_vms);
+ 	}
++	mutex_unlock(&sev_mirror_lock);
+ 
+ 	kvm_for_each_vcpu(i, dst_vcpu, dst_kvm) {
+ 		dst_svm = to_svm(dst_vcpu);
+@@ -2125,12 +2130,15 @@ int sev_vm_copy_enc_context_from(struct kvm *kvm, unsigned int source_fd)
+ 	 * disappear until we're done with it
+ 	 */
+ 	source_sev = &to_kvm_svm(source_kvm)->sev_info;
+-	kvm_get_kvm(source_kvm);
+ 	mirror_sev = &to_kvm_svm(kvm)->sev_info;
+-	list_add_tail(&mirror_sev->mirror_entry, &source_sev->mirror_vms);
+ 
+ 	/* Set enc_context_owner and copy its encryption context over */
++	mutex_lock(&sev_mirror_lock);
++	kvm_get_kvm(source_kvm);
++	list_add_tail(&mirror_sev->mirror_entry, &source_sev->mirror_vms);
+ 	mirror_sev->enc_context_owner = source_kvm;
++	mutex_unlock(&sev_mirror_lock);
++
+ 	mirror_sev->active = true;
+ 	mirror_sev->asid = source_sev->asid;
+ 	mirror_sev->fd = source_sev->fd;
+@@ -2166,11 +2174,19 @@ void sev_vm_destroy(struct kvm *kvm)
+ 
+ 	/* If this is a mirror_kvm release the enc_context_owner and skip sev cleanup */
+ 	if (is_mirroring_enc_context(kvm)) {
+-		struct kvm *owner_kvm = sev->enc_context_owner;
++		struct kvm *owner_kvm;
+ 
+-		mutex_lock(&owner_kvm->lock);
++		mutex_lock(&sev_mirror_lock);
++		owner_kvm = sev->enc_context_owner;
+ 		list_del(&sev->mirror_entry);
+-		mutex_unlock(&owner_kvm->lock);
++		sev->enc_context_owner = NULL;
++
++		/*
++		 * The reference to owner_kvm cannot move after sev_mirror_lock is
++		 * released.  Release it before kvm_put_kvm() so that owner_kvm is
++		 * never destroyed inside sev_mirror_lock.
++		 */
++		mutex_unlock(&sev_mirror_lock);
+ 		kvm_put_kvm(owner_kvm);
+ 		return;
+ 	}
+diff --git a/arch/x86/kvm/svm/svm.h b/arch/x86/kvm/svm/svm.h
+index cf0a516a9f8cd0..0191b0d28741ed 100644
+--- a/arch/x86/kvm/svm/svm.h
++++ b/arch/x86/kvm/svm/svm.h
+@@ -86,6 +86,7 @@ struct kvm_sev_info {
+ 	unsigned long pages_locked; /* Number of pages locked */
+ 	struct list_head regions_list;  /* List of registered regions */
+ 	u64 ap_jump_table;	/* SEV-ES AP Jump Table address */
++	/* The three fields below are protected by sev_mirror_lock */
+ 	struct kvm *enc_context_owner; /* Owner of copied encryption context */
+ 	struct list_head mirror_vms; /* List of VMs mirroring */
+ 	struct list_head mirror_entry; /* Use as a list entry of mirrors */
+diff --git a/block/genhd.c b/block/genhd.c
+index 6d01b0e3e1ea3d..3e88fe53f269d6 100644
+--- a/block/genhd.c
++++ b/block/genhd.c
+@@ -1174,14 +1174,18 @@ static void disk_release(struct device *dev)
+ 	/*
+ 	 * To undo the all initialization from blk_mq_init_allocated_queue in
+ 	 * case of a probe failure where add_disk is never called we have to
+-	 * call blk_mq_exit_queue here. We can't do this for the more common
+-	 * teardown case (yet) as the tagset can be gone by the time the disk
+-	 * is released once it was added.
++	 * call blk_mq_exit_queue here, after stopping the timer and work items
++	 * that I/O issued before add_disk may have left pending.  We can't do
++	 * this for the more common teardown case (yet) as the tagset can be
++	 * gone by the time the disk is released once it was added.
+ 	 */
+ 	if (queue_is_mq(disk->queue) &&
+ 	    test_bit(GD_OWNS_QUEUE, &disk->state) &&
+-	    !test_bit(GD_ADDED, &disk->state))
++	    !test_bit(GD_ADDED, &disk->state)) {
++		blk_sync_queue(disk->queue);
++		blk_mq_cancel_work_sync(disk->queue);
+ 		blk_mq_exit_queue(disk->queue);
++	}
+ 
+ 	blkcg_exit_disk(disk);
+ 
+diff --git a/crypto/ccm.c b/crypto/ccm.c
+index a9453129c51cb7..1770309c68c129 100644
+--- a/crypto/ccm.c
++++ b/crypto/ccm.c
+@@ -752,7 +752,7 @@ static int crypto_rfc4309_create(struct crypto_template *tmpl,
+ 
+ 	inst->alg.ivsize = 8;
+ 	inst->alg.chunksize = crypto_aead_alg_chunksize(alg);
+-	inst->alg.maxauthsize = 16;
++	inst->alg.maxauthsize = crypto_aead_alg_maxauthsize(alg);
+ 
+ 	inst->alg.base.cra_ctxsize = sizeof(struct crypto_rfc4309_ctx);
+ 
+diff --git a/drivers/crypto/qce/core.c b/drivers/crypto/qce/core.c
+index 8bcb9adf1aee3f..c0538b84affeed 100644
+--- a/drivers/crypto/qce/core.c
++++ b/drivers/crypto/qce/core.c
+@@ -58,7 +58,7 @@ static int qce_register_algs(struct qce_device *qce)
+ 		ret = ops->register_algs(qce);
+ 		if (ret) {
+ 			for (j = i - 1; j >= 0; j--)
+-				ops->unregister_algs(qce);
++				qce_ops[j]->unregister_algs(qce);
+ 			return ret;
+ 		}
+ 	}
+diff --git a/drivers/gpu/drm/amd/amdgpu/amdgpu_cs.c b/drivers/gpu/drm/amd/amdgpu/amdgpu_cs.c
+index 2d12bb47c574db..a5ede9ab877de8 100644
+--- a/drivers/gpu/drm/amd/amdgpu/amdgpu_cs.c
++++ b/drivers/gpu/drm/amd/amdgpu/amdgpu_cs.c
+@@ -253,6 +253,10 @@ static int amdgpu_cs_pass1(struct amdgpu_cs_parser *p,
+ 			if (size < sizeof(struct drm_amdgpu_cs_chunk_fence))
+ 				goto free_partial_kdata;
+ 
++			/* Only a single user fence is allowed to simplify handling. */
++			if (p->uf_bo)
++				goto free_partial_kdata;
++
+ 			ret = amdgpu_cs_p1_user_fence(p, p->chunks[i].kdata,
+ 						      &uf_offset);
+ 			if (ret)
+@@ -1178,19 +1182,6 @@ static int amdgpu_cs_vm_handling(struct amdgpu_cs_parser *p)
+ 		job->vm_pd_addr = amdgpu_gmc_pd_addr(vm->root.bo);
+ 	}
+ 
+-	if (amdgpu_vm_debug) {
+-		/* Invalidate all BOs to test for userspace bugs */
+-		amdgpu_bo_list_for_each_entry(e, p->bo_list) {
+-			struct amdgpu_bo *bo = e->bo;
+-
+-			/* ignore duplicates */
+-			if (!bo)
+-				continue;
+-
+-			amdgpu_vm_bo_invalidate(adev, bo, false);
+-		}
+-	}
+-
+ 	return 0;
+ }
+ 
+@@ -1379,6 +1370,8 @@ static int amdgpu_cs_submit(struct amdgpu_cs_parser *p,
+ /* Cleanup the parser structure */
+ static void amdgpu_cs_parser_fini(struct amdgpu_cs_parser *parser)
+ {
++	struct amdgpu_device *adev = parser->adev;
++	struct amdgpu_bo_list_entry *e;
+ 	unsigned int i;
+ 
+ 	amdgpu_sync_free(&parser->sync);
+@@ -1394,8 +1387,21 @@ static void amdgpu_cs_parser_fini(struct amdgpu_cs_parser *parser)
+ 
+ 	if (parser->ctx)
+ 		amdgpu_ctx_put(parser->ctx);
+-	if (parser->bo_list)
++	if (parser->bo_list) {
++		if (amdgpu_vm_debug) {
++			/* Invalidate all BOs to test for userspace bugs */
++			amdgpu_bo_list_for_each_entry(e, parser->bo_list) {
++				struct amdgpu_bo *bo = e->bo;
++
++				/* ignore duplicates */
++				if (!bo)
++					continue;
++
++				amdgpu_vm_bo_invalidate(adev, bo, false);
++			}
++		}
+ 		amdgpu_bo_list_put(parser->bo_list);
++	}
+ 
+ 	for (i = 0; i < parser->nchunks; i++)
+ 		kvfree(parser->chunks[i].kdata);
+diff --git a/drivers/gpu/drm/amd/amdgpu/amdgpu_gem.c b/drivers/gpu/drm/amd/amdgpu/amdgpu_gem.c
+index 73a00f30da9ced..b89afaf0c92ceb 100644
+--- a/drivers/gpu/drm/amd/amdgpu/amdgpu_gem.c
++++ b/drivers/gpu/drm/amd/amdgpu/amdgpu_gem.c
+@@ -273,6 +273,25 @@ static const struct drm_gem_object_funcs amdgpu_gem_object_funcs = {
+ 	.vm_ops = &amdgpu_gem_vm_ops,
+ };
+ 
++static bool amdgpu_gem_are_domains_valid(u32 domains)
++{
++	u32 normal = AMDGPU_GEM_DOMAIN_CPU |
++		     AMDGPU_GEM_DOMAIN_GTT |
++		     AMDGPU_GEM_DOMAIN_VRAM;
++	/* Treat all non CPU/GTT/VRAM domains as special domains. */
++	u32 special = AMDGPU_GEM_DOMAIN_MASK & ~normal;
++	u32 normal_mask = domains & normal;
++	u32 special_mask = domains & special;
++
++	if (!special_mask)
++		return true;
++
++	if (normal_mask)
++		return false;
++
++	return !(special_mask & (special_mask - 1));
++}
++
+ /*
+  * GEM ioctls.
+  */
+@@ -308,6 +327,8 @@ int amdgpu_gem_create_ioctl(struct drm_device *dev, void *data,
+ 	/* reject invalid gem domains */
+ 	if (args->in.domains & ~AMDGPU_GEM_DOMAIN_MASK)
+ 		return -EINVAL;
++	if (!amdgpu_gem_are_domains_valid(args->in.domains))
++		return -EINVAL;
+ 
+ 	if (!amdgpu_is_tmz(adev) && (flags & AMDGPU_GEM_CREATE_ENCRYPTED)) {
+ 		DRM_NOTE_ONCE("Cannot allocate secure buffer since TMZ is disabled\n");
+diff --git a/drivers/gpu/drm/amd/amdgpu/amdgpu_ttm.c b/drivers/gpu/drm/amd/amdgpu/amdgpu_ttm.c
+index df23a77a07d639..9016ff071d642c 100644
+--- a/drivers/gpu/drm/amd/amdgpu/amdgpu_ttm.c
++++ b/drivers/gpu/drm/amd/amdgpu/amdgpu_ttm.c
+@@ -2044,8 +2044,6 @@ int amdgpu_ttm_init(struct amdgpu_device *adev)
+  */
+ void amdgpu_ttm_fini(struct amdgpu_device *adev)
+ {
+-	int idx;
+-
+ 	if (!adev->mman.initialized)
+ 		return;
+ 
+@@ -2068,13 +2066,9 @@ void amdgpu_ttm_fini(struct amdgpu_device *adev)
+ 	amdgpu_ttm_fw_reserve_vram_fini(adev);
+ 	amdgpu_ttm_drv_reserve_vram_fini(adev);
+ 
+-	if (drm_dev_enter(adev_to_drm(adev), &idx)) {
+-
+-		if (adev->mman.aper_base_kaddr)
+-			iounmap(adev->mman.aper_base_kaddr);
++	if (adev->mman.aper_base_kaddr) {
++		iounmap(adev->mman.aper_base_kaddr);
+ 		adev->mman.aper_base_kaddr = NULL;
+-
+-		drm_dev_exit(idx);
+ 	}
+ 
+ 	amdgpu_vram_mgr_fini(adev);
+diff --git a/drivers/gpu/drm/amd/amdgpu/amdgpu_uvd.c b/drivers/gpu/drm/amd/amdgpu/amdgpu_uvd.c
+index 8c3ab7f0804827..aab293ec3417e6 100644
+--- a/drivers/gpu/drm/amd/amdgpu/amdgpu_uvd.c
++++ b/drivers/gpu/drm/amd/amdgpu/amdgpu_uvd.c
+@@ -638,17 +638,15 @@ static int amdgpu_uvd_cs_msg_decode(struct amdgpu_device *adev, uint32_t *msg,
+ 	unsigned int height = msg[7];
+ 	unsigned int dpb_size = msg[9];
+ 	unsigned int pitch = msg[28];
+-	unsigned int level = msg[57];
+ 
+ 	unsigned int width_in_mb = width / 16;
+ 	unsigned int height_in_mb = ALIGN(height / 16, 2);
+-	unsigned int fs_in_mb = width_in_mb * height_in_mb;
+ 
+ 	unsigned int image_size, tmp, min_dpb_size, num_dpb_buffer;
+ 	unsigned int min_ctx_size = ~0;
+ 
+-	/* Reject invalid dimensions to prevent division by zero */
+-	if (width < 16 || height < 16) {
++	/* Reject invalid dimensions */
++	if (width < 16 || height < 16 || width > 4096 || height > 4096) {
+ 		dev_WARN_ONCE(adev->dev, 1,
+ 			      "Invalid UVD decoding dimensions (%dx%d)!\n",
+ 			      width, height);
+@@ -661,35 +659,9 @@ static int amdgpu_uvd_cs_msg_decode(struct amdgpu_device *adev, uint32_t *msg,
+ 
+ 	switch (stream_type) {
+ 	case 0: /* H264 */
+-		switch (level) {
+-		case 30:
+-			num_dpb_buffer = 8100 / fs_in_mb;
+-			break;
+-		case 31:
+-			num_dpb_buffer = 18000 / fs_in_mb;
+-			break;
+-		case 32:
+-			num_dpb_buffer = 20480 / fs_in_mb;
+-			break;
+-		case 41:
+-			num_dpb_buffer = 32768 / fs_in_mb;
+-			break;
+-		case 42:
+-			num_dpb_buffer = 34816 / fs_in_mb;
+-			break;
+-		case 50:
+-			num_dpb_buffer = 110400 / fs_in_mb;
+-			break;
+-		case 51:
+-			num_dpb_buffer = 184320 / fs_in_mb;
+-			break;
+-		default:
+-			num_dpb_buffer = 184320 / fs_in_mb;
+-			break;
+-		}
+-		num_dpb_buffer++;
++		num_dpb_buffer = ((msg[61] >> 16) & 0xff) + 1;
+ 		if (num_dpb_buffer > 17)
+-			num_dpb_buffer = 17;
++			return -EINVAL;
+ 
+ 		/* reference picture buffer */
+ 		min_dpb_size = image_size * num_dpb_buffer;
+@@ -739,35 +711,9 @@ static int amdgpu_uvd_cs_msg_decode(struct amdgpu_device *adev, uint32_t *msg,
+ 		break;
+ 
+ 	case 7: /* H264 Perf */
+-		switch (level) {
+-		case 30:
+-			num_dpb_buffer = 8100 / fs_in_mb;
+-			break;
+-		case 31:
+-			num_dpb_buffer = 18000 / fs_in_mb;
+-			break;
+-		case 32:
+-			num_dpb_buffer = 20480 / fs_in_mb;
+-			break;
+-		case 41:
+-			num_dpb_buffer = 32768 / fs_in_mb;
+-			break;
+-		case 42:
+-			num_dpb_buffer = 34816 / fs_in_mb;
+-			break;
+-		case 50:
+-			num_dpb_buffer = 110400 / fs_in_mb;
+-			break;
+-		case 51:
+-			num_dpb_buffer = 184320 / fs_in_mb;
+-			break;
+-		default:
+-			num_dpb_buffer = 184320 / fs_in_mb;
+-			break;
+-		}
+-		num_dpb_buffer++;
++		num_dpb_buffer = ((msg[61] >> 16) & 0xff) + 1;
+ 		if (num_dpb_buffer > 17)
+-			num_dpb_buffer = 17;
++			return -EINVAL;
+ 
+ 		/* reference picture buffer */
+ 		min_dpb_size = image_size * num_dpb_buffer;
+@@ -795,6 +741,9 @@ static int amdgpu_uvd_cs_msg_decode(struct amdgpu_device *adev, uint32_t *msg,
+ 		image_size = ALIGN(image_size, 256);
+ 
+ 		num_dpb_buffer = (le32_to_cpu(msg[59]) & 0xff) + 2;
++		if (num_dpb_buffer > 17)
++			return -EINVAL;
++
+ 		min_dpb_size = image_size * num_dpb_buffer;
+ 		min_ctx_size = ((width + 255) / 16) * ((height + 255) / 16)
+ 					   * 16 * num_dpb_buffer + 52 * 1024;
+@@ -805,7 +754,7 @@ static int amdgpu_uvd_cs_msg_decode(struct amdgpu_device *adev, uint32_t *msg,
+ 		return -EINVAL;
+ 	}
+ 
+-	if (width > pitch) {
++	if (width > pitch || pitch > 4096) {
+ 		DRM_ERROR("Invalid UVD decoding target pitch!\n");
+ 		return -EINVAL;
+ 	}
+@@ -817,7 +766,7 @@ static int amdgpu_uvd_cs_msg_decode(struct amdgpu_device *adev, uint32_t *msg,
+ 	}
+ 
+ 	buf_sizes[0x1] = dpb_size;
+-	buf_sizes[0x2] = image_size;
++	buf_sizes[0x2] = (pitch * height) * 3 / 2;
+ 	buf_sizes[0x4] = min_ctx_size;
+ 	/* store image width to adjust nb memory pstate */
+ 	adev->uvd.decode_image_width = width;
+@@ -964,15 +913,16 @@ static int amdgpu_uvd_cs_pass2(struct amdgpu_uvd_cs_ctx *ctx)
+ 				  ctx->buf_sizes[cmd]);
+ 			return -EINVAL;
+ 		}
++	} else if (cmd == 0x204 || cmd == 0x206) {
++		unsigned int min_size = ctx->buf_sizes[cmd == 0x204 ? 5 : 4];
+ 
+-	} else if (cmd == 0x206) {
+-		if ((end - start) < ctx->buf_sizes[4]) {
++		if ((end - start) < min_size) {
+ 			DRM_ERROR("buffer (%d) to small (%d / %d)!\n", cmd,
+ 					  (unsigned int)(end - start),
+-					  ctx->buf_sizes[4]);
++					  min_size);
+ 			return -EINVAL;
+ 		}
+-	} else if ((cmd != 0x100) && (cmd != 0x204)) {
++	} else if ((cmd != 0x100)) {
+ 		DRM_ERROR("invalid UVD command %X!\n", cmd);
+ 		return -EINVAL;
+ 	}
+@@ -1102,11 +1052,12 @@ int amdgpu_uvd_ring_parse_cs(struct amdgpu_cs_parser *parser,
+ {
+ 	struct amdgpu_uvd_cs_ctx ctx = {};
+ 	unsigned int buf_sizes[] = {
+-		[0x00000000]	=	2048,
++		[0x00000000]	=	3556,
+ 		[0x00000001]	=	0xFFFFFFFF,
+ 		[0x00000002]	=	0xFFFFFFFF,
+ 		[0x00000003]	=	2048,
+ 		[0x00000004]	=	0xFFFFFFFF,
++		[0x00000005]	=	992,
+ 	};
+ 	int r;
+ 
+diff --git a/drivers/gpu/drm/amd/amdgpu/vce_v3_0.c b/drivers/gpu/drm/amd/amdgpu/vce_v3_0.c
+index 18f6e62af33984..1b5afa08f52b99 100644
+--- a/drivers/gpu/drm/amd/amdgpu/vce_v3_0.c
++++ b/drivers/gpu/drm/amd/amdgpu/vce_v3_0.c
+@@ -873,6 +873,23 @@ static void vce_v3_0_ring_emit_ib(struct amdgpu_ring *ring,
+ 	amdgpu_ring_write(ring, ib->length_dw);
+ }
+ 
++static void vce_v3_0_ring_emit_fence(struct amdgpu_ring *ring, u64 addr,
++			u64 seq, unsigned flags)
++{
++	WARN_ON(flags & AMDGPU_FENCE_FLAG_64BIT);
++
++	amdgpu_ring_write(ring, VCE_CMD_FENCE);
++	amdgpu_ring_write(ring, addr);
++	amdgpu_ring_write(ring, upper_32_bits(addr));
++	amdgpu_ring_write(ring, seq);
++	amdgpu_ring_write(ring, VCE_CMD_TRAP);
++}
++
++static void vce_v3_0_ring_insert_end(struct amdgpu_ring *ring)
++{
++	amdgpu_ring_write(ring, VCE_CMD_END);
++}
++
+ static void vce_v3_0_emit_vm_flush(struct amdgpu_ring *ring,
+ 				   unsigned int vmid, uint64_t pd_addr)
+ {
+@@ -882,7 +899,6 @@ static void vce_v3_0_emit_vm_flush(struct amdgpu_ring *ring,
+ 
+ 	amdgpu_ring_write(ring, VCE_CMD_FLUSH_TLB);
+ 	amdgpu_ring_write(ring, vmid);
+-	amdgpu_ring_write(ring, VCE_CMD_END);
+ }
+ 
+ static void vce_v3_0_emit_pipeline_sync(struct amdgpu_ring *ring)
+@@ -952,17 +968,19 @@ static const struct amdgpu_ring_funcs vce_v3_0_ring_vm_funcs = {
+ 	.set_wptr = vce_v3_0_ring_set_wptr,
+ 	.parse_cs = amdgpu_vce_ring_parse_cs_vm,
+ 	.emit_frame_size =
+-		6 + /* vce_v3_0_emit_vm_flush */
++		5 + /* vce_v3_0_emit_vm_flush */
+ 		4 + /* vce_v3_0_emit_pipeline_sync */
+-		6 + 6, /* amdgpu_vce_ring_emit_fence x2 vm fence */
++		5 + 5 + /* vce_v3_0_ring_emit_fence x2 vm fence */
++		1, /* vce_v3_0_ring_insert_end */
+ 	.emit_ib_size = 5, /* vce_v3_0_ring_emit_ib */
+ 	.emit_ib = vce_v3_0_ring_emit_ib,
+ 	.emit_vm_flush = vce_v3_0_emit_vm_flush,
+ 	.emit_pipeline_sync = vce_v3_0_emit_pipeline_sync,
+-	.emit_fence = amdgpu_vce_ring_emit_fence,
++	.emit_fence = vce_v3_0_ring_emit_fence,
+ 	.test_ring = amdgpu_vce_ring_test_ring,
+ 	.test_ib = amdgpu_vce_ring_test_ib,
+ 	.insert_nop = amdgpu_ring_insert_nop,
++	.insert_end = vce_v3_0_ring_insert_end,
+ 	.pad_ib = amdgpu_ring_generic_pad_ib,
+ 	.begin_use = amdgpu_vce_ring_begin_use,
+ 	.end_use = amdgpu_vce_ring_end_use,
+diff --git a/drivers/gpu/drm/amd/pm/amdgpu_dpm.c b/drivers/gpu/drm/amd/pm/amdgpu_dpm.c
+index 078aaaa5316280..6bc1f4b381c2ea 100644
+--- a/drivers/gpu/drm/amd/pm/amdgpu_dpm.c
++++ b/drivers/gpu/drm/amd/pm/amdgpu_dpm.c
+@@ -996,17 +996,28 @@ int amdgpu_dpm_dispatch_task(struct amdgpu_device *adev,
+ 	return ret;
+ }
+ 
+-int amdgpu_dpm_get_pp_table(struct amdgpu_device *adev, char **table)
++int amdgpu_dpm_get_pp_table(struct amdgpu_device *adev, char *table,
++			    size_t size)
+ {
+ 	const struct amd_pm_funcs *pp_funcs = adev->powerplay.pp_funcs;
++	char *pptable = NULL;
+ 	int ret = 0;
+ 
++	if ((!table && size) || (table && !size))
++		return -EINVAL;
++
+ 	if (!pp_funcs->get_pp_table)
+ 		return 0;
+ 
+ 	mutex_lock(&adev->pm.mutex);
+ 	ret = pp_funcs->get_pp_table(adev->powerplay.pp_handle,
+-				     table);
++				     &pptable);
++	if (ret > 0 && !pptable) {
++		ret = -EINVAL;
++	} else if (ret > 0 && table) {
++		ret = min_t(size_t, ret, size);
++		memcpy(table, pptable, ret);
++	}
+ 	mutex_unlock(&adev->pm.mutex);
+ 
+ 	return ret;
+@@ -1255,17 +1266,23 @@ int amdgpu_dpm_set_power_profile_mode(struct amdgpu_device *adev,
+ 	return ret;
+ }
+ 
+-int amdgpu_dpm_get_gpu_metrics(struct amdgpu_device *adev, void **table)
++ssize_t amdgpu_dpm_get_gpu_metrics(struct amdgpu_device *adev, void *buf,
++				   size_t size)
+ {
+ 	const struct amd_pm_funcs *pp_funcs = adev->powerplay.pp_funcs;
+-	int ret = 0;
++	void *table;
++	ssize_t ret;
+ 
+ 	if (!pp_funcs->get_gpu_metrics)
+ 		return 0;
+ 
+ 	mutex_lock(&adev->pm.mutex);
+ 	ret = pp_funcs->get_gpu_metrics(adev->powerplay.pp_handle,
+-					table);
++					&table);
++	if (ret > 0) {
++		ret = min_t(ssize_t, ret, size);
++		memcpy(buf, table, ret);
++	}
+ 	mutex_unlock(&adev->pm.mutex);
+ 
+ 	return ret;
+diff --git a/drivers/gpu/drm/amd/pm/amdgpu_pm.c b/drivers/gpu/drm/amd/pm/amdgpu_pm.c
+index 93fe215986d396..ada58a3f1533c7 100644
+--- a/drivers/gpu/drm/amd/pm/amdgpu_pm.c
++++ b/drivers/gpu/drm/amd/pm/amdgpu_pm.c
+@@ -496,7 +496,6 @@ static ssize_t amdgpu_get_pp_table(struct device *dev,
+ {
+ 	struct drm_device *ddev = dev_get_drvdata(dev);
+ 	struct amdgpu_device *adev = drm_to_adev(ddev);
+-	char *table = NULL;
+ 	int size, ret;
+ 
+ 	if (amdgpu_in_reset(adev))
+@@ -510,7 +509,7 @@ static ssize_t amdgpu_get_pp_table(struct device *dev,
+ 		return ret;
+ 	}
+ 
+-	size = amdgpu_dpm_get_pp_table(adev, &table);
++	size = amdgpu_dpm_get_pp_table(adev, buf, PAGE_SIZE - 1);
+ 
+ 	pm_runtime_mark_last_busy(ddev->dev);
+ 	pm_runtime_put_autosuspend(ddev->dev);
+@@ -518,11 +517,6 @@ static ssize_t amdgpu_get_pp_table(struct device *dev,
+ 	if (size <= 0)
+ 		return size;
+ 
+-	if (size >= PAGE_SIZE)
+-		size = PAGE_SIZE - 1;
+-
+-	memcpy(buf, table, size);
+-
+ 	return size;
+ }
+ 
+@@ -1781,7 +1775,6 @@ static ssize_t amdgpu_get_gpu_metrics(struct device *dev,
+ {
+ 	struct drm_device *ddev = dev_get_drvdata(dev);
+ 	struct amdgpu_device *adev = drm_to_adev(ddev);
+-	void *gpu_metrics;
+ 	ssize_t size = 0;
+ 	int ret;
+ 
+@@ -1796,15 +1789,10 @@ static ssize_t amdgpu_get_gpu_metrics(struct device *dev,
+ 		return ret;
+ 	}
+ 
+-	size = amdgpu_dpm_get_gpu_metrics(adev, &gpu_metrics);
++	size = amdgpu_dpm_get_gpu_metrics(adev, buf, PAGE_SIZE - 1);
+ 	if (size <= 0)
+ 		goto out;
+ 
+-	if (size >= PAGE_SIZE)
+-		size = PAGE_SIZE - 1;
+-
+-	memcpy(buf, gpu_metrics, size);
+-
+ out:
+ 	pm_runtime_mark_last_busy(ddev->dev);
+ 	pm_runtime_put_autosuspend(ddev->dev);
+diff --git a/drivers/gpu/drm/amd/pm/inc/amdgpu_dpm.h b/drivers/gpu/drm/amd/pm/inc/amdgpu_dpm.h
+index 42172b00be66df..cb4d33555feeea 100644
+--- a/drivers/gpu/drm/amd/pm/inc/amdgpu_dpm.h
++++ b/drivers/gpu/drm/amd/pm/inc/amdgpu_dpm.h
+@@ -463,7 +463,8 @@ int amdgpu_dpm_get_pp_num_states(struct amdgpu_device *adev,
+ int amdgpu_dpm_dispatch_task(struct amdgpu_device *adev,
+ 			      enum amd_pp_task task_id,
+ 			      enum amd_pm_state_type *user_state);
+-int amdgpu_dpm_get_pp_table(struct amdgpu_device *adev, char **table);
++int amdgpu_dpm_get_pp_table(struct amdgpu_device *adev, char *table,
++			    size_t size);
+ int amdgpu_dpm_set_fine_grain_clk_vol(struct amdgpu_device *adev,
+ 				      uint32_t type,
+ 				      long *input,
+@@ -493,7 +494,8 @@ int amdgpu_dpm_get_power_profile_mode(struct amdgpu_device *adev,
+ 				      char *buf);
+ int amdgpu_dpm_set_power_profile_mode(struct amdgpu_device *adev,
+ 				      long *input, uint32_t size);
+-int amdgpu_dpm_get_gpu_metrics(struct amdgpu_device *adev, void **table);
++ssize_t amdgpu_dpm_get_gpu_metrics(struct amdgpu_device *adev, void *buf,
++				   size_t size);
+ int amdgpu_dpm_get_fan_control_mode(struct amdgpu_device *adev,
+ 				    uint32_t *fan_mode);
+ int amdgpu_dpm_set_fan_speed_pwm(struct amdgpu_device *adev,
+diff --git a/drivers/gpu/drm/radeon/radeon_kms.c b/drivers/gpu/drm/radeon/radeon_kms.c
+index a16590c6247fa3..8eecf0a2327d52 100644
+--- a/drivers/gpu/drm/radeon/radeon_kms.c
++++ b/drivers/gpu/drm/radeon/radeon_kms.c
+@@ -71,6 +71,7 @@ void radeon_driver_unload_kms(struct drm_device *dev)
+ 	if (radeon_is_px(dev)) {
+ 		pm_runtime_get_sync(dev->dev);
+ 		pm_runtime_forbid(dev->dev);
++		pm_runtime_dont_use_autosuspend(dev->dev);
+ 	}
+ 
+ 	radeon_acpi_fini(rdev);
+diff --git a/drivers/i2c/busses/i2c-bcm-iproc.c b/drivers/i2c/busses/i2c-bcm-iproc.c
+index e905734c26a049..907f66cbf23261 100644
+--- a/drivers/i2c/busses/i2c-bcm-iproc.c
++++ b/drivers/i2c/busses/i2c-bcm-iproc.c
+@@ -811,7 +811,16 @@ static int bcm_iproc_i2c_xfer_wait(struct bcm_iproc_i2c_dev *iproc_i2c,
+ 	}
+ 
+ 	if (!time_left && !iproc_i2c->xfer_is_done) {
+-		dev_err(iproc_i2c->device, "transaction timed out\n");
++		/*
++		 * The controller may fail to clear START_BUSY after a timeout,
++		 * reset the controller to recover in that case.
++		 */
++		if (!!(iproc_i2c_rd_reg(iproc_i2c, M_CMD_OFFSET) &
++		       BIT(M_CMD_START_BUSY_SHIFT))) {
++			bcm_iproc_i2c_enable_disable(iproc_i2c, false);
++			bcm_iproc_i2c_init(iproc_i2c);
++			bcm_iproc_i2c_enable_disable(iproc_i2c, true);
++		}
+ 
+ 		/* flush both TX/RX FIFOs */
+ 		val = BIT(M_FIFO_RX_FLUSH_SHIFT) | BIT(M_FIFO_TX_FLUSH_SHIFT);
+diff --git a/drivers/input/joystick/iforce/iforce-packets.c b/drivers/input/joystick/iforce/iforce-packets.c
+index 9f7ba41a947b1e..b9fd6d3be99fdb 100644
+--- a/drivers/input/joystick/iforce/iforce-packets.c
++++ b/drivers/input/joystick/iforce/iforce-packets.c
+@@ -161,6 +161,9 @@ void iforce_process_packet(struct iforce *iforce,
+ 	switch (packet_id) {
+ 
+ 	case 0x01:	/* joystick position data */
++		if (len < 7)
++			break;
++
+ 		input_report_abs(dev, ABS_X,
+ 				 (__s16) get_unaligned_le16(data));
+ 		input_report_abs(dev, ABS_Y,
+@@ -176,6 +179,9 @@ void iforce_process_packet(struct iforce *iforce,
+ 		break;
+ 
+ 	case 0x03:	/* wheel position data */
++		if (len < 7)
++			break;
++
+ 		input_report_abs(dev, ABS_WHEEL,
+ 				 (__s16) get_unaligned_le16(data));
+ 		input_report_abs(dev, ABS_GAS,   255 - data[2]);
+@@ -187,6 +193,9 @@ void iforce_process_packet(struct iforce *iforce,
+ 		break;
+ 
+ 	case 0x02:	/* status report */
++		if (len < 2)
++			break;
++
+ 		input_report_key(dev, BTN_DEAD, data[0] & 0x02);
+ 		input_sync(dev);
+ 
+@@ -206,7 +215,7 @@ void iforce_process_packet(struct iforce *iforce,
+ 			}
+ 		}
+ 
+-		for (j = 3; j < len; j += 2)
++		for (j = 3; j + sizeof(u16) <= len; j += sizeof(u16))
+ 			mark_core_as_ready(iforce, get_unaligned_le16(data + j));
+ 
+ 		break;
+diff --git a/drivers/input/joystick/iforce/iforce-usb.c b/drivers/input/joystick/iforce/iforce-usb.c
+index cba92bd590a8d8..927c1378b21a29 100644
+--- a/drivers/input/joystick/iforce/iforce-usb.c
++++ b/drivers/input/joystick/iforce/iforce-usb.c
+@@ -159,6 +159,9 @@ static void iforce_usb_irq(struct urb *urb)
+ 		goto exit;
+ 	}
+ 
++	if (!urb->actual_length)
++		goto exit;
++
+ 	iforce_process_packet(iforce, iforce_usb->data_in[0],
+ 			      iforce_usb->data_in + 1, urb->actual_length - 1);
+ 
+diff --git a/drivers/input/joystick/psxpad-spi.c b/drivers/input/joystick/psxpad-spi.c
+index de734a927b4d97..3b5f72b61a427f 100644
+--- a/drivers/input/joystick/psxpad-spi.c
++++ b/drivers/input/joystick/psxpad-spi.c
+@@ -369,6 +369,7 @@ static int psxpad_spi_probe(struct spi_device *spi)
+ 		return err;
+ 	}
+ 
++	spi_set_drvdata(spi, pad);
+ 	pm_runtime_enable(&spi->dev);
+ 
+ 	return 0;
+diff --git a/drivers/input/joystick/xpad.c b/drivers/input/joystick/xpad.c
+index ff49f01bd94963..9fddabcee9c273 100644
+--- a/drivers/input/joystick/xpad.c
++++ b/drivers/input/joystick/xpad.c
+@@ -417,6 +417,7 @@ static const struct xpad_device {
+ 	{ 0x3285, 0x0646, "Nacon Pro Compact", 0, XTYPE_XBOXONE },
+ 	{ 0x3285, 0x0662, "Nacon Revolution5 Pro", 0, XTYPE_XBOX360 },
+ 	{ 0x3285, 0x0663, "Nacon Evol-X", 0, XTYPE_XBOXONE },
++	{ 0x3507, 0x000b, "ZENAIM LEVERLESS", 0, XTYPE_XBOX360 },
+ 	{ 0x3537, 0x1004, "GameSir T4 Kaleid", 0, XTYPE_XBOX360 },
+ 	{ 0x3537, 0x100f, "GameSir Nova 2 Lite", 0, XTYPE_XBOX360 },
+ 	{ 0x3537, 0x1010, "GameSir G7 SE", 0, XTYPE_XBOXONE },
+@@ -575,6 +576,7 @@ static const struct usb_device_id xpad_table[] = {
+ 	XPAD_XBOX360_VENDOR(0x31e3),		/* Wooting Keyboards */
+ 	XPAD_XBOX360_VENDOR(0x3285),		/* Nacon GC-100 */
+ 	XPAD_XBOXONE_VENDOR(0x3285),		/* Nacon Evol-X */
++	XPAD_XBOX360_VENDOR(0x3507),		/* ZENAIM Controllers */
+ 	XPAD_XBOX360_VENDOR(0x3537),		/* GameSir Controllers */
+ 	XPAD_XBOXONE_VENDOR(0x3537),		/* GameSir Controllers */
+ 	XPAD_XBOX360_VENDOR(0x413d),		/* Black Shark Green Ghost Controller */
+diff --git a/drivers/input/keyboard/atkbd.c b/drivers/input/keyboard/atkbd.c
+index cd1e8466c85adb..66d73cad96eaa4 100644
+--- a/drivers/input/keyboard/atkbd.c
++++ b/drivers/input/keyboard/atkbd.c
+@@ -1959,6 +1959,14 @@ static const struct dmi_system_id atkbd_dmi_quirk_table[] __initconst = {
+ 		},
+ 		.callback = atkbd_deactivate_fixup,
+ 	},
++	{
++		/* Xiaomi Book Pro 14 (TM2424) */
++		.matches = {
++			DMI_MATCH(DMI_SYS_VENDOR, "XIAOMI"),
++			DMI_MATCH(DMI_PRODUCT_NAME, "Xiaomi Book Pro 14"),
++		},
++		.callback = atkbd_deactivate_fixup,
++	},
+ 	{ }
+ };
+ 
+diff --git a/drivers/input/mouse/focaltech.c b/drivers/input/mouse/focaltech.c
+index c74b99077d16a3..2ca5ac1836dd6d 100644
+--- a/drivers/input/mouse/focaltech.c
++++ b/drivers/input/mouse/focaltech.c
+@@ -197,7 +197,7 @@ static void focaltech_process_rel_packet(struct psmouse *psmouse,
+ {
+ 	struct focaltech_data *priv = psmouse->private;
+ 	struct focaltech_hw_state *state = &priv->state;
+-	int finger1, finger2;
++	unsigned int finger1, finger2;
+ 
+ 	state->pressed = packet[0] >> 7;
+ 	finger1 = ((packet[0] >> 4) & 0x7) - 1;
+diff --git a/drivers/input/rmi4/rmi_f54.c b/drivers/input/rmi4/rmi_f54.c
+index a035b04b43ce59..fe5e6425395048 100644
+--- a/drivers/input/rmi4/rmi_f54.c
++++ b/drivers/input/rmi4/rmi_f54.c
+@@ -104,7 +104,9 @@ struct f54_data {
+ 
+ 	enum rmi_f54_report_type report_type;
+ 	u8 *report_data;
++	size_t max_report_size;
+ 	int report_size;
++	int report_error;
+ 
+ 	bool is_busy;
+ 	struct mutex status_mutex;
+@@ -339,6 +341,12 @@ static void rmi_f54_buffer_queue(struct vb2_buffer *vb)
+ 		mutex_lock(&f54->data_mutex);
+ 	}
+ 
++	if (f54->report_error) {
++		dev_err(&f54->fn->dev, "Error acquiring report: %d\n", f54->report_error);
++		state = VB2_BUF_STATE_ERROR;
++		goto data_done;
++	}
++
+ 	ptr = vb2_plane_vaddr(vb, 0);
+ 	if (!ptr) {
+ 		dev_err(&f54->fn->dev, "Error acquiring frame ptr\n");
+@@ -446,7 +454,12 @@ static int rmi_f54_set_input(struct f54_data *f54, unsigned int i)
+ 
+ static int rmi_f54_vidioc_s_input(struct file *file, void *priv, unsigned int i)
+ {
+-	return rmi_f54_set_input(video_drvdata(file), i);
++	struct f54_data *f54 = video_drvdata(file);
++
++	if (vb2_is_busy(&f54->queue))
++		return -EBUSY;
++
++	return rmi_f54_set_input(f54, i);
+ }
+ 
+ static int rmi_f54_vidioc_g_input(struct file *file, void *priv,
+@@ -547,7 +560,14 @@ static void rmi_f54_work(struct work_struct *work)
+ 		dev_err(&fn->dev, "Bad report size, report type=%d\n",
+ 				f54->report_type);
+ 		error = -EINVAL;
+-		goto error;     /* retry won't help */
++		goto out;     /* retry won't help */
++	}
++
++	if (report_size > f54->max_report_size) {
++		dev_err(&fn->dev, "Report size %d exceeds buffer size %zu\n",
++			report_size, f54->max_report_size);
++		error = -EINVAL;
++		goto out;
+ 	}
+ 
+ 	/*
+@@ -558,7 +578,7 @@ static void rmi_f54_work(struct work_struct *work)
+ 			 &command);
+ 	if (error) {
+ 		dev_err(&fn->dev, "Failed to read back command\n");
+-		goto error;
++		goto out;
+ 	}
+ 	if (command & F54_GET_REPORT) {
+ 		if (time_after(jiffies, f54->timeout)) {
+@@ -566,7 +586,7 @@ static void rmi_f54_work(struct work_struct *work)
+ 			error = -ETIMEDOUT;
+ 		}
+ 		report_size = 0;
+-		goto error;
++		goto out;
+ 	}
+ 
+ 	rmi_dbg(RMI_DEBUG_FN, &fn->dev, "Get report command completed, reading data\n");
+@@ -581,7 +601,7 @@ static void rmi_f54_work(struct work_struct *work)
+ 					fifo, sizeof(fifo));
+ 		if (error) {
+ 			dev_err(&fn->dev, "Failed to set fifo start offset\n");
+-			goto abort;
++			goto out;
+ 		}
+ 
+ 		error = rmi_read_block(fn->rmi_dev, fn->fd.data_base_addr +
+@@ -590,16 +610,17 @@ static void rmi_f54_work(struct work_struct *work)
+ 		if (error) {
+ 			dev_err(&fn->dev, "%s: read [%d bytes] returned %d\n",
+ 				__func__, size, error);
+-			goto abort;
++			goto out;
+ 		}
+ 	}
+ 
+-abort:
+-	f54->report_size = error ? 0 : report_size;
+-error:
++out:
+ 	if (error)
+ 		report_size = 0;
+ 
++	f54->report_size = report_size;
++	f54->report_error = error;
++
+ 	if (report_size == 0 && !error) {
+ 		queue_delayed_work(f54->workqueue, &f54->work,
+ 				   msecs_to_jiffies(1));
+@@ -680,8 +701,8 @@ static int rmi_f54_probe(struct rmi_function *fn)
+ 
+ 	rx = f54->num_rx_electrodes;
+ 	tx = f54->num_tx_electrodes;
+-	f54->report_data = devm_kzalloc(&fn->dev,
+-					array3_size(tx, rx, sizeof(u16)),
++	f54->max_report_size = array3_size(tx, rx, sizeof(u16));
++	f54->report_data = devm_kzalloc(&fn->dev, f54->max_report_size,
+ 					GFP_KERNEL);
+ 	if (f54->report_data == NULL)
+ 		return -ENOMEM;
+diff --git a/drivers/input/rmi4/rmi_f55.c b/drivers/input/rmi4/rmi_f55.c
+index 488adaca4dd004..a0877d32a9141f 100644
+--- a/drivers/input/rmi4/rmi_f55.c
++++ b/drivers/input/rmi4/rmi_f55.c
+@@ -54,10 +54,10 @@ static int rmi_f55_detect(struct rmi_function *fn)
+ 	f55->num_tx_electrodes = f55->qry[F55_NUM_TX_OFFSET];
+ 
+ 	f55->cfg_num_rx_electrodes = f55->num_rx_electrodes;
+-	f55->cfg_num_tx_electrodes = f55->num_rx_electrodes;
++	f55->cfg_num_tx_electrodes = f55->num_tx_electrodes;
+ 
+ 	drv_data->num_rx_electrodes = f55->cfg_num_rx_electrodes;
+-	drv_data->num_tx_electrodes = f55->cfg_num_rx_electrodes;
++	drv_data->num_tx_electrodes = f55->cfg_num_tx_electrodes;
+ 
+ 	if (f55->qry[F55_PHYS_CHAR_OFFSET] & F55_CAP_SENSOR_ASSIGN) {
+ 		int i, total;
+diff --git a/drivers/input/touchscreen/hynitron_cstxxx.c b/drivers/input/touchscreen/hynitron_cstxxx.c
+index 05946fee4fd440..c1aa91a6421270 100644
+--- a/drivers/input/touchscreen/hynitron_cstxxx.c
++++ b/drivers/input/touchscreen/hynitron_cstxxx.c
+@@ -313,6 +313,12 @@ static void cst3xx_touch_report(struct i2c_client *client)
+ 		return;
+ 
+ 	touch_cnt = buf[5] & CST3XX_TOUCH_COUNT_MASK;
++	if (touch_cnt > ts_data->chip->max_touch_num) {
++		dev_err(&client->dev, "cst3xx invalid touch count (%d vs %d max)\n",
++			touch_cnt, ts_data->chip->max_touch_num);
++		return;
++	}
++
+ 	/*
+ 	 * Check the check bit of the last touch slot. The check bit is
+ 	 * always present after touch point 1 for valid data, and then
+@@ -335,9 +341,10 @@ static void cst3xx_touch_report(struct i2c_client *client)
+ 		finger_id = (buf[idx] >> 4) & 0x0f;
+ 
+ 		/* Sanity check we don't have more fingers than we expect */
+-		if (ts_data->chip->max_touch_num < finger_id) {
+-			dev_err(&client->dev, "cst3xx touch read failure\n");
+-			break;
++		if (finger_id >= ts_data->chip->max_touch_num) {
++			dev_err(&client->dev,
++				"cst3xx invalid finger id %d\n", finger_id);
++			return;
+ 		}
+ 
+ 		/* sw value of 0 means no touch, 0x03 means touch */
+diff --git a/drivers/input/touchscreen/sur40.c b/drivers/input/touchscreen/sur40.c
+index 8ddb3f7d307aa4..38ad0e43448333 100644
+--- a/drivers/input/touchscreen/sur40.c
++++ b/drivers/input/touchscreen/sur40.c
+@@ -725,21 +725,13 @@ static int sur40_probe(struct usb_interface *interface,
+ 		goto err_free_input;
+ 	}
+ 
+-	/* register the polled input device */
+-	error = input_register_device(input);
+-	if (error) {
+-		dev_err(&interface->dev,
+-			"Unable to register polled input device.");
+-		goto err_free_buffer;
+-	}
+-
+ 	/* register the video master device */
+ 	snprintf(sur40->v4l2.name, sizeof(sur40->v4l2.name), "%s", DRIVER_LONG);
+ 	error = v4l2_device_register(sur40->dev, &sur40->v4l2);
+ 	if (error) {
+ 		dev_err(&interface->dev,
+ 			"Unable to register video master device.");
+-		goto err_unreg_v4l2;
++		goto err_free_buffer;
+ 	}
+ 
+ 	/* initialize the lock and subdevice */
+@@ -795,6 +787,14 @@ static int sur40_probe(struct usb_interface *interface,
+ 	if (error) {
+ 		dev_err(&interface->dev,
+ 			"Unable to register video subdevice.");
++		goto err_free_ctrl;
++	}
++
++	/* register the polled input device */
++	error = input_register_device(input);
++	if (error) {
++		dev_err(&interface->dev,
++			"Unable to register polled input device.");
+ 		goto err_unreg_video;
+ 	}
+ 
+@@ -806,6 +806,8 @@ static int sur40_probe(struct usb_interface *interface,
+ 
+ err_unreg_video:
+ 	video_unregister_device(&sur40->vdev);
++err_free_ctrl:
++	v4l2_ctrl_handler_free(&sur40->hdl);
+ err_unreg_v4l2:
+ 	v4l2_device_unregister(&sur40->v4l2);
+ err_free_buffer:
+@@ -823,11 +825,12 @@ static void sur40_disconnect(struct usb_interface *interface)
+ {
+ 	struct sur40_state *sur40 = usb_get_intfdata(interface);
+ 
++	input_unregister_device(sur40->input);
++
+ 	v4l2_ctrl_handler_free(&sur40->hdl);
+ 	video_unregister_device(&sur40->vdev);
+ 	v4l2_device_unregister(&sur40->v4l2);
+ 
+-	input_unregister_device(sur40->input);
+ 	kfree(sur40->bulk_in_buffer);
+ 	kfree(sur40);
+ 
+diff --git a/drivers/mmc/host/omap_hsmmc.c b/drivers/mmc/host/omap_hsmmc.c
+index e120aeb869b892..e87546dd87e36f 100644
+--- a/drivers/mmc/host/omap_hsmmc.c
++++ b/drivers/mmc/host/omap_hsmmc.c
+@@ -1358,7 +1358,7 @@ omap_hsmmc_prepare_data(struct omap_hsmmc_host *host, struct mmc_request *req)
+ 	if (req->data == NULL) {
+ 		OMAP_HSMMC_WRITE(host->base, BLK, 0);
+ 		if (req->cmd->flags & MMC_RSP_BUSY) {
+-			timeout = req->cmd->busy_timeout * NSEC_PER_MSEC;
++			timeout = (u64)req->cmd->busy_timeout * NSEC_PER_MSEC;
+ 
+ 			/*
+ 			 * Set an arbitrary 100ms data timeout for commands with
+diff --git a/drivers/mmc/host/sdhci.c b/drivers/mmc/host/sdhci.c
+index e91c6a29ff3553..b7d4bdb4340278 100644
+--- a/drivers/mmc/host/sdhci.c
++++ b/drivers/mmc/host/sdhci.c
+@@ -4152,6 +4152,14 @@ void __sdhci_read_caps(struct sdhci_host *host, const u16 *ver,
+ }
+ EXPORT_SYMBOL_GPL(__sdhci_read_caps);
+ 
++static void sdhci_unmap_bounce_buffer(void *data)
++{
++	struct sdhci_host *host = data;
++
++	dma_unmap_single(mmc_dev(host->mmc), host->bounce_addr,
++			 host->bounce_buffer_size, DMA_BIDIRECTIONAL);
++}
++
+ static void sdhci_allocate_bounce_buffer(struct sdhci_host *host)
+ {
+ 	struct mmc_host *mmc = host->mmc;
+@@ -4206,6 +4214,14 @@ static void sdhci_allocate_bounce_buffer(struct sdhci_host *host)
+ 	}
+ 
+ 	host->bounce_buffer_size = bounce_size;
++	ret = devm_add_action_or_reset(mmc_dev(mmc),
++				       sdhci_unmap_bounce_buffer, host);
++	if (ret) {
++		devm_kfree(mmc_dev(mmc), host->bounce_buffer);
++		host->bounce_buffer = NULL;
++		host->bounce_buffer_size = 0;
++		return;
++	}
+ 
+ 	/* Lie about this since we're bouncing */
+ 	mmc->max_segs = max_blocks;
+diff --git a/drivers/mmc/host/sdhci.h b/drivers/mmc/host/sdhci.h
+index 16d7bff9eae562..1cc79aaee46a3a 100644
+--- a/drivers/mmc/host/sdhci.h
++++ b/drivers/mmc/host/sdhci.h
+@@ -606,7 +606,7 @@ struct sdhci_host {
+ 
+ 	unsigned int		tuning_count;	/* Timer count for re-tuning */
+ 	unsigned int		tuning_mode;	/* Re-tuning mode supported by host */
+-	unsigned int		tuning_err;	/* Error code for re-tuning */
++	int			tuning_err;	/* Error code for re-tuning */
+ #define SDHCI_TUNING_MODE_1	0
+ #define SDHCI_TUNING_MODE_2	1
+ #define SDHCI_TUNING_MODE_3	2
+diff --git a/drivers/net/can/rcar/rcar_canfd.c b/drivers/net/can/rcar/rcar_canfd.c
+index 5a30667001c94e..0a2dc41d40d4f2 100644
+--- a/drivers/net/can/rcar/rcar_canfd.c
++++ b/drivers/net/can/rcar/rcar_canfd.c
+@@ -1999,27 +1999,27 @@ static int rcar_canfd_probe(struct platform_device *pdev)
+ 		}
+ 	}
+ 
+-	err = reset_control_reset(gpriv->rstc1);
+-	if (err)
+-		goto fail_dev;
+-	err = reset_control_reset(gpriv->rstc2);
+-	if (err) {
+-		reset_control_assert(gpriv->rstc1);
+-		goto fail_dev;
+-	}
+-
+ 	/* Enable peripheral clock for register access */
+ 	err = clk_prepare_enable(gpriv->clkp);
+ 	if (err) {
+ 		dev_err(dev, "failed to enable peripheral clock: %pe\n",
+ 			ERR_PTR(err));
+-		goto fail_reset;
++		goto fail_dev;
++	}
++
++	err = reset_control_reset(gpriv->rstc1);
++	if (err)
++		goto fail_clk;
++	err = reset_control_reset(gpriv->rstc2);
++	if (err) {
++		reset_control_assert(gpriv->rstc1);
++		goto fail_clk;
+ 	}
+ 
+ 	err = rcar_canfd_reset_controller(gpriv);
+ 	if (err) {
+ 		dev_err(dev, "reset controller failed: %pe\n", ERR_PTR(err));
+-		goto fail_clk;
++		goto fail_reset;
+ 	}
+ 
+ 	/* Controller in Global reset & Channel reset mode */
+@@ -2070,11 +2070,11 @@ fail_channel:
+ 		rcar_canfd_channel_remove(gpriv, ch);
+ fail_mode:
+ 	rcar_canfd_disable_global_interrupts(gpriv);
+-fail_clk:
+-	clk_disable_unprepare(gpriv->clkp);
+ fail_reset:
+ 	reset_control_assert(gpriv->rstc1);
+ 	reset_control_assert(gpriv->rstc2);
++fail_clk:
++	clk_disable_unprepare(gpriv->clkp);
+ fail_dev:
+ 	return err;
+ }
+@@ -2094,9 +2094,9 @@ static void rcar_canfd_remove(struct platform_device *pdev)
+ 
+ 	/* Enter global sleep mode */
+ 	rcar_canfd_set_bit(gpriv->base, RCANFD_GCTR, RCANFD_GCTR_GSLPR);
+-	clk_disable_unprepare(gpriv->clkp);
+ 	reset_control_assert(gpriv->rstc1);
+ 	reset_control_assert(gpriv->rstc2);
++	clk_disable_unprepare(gpriv->clkp);
+ }
+ 
+ static int __maybe_unused rcar_canfd_suspend(struct device *dev)
+diff --git a/drivers/net/ethernet/intel/ice/ice_vf_lib.c b/drivers/net/ethernet/intel/ice/ice_vf_lib.c
+index fe4a641ce70dca..4bca813ceac28e 100644
+--- a/drivers/net/ethernet/intel/ice/ice_vf_lib.c
++++ b/drivers/net/ethernet/intel/ice/ice_vf_lib.c
+@@ -832,6 +832,30 @@ static void ice_notify_vf_reset(struct ice_vf *vf)
+ 			      NULL);
+ }
+ 
++/**
++ * ice_reset_interrupts - clear all queue interrupt configuration for a VSI
++ * @vsi: the VSI whose interrupt registers should be cleared
++ *
++ * Zero the QINT_RQCTL and QINT_TQCTL registers for all allocated queues
++ * in the VSI. This clears the entire register including MSIX_INDX, ITR_INDX,
++ * CAUSE_ENA and NEXTQ fields, unlike ice_vf_dis_rxq_interrupt() which only
++ * clears the CAUSE_ENA bit.
++ */
++void ice_reset_interrupts(struct ice_vsi *vsi)
++{
++	struct ice_pf *pf = vsi->back;
++	struct ice_hw *hw = &pf->hw;
++	int i;
++
++	ice_for_each_alloc_rxq(vsi, i)
++		wr32(hw, QINT_RQCTL(vsi->rxq_map[i]), 0);
++
++	ice_for_each_alloc_txq(vsi, i)
++		wr32(hw, QINT_TQCTL(vsi->txq_map[i]), 0);
++
++	ice_flush(hw);
++}
++
+ /**
+  * ice_reset_vf - Reset a particular VF
+  * @vf: pointer to the VF structure
+@@ -914,6 +938,9 @@ int ice_reset_vf(struct ice_vf *vf, u32 flags)
+ 
+ 	ice_dis_vf_qs(vf);
+ 
++	/* cleanup interrupt registers */
++	ice_reset_interrupts(vsi);
++
+ 	/* Call Disable LAN Tx queue AQ whether or not queues are
+ 	 * enabled. This is needed for successful completion of VFR.
+ 	 */
+diff --git a/drivers/net/ethernet/intel/ice/ice_vf_lib_private.h b/drivers/net/ethernet/intel/ice/ice_vf_lib_private.h
+index 5392b040498621..321d29c25b7c18 100644
+--- a/drivers/net/ethernet/intel/ice/ice_vf_lib_private.h
++++ b/drivers/net/ethernet/intel/ice/ice_vf_lib_private.h
+@@ -26,6 +26,7 @@
+ void ice_initialize_vf_entry(struct ice_vf *vf);
+ void ice_deinitialize_vf_entry(struct ice_vf *vf);
+ void ice_dis_vf_qs(struct ice_vf *vf);
++void ice_reset_interrupts(struct ice_vsi *vsi);
+ int ice_check_vf_init(struct ice_vf *vf);
+ enum virtchnl_status_code ice_err_to_virt_err(int err);
+ struct ice_port_info *ice_vf_get_port_info(struct ice_vf *vf);
+diff --git a/drivers/net/ethernet/intel/ice/ice_virtchnl.c b/drivers/net/ethernet/intel/ice/ice_virtchnl.c
+index 61c40219de1a08..fb4744f97143b5 100644
+--- a/drivers/net/ethernet/intel/ice/ice_virtchnl.c
++++ b/drivers/net/ethernet/intel/ice/ice_virtchnl.c
+@@ -1215,6 +1215,24 @@ static void ice_vf_ena_rxq_interrupt(struct ice_vsi *vsi, u32 q_idx)
+ 	wr32(hw, QINT_RQCTL(pfq), reg | QINT_RQCTL_CAUSE_ENA_M);
+ }
+ 
++/**
++ * ice_vf_dis_rxq_interrupt - disable Rx queue interrupt via QINT_RQCTL
++ * @vsi: VSI of the VF to configure
++ * @q_idx: VF queue index used to determine the queue in the PF's space
++ */
++static void ice_vf_dis_rxq_interrupt(struct ice_vsi *vsi, u32 q_idx)
++{
++	struct ice_hw *hw = &vsi->back->hw;
++	u32 pfq = vsi->rxq_map[q_idx];
++	u32 reg;
++
++	reg = rd32(hw, QINT_RQCTL(pfq));
++	reg &= ~QINT_RQCTL_CAUSE_ENA_M;
++	wr32(hw, QINT_RQCTL(pfq), reg);
++
++	ice_flush(hw);
++}
++
+ /**
+  * ice_vc_ena_qs_msg
+  * @vf: pointer to the VF info
+@@ -1408,6 +1426,8 @@ static int ice_vc_dis_qs_msg(struct ice_vf *vf, u8 *msg)
+ 			goto error_param;
+ 		}
+ 
++		for_each_set_bit(vf_q_id, &q_map, ICE_MAX_RSS_QS_PER_VF)
++			ice_vf_dis_rxq_interrupt(vsi, vf_q_id);
+ 		bitmap_zero(vf->rxq_ena, ICE_MAX_RSS_QS_PER_VF);
+ 	} else if (q_map) {
+ 		for_each_set_bit(vf_q_id, &q_map, ICE_MAX_RSS_QS_PER_VF) {
+@@ -1428,6 +1448,7 @@ static int ice_vc_dis_qs_msg(struct ice_vf *vf, u8 *msg)
+ 				goto error_param;
+ 			}
+ 
++			ice_vf_dis_rxq_interrupt(vsi, vf_q_id);
+ 			/* Clear enabled queues flag */
+ 			clear_bit(vf_q_id, vf->rxq_ena);
+ 		}
+diff --git a/drivers/net/ethernet/intel/igc/igc_main.c b/drivers/net/ethernet/intel/igc/igc_main.c
+index 13c41facfc9760..6fdf009df836d4 100644
+--- a/drivers/net/ethernet/intel/igc/igc_main.c
++++ b/drivers/net/ethernet/intel/igc/igc_main.c
+@@ -5085,7 +5085,6 @@ void igc_down(struct igc_adapter *adapter)
+ 
+ 	for (i = 0; i < adapter->num_q_vectors; i++) {
+ 		if (adapter->q_vector[i]) {
+-			napi_synchronize(&adapter->q_vector[i]->napi);
+ 			napi_disable(&adapter->q_vector[i]->napi);
+ 		}
+ 	}
+diff --git a/drivers/net/ethernet/microsoft/mana/mana_en.c b/drivers/net/ethernet/microsoft/mana/mana_en.c
+index ec5d38164d41b2..2808527315fe5e 100644
+--- a/drivers/net/ethernet/microsoft/mana/mana_en.c
++++ b/drivers/net/ethernet/microsoft/mana/mana_en.c
+@@ -2931,7 +2931,7 @@ void mana_remove(struct gdma_dev *gd, bool suspending)
+ 		if (!ndev) {
+ 			if (i == 0)
+ 				dev_err(dev, "No net device to remove\n");
+-			goto out;
++			break;
+ 		}
+ 
+ 		/* All cleanup actions should stay after rtnl_lock(), otherwise
+@@ -2958,7 +2958,7 @@ void mana_remove(struct gdma_dev *gd, bool suspending)
+ 	}
+ 
+ 	mana_destroy_eq(ac);
+-out:
++
+ 	mana_gd_deregister_device(gd);
+ 
+ 	if (suspending)
+diff --git a/drivers/net/ethernet/ti/am65-cpsw-nuss.c b/drivers/net/ethernet/ti/am65-cpsw-nuss.c
+index 93cb4193cf0ac7..8e7bcb3e42251d 100644
+--- a/drivers/net/ethernet/ti/am65-cpsw-nuss.c
++++ b/drivers/net/ethernet/ti/am65-cpsw-nuss.c
+@@ -753,6 +753,8 @@ static int am65_cpsw_nuss_rx_packets(struct am65_cpsw_common *common,
+ 	k3_udma_glue_rx_cppi5_to_dma_addr(rx_chn->rx_chn, &buf_dma);
+ 	pkt_len = cppi5_hdesc_get_pktlen(desc_rx);
+ 	cppi5_desc_get_tags_ids(&desc_rx->hdr, &port_id, NULL);
++	/* Port ID is contained in the lower 8-bits of the 16-bit Source Tag */
++	port_id &= 0xFF;
+ 	dev_dbg(dev, "%s rx port_id:%d\n", __func__, port_id);
+ 	port = am65_common_get_port(common, port_id);
+ 	ndev = port->ndev;
+diff --git a/drivers/net/ipvlan/ipvlan_main.c b/drivers/net/ipvlan/ipvlan_main.c
+index 679e816146d81c..706bf2e38d089a 100644
+--- a/drivers/net/ipvlan/ipvlan_main.c
++++ b/drivers/net/ipvlan/ipvlan_main.c
+@@ -144,6 +144,8 @@ static int ipvlan_init(struct net_device *dev)
+ 	dev->hw_enc_features |= dev->features;
+ 	netif_inherit_tso_max(dev, phy_dev);
+ 	dev->hard_header_len = phy_dev->hard_header_len;
++	dev->needed_headroom = phy_dev->needed_headroom;
++	dev->needed_tailroom = phy_dev->needed_tailroom;
+ 
+ 	netdev_lockdep_set_classes(dev);
+ 
+@@ -767,6 +769,8 @@ static int ipvlan_device_event(struct notifier_block *unused,
+ 	case NETDEV_FEAT_CHANGE:
+ 		list_for_each_entry(ipvlan, &port->ipvlans, pnode) {
+ 			netif_inherit_tso_max(ipvlan->dev, dev);
++			ipvlan->dev->needed_headroom = dev->needed_headroom;
++			ipvlan->dev->needed_tailroom = dev->needed_tailroom;
+ 			netdev_update_features(ipvlan->dev);
+ 		}
+ 		break;
+diff --git a/drivers/net/macvlan.c b/drivers/net/macvlan.c
+index 399c8deb35103b..438626c4480eff 100644
+--- a/drivers/net/macvlan.c
++++ b/drivers/net/macvlan.c
+@@ -940,6 +940,8 @@ static int macvlan_init(struct net_device *dev)
+ 	dev->hw_enc_features    |= dev->features;
+ 	netif_inherit_tso_max(dev, lowerdev);
+ 	dev->hard_header_len	= lowerdev->hard_header_len;
++	dev->needed_headroom	= lowerdev->needed_headroom;
++	dev->needed_tailroom	= lowerdev->needed_tailroom;
+ 	macvlan_set_lockdep_class(dev);
+ 
+ 	vlan->pcpu_stats = netdev_alloc_pcpu_stats(struct vlan_pcpu_stats);
+@@ -1822,6 +1824,8 @@ static int macvlan_device_event(struct notifier_block *unused,
+ 	case NETDEV_FEAT_CHANGE:
+ 		list_for_each_entry(vlan, &port->vlans, list) {
+ 			netif_inherit_tso_max(vlan->dev, dev);
++			vlan->dev->needed_headroom = dev->needed_headroom;
++			vlan->dev->needed_tailroom = dev->needed_tailroom;
+ 			netdev_update_features(vlan->dev);
+ 		}
+ 		break;
+diff --git a/drivers/net/veth.c b/drivers/net/veth.c
+index e2fa5ba5a032c9..f34f4b24fbfd24 100644
+--- a/drivers/net/veth.c
++++ b/drivers/net/veth.c
+@@ -731,7 +731,7 @@ static int veth_convert_skb_to_xdp_buff(struct veth_rq *rq,
+ 	u32 frame_sz;
+ 
+ 	if (skb_shared(skb) || skb_head_is_locked(skb) ||
+-	    skb_shinfo(skb)->nr_frags ||
++	    skb_is_nonlinear(skb) ||
+ 	    skb_headroom(skb) < XDP_PACKET_HEADROOM) {
+ 		u32 size, len, max_head_size, off;
+ 		struct sk_buff *nskb;
+@@ -808,7 +808,7 @@ static int veth_convert_skb_to_xdp_buff(struct veth_rq *rq,
+ 	xdp_prepare_buff(xdp, skb->head, skb_headroom(skb),
+ 			 skb_headlen(skb), true);
+ 
+-	if (skb_is_nonlinear(skb)) {
++	if (skb_shinfo(skb)->nr_frags) {
+ 		skb_shinfo(skb)->xdp_frags_size = skb->data_len;
+ 		xdp_buff_set_frags_flag(xdp);
+ 	} else {
+diff --git a/drivers/net/vrf.c b/drivers/net/vrf.c
+index bce55ad2bcd998..8f435f58a8886a 100644
+--- a/drivers/net/vrf.c
++++ b/drivers/net/vrf.c
+@@ -121,16 +121,6 @@ struct net_vrf {
+ 	int			ifindex;
+ };
+ 
+-static void vrf_rx_stats(struct net_device *dev, int len)
+-{
+-	struct pcpu_dstats *dstats = this_cpu_ptr(dev->dstats);
+-
+-	u64_stats_update_begin(&dstats->syncp);
+-	dstats->rx_packets++;
+-	dstats->rx_bytes += len;
+-	u64_stats_update_end(&dstats->syncp);
+-}
+-
+ static void vrf_tx_error(struct net_device *vrf_dev, struct sk_buff *skb)
+ {
+ 	vrf_dev->stats.tx_errors++;
+@@ -150,11 +140,11 @@ static void vrf_get_stats64(struct net_device *dev,
+ 		dstats = per_cpu_ptr(dev->dstats, i);
+ 		do {
+ 			start = u64_stats_fetch_begin(&dstats->syncp);
+-			tbytes = dstats->tx_bytes;
+-			tpkts = dstats->tx_packets;
+-			tdrops = dstats->tx_drops;
+-			rbytes = dstats->rx_bytes;
+-			rpkts = dstats->rx_packets;
++			tbytes = u64_stats_read(&dstats->tx_bytes);
++			tpkts = u64_stats_read(&dstats->tx_packets);
++			tdrops = u64_stats_read(&dstats->tx_drops);
++			rbytes = u64_stats_read(&dstats->rx_bytes);
++			rpkts = u64_stats_read(&dstats->rx_packets);
+ 		} while (u64_stats_fetch_retry(&dstats->syncp, start));
+ 		stats->tx_bytes += tbytes;
+ 		stats->tx_packets += tpkts;
+@@ -395,7 +385,7 @@ static bool qdisc_tx_is_default(const struct net_device *dev)
+ static int vrf_local_xmit(struct sk_buff *skb, struct net_device *dev,
+ 			  struct dst_entry *dst)
+ {
+-	int len = skb->len;
++	unsigned int len = skb->len;
+ 
+ 	skb_orphan(skb);
+ 
+@@ -409,9 +399,9 @@ static int vrf_local_xmit(struct sk_buff *skb, struct net_device *dev,
+ 	skb->protocol = eth_type_trans(skb, dev);
+ 
+ 	if (likely(__netif_rx(skb) == NET_RX_SUCCESS))
+-		vrf_rx_stats(dev, len);
++		dev_dstats_rx_add(dev, len);
+ 	else
+-		this_cpu_inc(dev->dstats->rx_drops);
++		dev_dstats_rx_dropped(dev);
+ 
+ 	return NETDEV_TX_OK;
+ }
+@@ -599,19 +589,14 @@ static netdev_tx_t is_ip_tx_frame(struct sk_buff *skb, struct net_device *dev)
+ 
+ static netdev_tx_t vrf_xmit(struct sk_buff *skb, struct net_device *dev)
+ {
+-	int len = skb->len;
+-	netdev_tx_t ret = is_ip_tx_frame(skb, dev);
++	unsigned int len = skb->len;
++	netdev_tx_t ret;
+ 
+-	if (likely(ret == NET_XMIT_SUCCESS || ret == NET_XMIT_CN)) {
+-		struct pcpu_dstats *dstats = this_cpu_ptr(dev->dstats);
+-
+-		u64_stats_update_begin(&dstats->syncp);
+-		dstats->tx_packets++;
+-		dstats->tx_bytes += len;
+-		u64_stats_update_end(&dstats->syncp);
+-	} else {
+-		this_cpu_inc(dev->dstats->tx_drops);
+-	}
++	ret = is_ip_tx_frame(skb, dev);
++	if (likely(ret == NET_XMIT_SUCCESS || ret == NET_XMIT_CN))
++		dev_dstats_tx_add(dev, len);
++	else
++		dev_dstats_tx_dropped(dev);
+ 
+ 	return ret;
+ }
+@@ -1394,7 +1379,7 @@ static struct sk_buff *vrf_ip6_rcv(struct net_device *vrf_dev,
+ 	if (!is_ndisc) {
+ 		struct net_device *orig_dev = skb->dev;
+ 
+-		vrf_rx_stats(vrf_dev, skb->len);
++		dev_dstats_rx_add(vrf_dev, skb->len);
+ 		skb->dev = vrf_dev;
+ 		skb->skb_iif = vrf_dev->ifindex;
+ 
+@@ -1450,7 +1435,7 @@ static struct sk_buff *vrf_ip_rcv(struct net_device *vrf_dev,
+ 		goto out;
+ 	}
+ 
+-	vrf_rx_stats(vrf_dev, skb->len);
++	dev_dstats_rx_add(vrf_dev, skb->len);
+ 
+ 	if (!list_empty(&vrf_dev->ptype_all)) {
+ 		int err;
+diff --git a/drivers/net/vxlan/vxlan_core.c b/drivers/net/vxlan/vxlan_core.c
+index 9d3546f95fa459..4415c1f6585eac 100644
+--- a/drivers/net/vxlan/vxlan_core.c
++++ b/drivers/net/vxlan/vxlan_core.c
+@@ -1798,13 +1798,13 @@ static int vxlan_rcv(struct sock *sk, struct sk_buff *skb)
+ 
+ 	if (unlikely(!(vxlan->dev->flags & IFF_UP))) {
+ 		rcu_read_unlock();
+-		dev_core_stats_rx_dropped_inc(vxlan->dev);
++		dev_dstats_rx_dropped(vxlan->dev);
+ 		vxlan_vnifilter_count(vxlan, vni, vninode,
+ 				      VXLAN_VNI_STATS_RX_DROPS, 0);
+ 		goto drop;
+ 	}
+ 
+-	dev_sw_netstats_rx_add(vxlan->dev, skb->len);
++	dev_dstats_rx_add(vxlan->dev, skb->len);
+ 	vxlan_vnifilter_count(vxlan, vni, vninode, VXLAN_VNI_STATS_RX, skb->len);
+ 	gro_cells_receive(&vxlan->gro_cells, skb);
+ 
+@@ -1857,8 +1857,8 @@ static int arp_reduce(struct net_device *dev, struct sk_buff *skb, __be32 vni)
+ 	if (dev->flags & IFF_NOARP)
+ 		goto out;
+ 
+-	if (!pskb_may_pull(skb, arp_hdr_len(dev))) {
+-		dev_core_stats_tx_dropped_inc(dev);
++	if (!pskb_network_may_pull(skb, arp_hdr_len(dev))) {
++		dev_dstats_tx_dropped(dev);
+ 		vxlan_vnifilter_count(vxlan, vni, NULL,
+ 				      VXLAN_VNI_STATS_TX_DROPS, 0);
+ 		goto out;
+@@ -1916,7 +1916,7 @@ static int arp_reduce(struct net_device *dev, struct sk_buff *skb, __be32 vni)
+ 		reply->pkt_type = PACKET_HOST;
+ 
+ 		if (netif_rx(reply) == NET_RX_DROP) {
+-			dev_core_stats_rx_dropped_inc(dev);
++			dev_dstats_rx_dropped(dev);
+ 			vxlan_vnifilter_count(vxlan, vni, NULL,
+ 					      VXLAN_VNI_STATS_RX_DROPS, 0);
+ 		}
+@@ -2077,7 +2077,7 @@ static int neigh_reduce(struct net_device *dev, struct sk_buff *skb, __be32 vni)
+ 			goto out;
+ 
+ 		if (netif_rx(reply) == NET_RX_DROP) {
+-			dev_core_stats_rx_dropped_inc(dev);
++			dev_dstats_rx_dropped(dev);
+ 			vxlan_vnifilter_count(vxlan, vni, NULL,
+ 					      VXLAN_VNI_STATS_RX_DROPS, 0);
+ 		}
+@@ -2370,8 +2370,8 @@ static void vxlan_encap_bypass(struct sk_buff *skb, struct vxlan_dev *src_vxlan,
+ {
+ 	union vxlan_addr loopback;
+ 	union vxlan_addr *remote_ip = &dst_vxlan->default_dst.remote_ip;
++	unsigned int len = skb->len;
+ 	struct net_device *dev;
+-	int len = skb->len;
+ 
+ 	skb->pkt_type = PACKET_HOST;
+ 	skb->encapsulation = 0;
+@@ -2398,16 +2398,16 @@ static void vxlan_encap_bypass(struct sk_buff *skb, struct vxlan_dev *src_vxlan,
+ 	if ((dst_vxlan->cfg.flags & VXLAN_F_LEARN) && snoop)
+ 		vxlan_snoop(dev, &loopback, eth_hdr(skb)->h_source, 0, vni);
+ 
+-	dev_sw_netstats_tx_add(src_vxlan->dev, 1, len);
++	dev_dstats_tx_add(src_vxlan->dev, len);
+ 	vxlan_vnifilter_count(src_vxlan, vni, NULL, VXLAN_VNI_STATS_TX, len);
+ 
+ 	if (__netif_rx(skb) == NET_RX_SUCCESS) {
+-		dev_sw_netstats_rx_add(dst_vxlan->dev, len);
++		dev_dstats_rx_add(dst_vxlan->dev, len);
+ 		vxlan_vnifilter_count(dst_vxlan, vni, NULL, VXLAN_VNI_STATS_RX,
+ 				      len);
+ 	} else {
+ drop:
+-		dev_core_stats_rx_dropped_inc(dev);
++		dev_dstats_rx_dropped(dev);
+ 		vxlan_vnifilter_count(dst_vxlan, vni, NULL,
+ 				      VXLAN_VNI_STATS_RX_DROPS, 0);
+ 	}
+@@ -2700,7 +2700,7 @@ out_unlock:
+ 	return;
+ 
+ drop:
+-	dev_core_stats_tx_dropped_inc(dev);
++	dev_dstats_tx_dropped(dev);
+ 	vxlan_vnifilter_count(vxlan, vni, NULL, VXLAN_VNI_STATS_TX_DROPS, 0);
+ 	dev_kfree_skb(skb);
+ 	return;
+@@ -2745,7 +2745,7 @@ static void vxlan_xmit_nh(struct sk_buff *skb, struct net_device *dev,
+ 	return;
+ 
+ drop:
+-	dev_core_stats_tx_dropped_inc(dev);
++	dev_dstats_tx_dropped(dev);
+ 	vxlan_vnifilter_count(netdev_priv(dev), vni, NULL,
+ 			      VXLAN_VNI_STATS_TX_DROPS, 0);
+ 	dev_kfree_skb(skb);
+@@ -2783,7 +2783,7 @@ static netdev_tx_t vxlan_xmit_nhid(struct sk_buff *skb, struct net_device *dev,
+ 	return NETDEV_TX_OK;
+ 
+ drop:
+-	dev_core_stats_tx_dropped_inc(dev);
++	dev_dstats_tx_dropped(dev);
+ 	vxlan_vnifilter_count(netdev_priv(dev), vni, NULL,
+ 			      VXLAN_VNI_STATS_TX_DROPS, 0);
+ 	dev_kfree_skb(skb);
+@@ -2831,8 +2831,8 @@ static netdev_tx_t vxlan_xmit(struct sk_buff *skb, struct net_device *dev)
+ 			return arp_reduce(dev, skb, vni);
+ #if IS_ENABLED(CONFIG_IPV6)
+ 		else if (ntohs(eth->h_proto) == ETH_P_IPV6 &&
+-			 pskb_may_pull(skb, sizeof(struct ipv6hdr) +
+-					    sizeof(struct nd_msg)) &&
++			 pskb_network_may_pull(skb, sizeof(struct ipv6hdr) +
++						    sizeof(struct nd_msg)) &&
+ 			 ipv6_hdr(skb)->nexthdr == IPPROTO_ICMPV6) {
+ 			struct nd_msg *m = (struct nd_msg *)(ipv6_hdr(skb) + 1);
+ 
+@@ -2881,7 +2881,7 @@ static netdev_tx_t vxlan_xmit(struct sk_buff *skb, struct net_device *dev)
+ 			    !is_multicast_ether_addr(eth->h_dest))
+ 				vxlan_fdb_miss(vxlan, eth->h_dest);
+ 
+-			dev_core_stats_tx_dropped_inc(dev);
++			dev_dstats_tx_dropped(dev);
+ 			vxlan_vnifilter_count(vxlan, vni, NULL,
+ 					      VXLAN_VNI_STATS_TX_DROPS, 0);
+ 			kfree_skb(skb);
+@@ -2990,15 +2990,9 @@ static int vxlan_init(struct net_device *dev)
+ 			return err;
+ 	}
+ 
+-	dev->tstats = netdev_alloc_pcpu_stats(struct pcpu_sw_netstats);
+-	if (!dev->tstats) {
+-		err = -ENOMEM;
+-		goto err_vnigroup_uninit;
+-	}
+-
+ 	err = gro_cells_init(&vxlan->gro_cells, dev);
+ 	if (err)
+-		goto err_free_percpu;
++		goto err_vnigroup_uninit;
+ 
+ 	err = vxlan_mdb_init(vxlan);
+ 	if (err)
+@@ -3009,8 +3003,6 @@ static int vxlan_init(struct net_device *dev)
+ 
+ err_gro_cells_destroy:
+ 	gro_cells_destroy(&vxlan->gro_cells);
+-err_free_percpu:
+-	free_percpu(dev->tstats);
+ err_vnigroup_uninit:
+ 	if (vxlan->cfg.flags & VXLAN_F_VNIFILTER)
+ 		vxlan_vnigroup_uninit(vxlan);
+@@ -3041,8 +3033,6 @@ static void vxlan_uninit(struct net_device *dev)
+ 	gro_cells_destroy(&vxlan->gro_cells);
+ 
+ 	vxlan_fdb_delete_default(vxlan, vxlan->cfg.vni);
+-
+-	free_percpu(dev->tstats);
+ }
+ 
+ /* Start ageing timer and join group when device is brought up */
+@@ -3269,6 +3259,7 @@ static void vxlan_setup(struct net_device *dev)
+ 	dev->min_mtu = ETH_MIN_MTU;
+ 	dev->max_mtu = ETH_MAX_MTU;
+ 
++	dev->pcpu_stat_type = NETDEV_PCPU_STAT_DSTATS;
+ 	INIT_LIST_HEAD(&vxlan->next);
+ 
+ 	timer_setup(&vxlan->age_timer, vxlan_cleanup, TIMER_DEFERRABLE);
+diff --git a/drivers/net/vxlan/vxlan_mdb.c b/drivers/net/vxlan/vxlan_mdb.c
+index 73c128c3d90dee..eb919fc05cdf96 100644
+--- a/drivers/net/vxlan/vxlan_mdb.c
++++ b/drivers/net/vxlan/vxlan_mdb.c
+@@ -1326,7 +1326,7 @@ struct vxlan_mdb_entry *vxlan_mdb_entry_skb_get(struct vxlan_dev *vxlan,
+ 
+ 	switch (skb->protocol) {
+ 	case htons(ETH_P_IP):
+-		if (!pskb_may_pull(skb, sizeof(struct iphdr)))
++		if (!pskb_network_may_pull(skb, sizeof(struct iphdr)))
+ 			return NULL;
+ 		group.dst.sa.sa_family = AF_INET;
+ 		group.dst.sin.sin_addr.s_addr = ip_hdr(skb)->daddr;
+@@ -1335,7 +1335,7 @@ struct vxlan_mdb_entry *vxlan_mdb_entry_skb_get(struct vxlan_dev *vxlan,
+ 		break;
+ #if IS_ENABLED(CONFIG_IPV6)
+ 	case htons(ETH_P_IPV6):
+-		if (!pskb_may_pull(skb, sizeof(struct ipv6hdr)))
++		if (!pskb_network_may_pull(skb, sizeof(struct ipv6hdr)))
+ 			return NULL;
+ 		group.dst.sa.sa_family = AF_INET6;
+ 		group.dst.sin6.sin6_addr = ipv6_hdr(skb)->daddr;
+diff --git a/drivers/s390/cio/vfio_ccw_async.c b/drivers/s390/cio/vfio_ccw_async.c
+index 420d89ba7f8387..4aff0b58fa5d56 100644
+--- a/drivers/s390/cio/vfio_ccw_async.c
++++ b/drivers/s390/cio/vfio_ccw_async.c
+@@ -8,6 +8,7 @@
+  */
+ 
+ #include <linux/vfio.h>
++#include <linux/nospec.h>
+ 
+ #include "vfio_ccw_private.h"
+ 
+@@ -24,11 +25,20 @@ static ssize_t vfio_ccw_async_region_read(struct vfio_ccw_private *private,
+ 		return -EINVAL;
+ 
+ 	mutex_lock(&private->io_mutex);
++
++	if (i >= private->num_regions) {
++		ret = -EINVAL;
++		goto out_unlock;
++	}
++
++	i = array_index_nospec(i, private->num_regions);
+ 	region = private->region[i].data;
+ 	if (copy_to_user(buf, (void *)region + pos, count))
+ 		ret = -EFAULT;
+ 	else
+ 		ret = count;
++
++out_unlock:
+ 	mutex_unlock(&private->io_mutex);
+ 	return ret;
+ }
+@@ -48,6 +58,12 @@ static ssize_t vfio_ccw_async_region_write(struct vfio_ccw_private *private,
+ 	if (!mutex_trylock(&private->io_mutex))
+ 		return -EAGAIN;
+ 
++	if (i >= private->num_regions) {
++		ret = -EINVAL;
++		goto out_unlock;
++	}
++
++	i = array_index_nospec(i, private->num_regions);
+ 	region = private->region[i].data;
+ 	if (copy_from_user((void *)region + pos, buf, count)) {
+ 		ret = -EFAULT;
+diff --git a/drivers/s390/cio/vfio_ccw_chp.c b/drivers/s390/cio/vfio_ccw_chp.c
+index d3f3a611f95b41..3284b676334740 100644
+--- a/drivers/s390/cio/vfio_ccw_chp.c
++++ b/drivers/s390/cio/vfio_ccw_chp.c
+@@ -9,6 +9,7 @@
+  */
+ 
+ #include <linux/slab.h>
++#include <linux/nospec.h>
+ #include <linux/vfio.h>
+ #include "vfio_ccw_private.h"
+ 
+@@ -26,6 +27,13 @@ static ssize_t vfio_ccw_schib_region_read(struct vfio_ccw_private *private,
+ 		return -EINVAL;
+ 
+ 	mutex_lock(&private->io_mutex);
++
++	if (i >= private->num_regions) {
++		ret = -EINVAL;
++		goto out;
++	}
++
++	i = array_index_nospec(i, private->num_regions);
+ 	region = private->region[i].data;
+ 
+ 	if (cio_update_schib(sch)) {
+@@ -90,13 +98,19 @@ static ssize_t vfio_ccw_crw_region_read(struct vfio_ccw_private *private,
+ 	if (pos + count > sizeof(*region))
+ 		return -EINVAL;
+ 
++	mutex_lock(&private->io_mutex);
+ 	crw = list_first_entry_or_null(&private->crw,
+ 				       struct vfio_ccw_crw, next);
+ 
+ 	if (crw)
+ 		list_del(&crw->next);
+ 
+-	mutex_lock(&private->io_mutex);
++	if (i >= private->num_regions) {
++		ret = -EINVAL;
++		goto out;
++	}
++
++	i = array_index_nospec(i, private->num_regions);
+ 	region = private->region[i].data;
+ 
+ 	if (crw)
+@@ -109,6 +123,7 @@ static ssize_t vfio_ccw_crw_region_read(struct vfio_ccw_private *private,
+ 
+ 	region->crw = 0;
+ 
++out:
+ 	mutex_unlock(&private->io_mutex);
+ 
+ 	kfree(crw);
+diff --git a/drivers/s390/cio/vfio_ccw_cp.c b/drivers/s390/cio/vfio_ccw_cp.c
+index aafd66305eadeb..933eb4a6cbdb5d 100644
+--- a/drivers/s390/cio/vfio_ccw_cp.c
++++ b/drivers/s390/cio/vfio_ccw_cp.c
+@@ -331,6 +331,7 @@ static struct ccwchain *ccwchain_alloc(struct channel_program *cp, int len)
+ 		goto out_err;
+ 
+ 	list_add_tail(&chain->next, &cp->ccwchain_list);
++	cp->ccwchain_count++;
+ 
+ 	return chain;
+ 
+@@ -375,11 +376,9 @@ static void ccwchain_cda_free(struct ccwchain *chain, int idx)
+ static int ccwchain_calc_length(u64 iova, struct channel_program *cp)
+ {
+ 	struct ccw1 *ccw = cp->guest_cp;
+-	int cnt = 0;
+-
+-	do {
+-		cnt++;
++	int cnt;
+ 
++	for (cnt = 1; cnt <= CCWCHAIN_LEN_MAX; cnt++, ccw++) {
+ 		/*
+ 		 * We want to keep counting if the current CCW has the
+ 		 * command-chaining flag enabled, or if it is a TIC CCW
+@@ -389,15 +388,10 @@ static int ccwchain_calc_length(u64 iova, struct channel_program *cp)
+ 		 * after the TIC, depending on the results of its operation.
+ 		 */
+ 		if (!ccw_is_chain(ccw) && !is_tic_within_range(ccw, iova, cnt))
+-			break;
+-
+-		ccw++;
+-	} while (cnt < CCWCHAIN_LEN_MAX + 1);
+-
+-	if (cnt == CCWCHAIN_LEN_MAX + 1)
+-		cnt = -EINVAL;
++			return cnt;
++	}
+ 
+-	return cnt;
++	return -EINVAL;
+ }
+ 
+ static int tic_target_chain_exists(struct ccw1 *tic, struct channel_program *cp)
+@@ -438,6 +432,10 @@ static int ccwchain_handle_ccw(u32 cda, struct channel_program *cp)
+ 	if (len < 0)
+ 		return len;
+ 
++	/* Limit number of chains in a single channel program */
++	if (cp->ccwchain_count >= CCWCHAIN_COUNT_MAX)
++		return -EINVAL;
++
+ 	/* Need alloc a new chain for this one. */
+ 	chain = ccwchain_alloc(cp, len);
+ 	if (!chain)
+@@ -725,6 +723,7 @@ int cp_init(struct channel_program *cp, union orb *orb)
+ 			vdev->dev,
+ 			"Prefetching channel program even though prefetch not specified in ORB");
+ 
++	cp->ccwchain_count = 0;
+ 	INIT_LIST_HEAD(&cp->ccwchain_list);
+ 	memcpy(&cp->orb, orb, sizeof(*orb));
+ 
+@@ -940,17 +939,23 @@ void cp_update_scsw(struct channel_program *cp, union scsw *scsw)
+  */
+ bool cp_iova_pinned(struct channel_program *cp, u64 iova, u64 length)
+ {
++	struct vfio_ccw_private *private =
++		container_of(cp, struct vfio_ccw_private, cp);
+ 	struct ccwchain *chain;
+ 	int i;
+ 
+ 	if (!cp->initialized)
+ 		return false;
+ 
++	mutex_lock(&private->io_mutex);
+ 	list_for_each_entry(chain, &cp->ccwchain_list, next) {
+ 		for (i = 0; i < chain->ch_len; i++)
+-			if (page_array_iova_pinned(&chain->ch_pa[i], iova, length))
++			if (page_array_iova_pinned(&chain->ch_pa[i], iova, length)) {
++				mutex_unlock(&private->io_mutex);
+ 				return true;
++			}
+ 	}
++	mutex_unlock(&private->io_mutex);
+ 
+ 	return false;
+ }
+diff --git a/drivers/s390/cio/vfio_ccw_cp.h b/drivers/s390/cio/vfio_ccw_cp.h
+index fc31eb69980724..a9b1d8dbc6f655 100644
+--- a/drivers/s390/cio/vfio_ccw_cp.h
++++ b/drivers/s390/cio/vfio_ccw_cp.h
+@@ -23,11 +23,18 @@
+  */
+ #define CCWCHAIN_LEN_MAX	256
+ 
++/*
++ * Maximum number of chains
++ */
++#define CCWCHAIN_COUNT_MAX	16
++
+ /**
+  * struct channel_program - manage information for channel program
+  * @ccwchain_list: list head of ccwchains
+  * @orb: orb for the currently processed ssch request
+  * @initialized: whether this instance is actually initialized
++ * @guest_cp: copy of guest channel program
++ * @ccwchain_count: number of channel program segments (linked by TIC)
+  *
+  * @ccwchain_list is the head of a ccwchain list, that contents the
+  * translated result of the guest channel program that pointed out by
+@@ -38,6 +45,7 @@ struct channel_program {
+ 	union orb orb;
+ 	bool initialized;
+ 	struct ccw1 *guest_cp;
++	unsigned int ccwchain_count;
+ };
+ 
+ int cp_init(struct channel_program *cp, union orb *orb);
+diff --git a/drivers/s390/cio/vfio_ccw_drv.c b/drivers/s390/cio/vfio_ccw_drv.c
+index a3e25bdd6a76b7..884e2e5e410490 100644
+--- a/drivers/s390/cio/vfio_ccw_drv.c
++++ b/drivers/s390/cio/vfio_ccw_drv.c
+@@ -91,6 +91,7 @@ void vfio_ccw_sch_io_todo(struct work_struct *work)
+ 
+ 	is_final = !(scsw_actl(&irb->scsw) &
+ 		     (SCSW_ACTL_DEVACT | SCSW_ACTL_SCHACT));
++	mutex_lock(&private->io_mutex);
+ 	if (scsw_is_solicited(&irb->scsw)) {
+ 		cp_update_scsw(&private->cp, &irb->scsw);
+ 		if (is_final && private->state == VFIO_CCW_STATE_CP_PENDING) {
+@@ -98,9 +99,7 @@ void vfio_ccw_sch_io_todo(struct work_struct *work)
+ 			cp_is_finished = true;
+ 		}
+ 	}
+-	mutex_lock(&private->io_mutex);
+ 	memcpy(private->io_region->irb_area, irb, sizeof(*irb));
+-	mutex_unlock(&private->io_mutex);
+ 
+ 	/*
+ 	 * Reset to IDLE only if processing of a channel program
+@@ -110,6 +109,7 @@ void vfio_ccw_sch_io_todo(struct work_struct *work)
+ 	 */
+ 	if (cp_is_finished)
+ 		private->state = VFIO_CCW_STATE_IDLE;
++	mutex_unlock(&private->io_mutex);
+ 
+ 	if (private->io_trigger)
+ 		eventfd_signal(private->io_trigger, 1);
+@@ -125,6 +125,17 @@ void vfio_ccw_crw_todo(struct work_struct *work)
+ 		eventfd_signal(private->crw_trigger, 1);
+ }
+ 
++void vfio_ccw_notoper_todo(struct work_struct *work)
++{
++	struct vfio_ccw_private *private;
++
++	private = container_of(work, struct vfio_ccw_private, notoper_work);
++
++	mutex_lock(&private->io_mutex);
++	cp_free(&private->cp);
++	mutex_unlock(&private->io_mutex);
++}
++
+ /*
+  * Css driver callbacks
+  */
+diff --git a/drivers/s390/cio/vfio_ccw_fsm.c b/drivers/s390/cio/vfio_ccw_fsm.c
+index 09877b46181d46..29848cebfc63d1 100644
+--- a/drivers/s390/cio/vfio_ccw_fsm.c
++++ b/drivers/s390/cio/vfio_ccw_fsm.c
+@@ -170,8 +170,8 @@ static void fsm_notoper(struct vfio_ccw_private *private,
+ 	css_sched_sch_todo(sch, SCH_TODO_UNREG);
+ 	private->state = VFIO_CCW_STATE_NOT_OPER;
+ 
+-	/* This is usually handled during CLOSE event */
+-	cp_free(&private->cp);
++	/* This routine could be called from IRQ context, so defer */
++	queue_work(vfio_ccw_work_q, &private->notoper_work);
+ }
+ 
+ /*
+@@ -410,7 +410,11 @@ static void fsm_close(struct vfio_ccw_private *private,
+ 
+ 	private->state = VFIO_CCW_STATE_STANDBY;
+ 	spin_unlock_irq(&sch->lock);
++
++	mutex_lock(&private->io_mutex);
+ 	cp_free(&private->cp);
++	mutex_unlock(&private->io_mutex);
++
+ 	return;
+ 
+ err_unlock:
+diff --git a/drivers/s390/cio/vfio_ccw_ops.c b/drivers/s390/cio/vfio_ccw_ops.c
+index cba4971618ff6d..67acfa2533eef7 100644
+--- a/drivers/s390/cio/vfio_ccw_ops.c
++++ b/drivers/s390/cio/vfio_ccw_ops.c
+@@ -54,6 +54,7 @@ static int vfio_ccw_mdev_init_dev(struct vfio_device *vdev)
+ 	INIT_LIST_HEAD(&private->crw);
+ 	INIT_WORK(&private->io_work, vfio_ccw_sch_io_todo);
+ 	INIT_WORK(&private->crw_work, vfio_ccw_crw_todo);
++	INIT_WORK(&private->notoper_work, vfio_ccw_notoper_todo);
+ 
+ 	private->cp.guest_cp = kcalloc(CCWCHAIN_LEN_MAX, sizeof(struct ccw1),
+ 				       GFP_KERNEL);
+@@ -132,6 +133,20 @@ static void vfio_ccw_mdev_release_dev(struct vfio_device *vdev)
+ 		container_of(vdev, struct vfio_ccw_private, vdev);
+ 	struct vfio_ccw_crw *crw, *temp;
+ 
++	/*
++	 * Ensure these work items are fully drained, so none can
++	 * fire after being released.
++	 *
++	 * notoper_work should have nothing to do here, because only
++	 * open devices could have channel_program resources in use
++	 * and those would be released during close. Nevertheless,
++	 * call flush here as well to be certain anything that was
++	 * allocated is freed.
++	 */
++	cancel_work_sync(&private->io_work);
++	cancel_work_sync(&private->crw_work);
++	flush_work(&private->notoper_work);
++
+ 	list_for_each_entry_safe(crw, temp, &private->crw, next) {
+ 		list_del(&crw->next);
+ 		kfree(crw);
+@@ -203,6 +218,19 @@ static void vfio_ccw_mdev_close_device(struct vfio_device *vdev)
+ 		container_of(vdev, struct vfio_ccw_private, vdev);
+ 
+ 	vfio_ccw_fsm_event(private, VFIO_CCW_EVENT_CLOSE);
++
++	/*
++	 * Ensure these work items are drained, in the event the
++	 * device is re-opened instead of released.
++	 *
++	 * notoper_work needs to be given a chance to run if it
++	 * is queued, so any memory associated with the channel
++	 * program can be returned.
++	 */
++	cancel_work_sync(&private->io_work);
++	cancel_work_sync(&private->crw_work);
++	flush_work(&private->notoper_work);
++
+ 	vfio_ccw_unregister_dev_regions(private);
+ }
+ 
+@@ -244,6 +272,7 @@ static ssize_t vfio_ccw_mdev_read(struct vfio_device *vdev,
+ 		return vfio_ccw_mdev_read_io_region(private, buf, count, ppos);
+ 	default:
+ 		index -= VFIO_CCW_NUM_REGIONS;
++		index = array_index_nospec(index, private->num_regions);
+ 		return private->region[index].ops->read(private, buf, count,
+ 							ppos);
+ 	}
+@@ -296,6 +325,7 @@ static ssize_t vfio_ccw_mdev_write(struct vfio_device *vdev,
+ 		return vfio_ccw_mdev_write_io_region(private, buf, count, ppos);
+ 	default:
+ 		index -= VFIO_CCW_NUM_REGIONS;
++		index = array_index_nospec(index, private->num_regions);
+ 		return private->region[index].ops->write(private, buf, count,
+ 							 ppos);
+ 	}
+@@ -338,11 +368,8 @@ static int vfio_ccw_mdev_get_region_info(struct vfio_ccw_private *private,
+ 		    VFIO_CCW_NUM_REGIONS + private->num_regions)
+ 			return -EINVAL;
+ 
+-		info->index = array_index_nospec(info->index,
+-						 VFIO_CCW_NUM_REGIONS +
+-						 private->num_regions);
+-
+ 		i = info->index - VFIO_CCW_NUM_REGIONS;
++		i = array_index_nospec(i, private->num_regions);
+ 
+ 		info->offset = VFIO_CCW_INDEX_TO_OFFSET(info->index);
+ 		info->size = private->region[i].size;
+diff --git a/drivers/s390/cio/vfio_ccw_private.h b/drivers/s390/cio/vfio_ccw_private.h
+index b62bbc5c637692..0e30497da600f8 100644
+--- a/drivers/s390/cio/vfio_ccw_private.h
++++ b/drivers/s390/cio/vfio_ccw_private.h
+@@ -88,7 +88,8 @@ struct vfio_ccw_parent {
+  * @state: internal state of the device
+  * @completion: synchronization helper of the I/O completion
+  * @io_region: MMIO region to input/output I/O arguments/results
+- * @io_mutex: protect against concurrent update of I/O regions
++ * @io_mutex: protect against concurrent update of I/O resources
++ *            and @cp lifecycle
+  * @region: additional regions for other subchannel operations
+  * @cmd_region: MMIO region for asynchronous I/O commands other than START
+  * @schib_region: MMIO region for SCHIB information
+@@ -102,6 +103,7 @@ struct vfio_ccw_parent {
+  * @req_trigger: eventfd ctx for signaling userspace to return device
+  * @io_work: work for deferral process of I/O handling
+  * @crw_work: work for deferral process of CRW handling
++ * @notoper_work: work for deferred processing in not-operational state
+  */
+ struct vfio_ccw_private {
+ 	struct vfio_device vdev;
+@@ -125,11 +127,13 @@ struct vfio_ccw_private {
+ 	struct eventfd_ctx	*req_trigger;
+ 	struct work_struct	io_work;
+ 	struct work_struct	crw_work;
++	struct work_struct	notoper_work;
+ } __aligned(8);
+ 
+ int vfio_ccw_sch_quiesce(struct subchannel *sch);
+ void vfio_ccw_sch_io_todo(struct work_struct *work);
+ void vfio_ccw_crw_todo(struct work_struct *work);
++void vfio_ccw_notoper_todo(struct work_struct *work);
+ 
+ extern struct mdev_driver vfio_ccw_mdev_driver;
+ 
+diff --git a/drivers/s390/net/qeth_core_main.c b/drivers/s390/net/qeth_core_main.c
+index 8f34d4eee0129c..98750414c2c94f 100644
+--- a/drivers/s390/net/qeth_core_main.c
++++ b/drivers/s390/net/qeth_core_main.c
+@@ -4710,6 +4710,9 @@ static int qeth_snmp_command(struct qeth_card *card, char __user *udata)
+ 	if (req_len > QETH_BUFSIZE)
+ 		return -EINVAL;
+ 
++	if (qinfo.udata_len < sizeof(struct qeth_snmp_ureq_hdr))
++		return -EINVAL;
++
+ 	iob = qeth_get_adapter_cmd(card, IPA_SETADP_SET_SNMP_CONTROL, req_len);
+ 	if (!iob)
+ 		return -ENOMEM;
+diff --git a/drivers/s390/net/qeth_l3_main.c b/drivers/s390/net/qeth_l3_main.c
+index 04c64ce0a1ca1a..15558d2857b44a 100644
+--- a/drivers/s390/net/qeth_l3_main.c
++++ b/drivers/s390/net/qeth_l3_main.c
+@@ -1415,6 +1415,11 @@ static int qeth_l3_arp_query(struct qeth_card *card, char __user *udata)
+ 		rc = -EFAULT;
+ 		goto out;
+ 	}
++
++	if (qinfo.udata_len < QETH_QARP_ENTRIES_OFFSET) {
++		rc = -EINVAL;
++		goto out;
++	}
+ 	qinfo.udata = kzalloc(qinfo.udata_len, GFP_KERNEL);
+ 	if (!qinfo.udata) {
+ 		rc = -ENOMEM;
+diff --git a/drivers/video/fbdev/core/fb_io_fops.c b/drivers/video/fbdev/core/fb_io_fops.c
+index 871b829521af35..15cfef88efbdd3 100644
+--- a/drivers/video/fbdev/core/fb_io_fops.c
++++ b/drivers/video/fbdev/core/fb_io_fops.c
+@@ -57,6 +57,14 @@ ssize_t fb_io_read(struct fb_info *info, char __user *buf, size_t count, loff_t
+ 		buf += c;
+ 		cnt += c;
+ 		count -= c;
++
++		/*
++		 * If there was a partial copy, the user buffer is faulty.
++		 * Break out to avoid over-advancing the src pointer and
++		 * reading out of bounds in the next iteration.
++		 */
++		if (trailing)
++			break;
+ 	}
+ 
+ 	kfree(buffer);
+diff --git a/fs/binfmt_elf.c b/fs/binfmt_elf.c
+index e4348dd76658ec..0fbf5474b8fe16 100644
+--- a/fs/binfmt_elf.c
++++ b/fs/binfmt_elf.c
+@@ -1287,7 +1287,7 @@ out_free_interp:
+ 		}
+ 		reloc_func_desc = interp_load_addr;
+ 
+-		allow_write_access(interpreter);
++		exe_file_allow_write_access(interpreter);
+ 		fput(interpreter);
+ 
+ 		kfree(interp_elf_ex);
+@@ -1396,7 +1396,7 @@ out_free_dentry:
+ 	kfree(interp_elf_ex);
+ 	kfree(interp_elf_phdata);
+ out_free_file:
+-	allow_write_access(interpreter);
++	exe_file_allow_write_access(interpreter);
+ 	if (interpreter)
+ 		fput(interpreter);
+ out_free_ph:
+diff --git a/fs/binfmt_elf_fdpic.c b/fs/binfmt_elf_fdpic.c
+index d872ccb5f4b2d9..70b8a987de2235 100644
+--- a/fs/binfmt_elf_fdpic.c
++++ b/fs/binfmt_elf_fdpic.c
+@@ -398,7 +398,7 @@ static int load_elf_fdpic_binary(struct linux_binprm *bprm)
+ 			goto error;
+ 		}
+ 
+-		allow_write_access(interpreter);
++		exe_file_allow_write_access(interpreter);
+ 		fput(interpreter);
+ 		interpreter = NULL;
+ 	}
+@@ -471,7 +471,7 @@ static int load_elf_fdpic_binary(struct linux_binprm *bprm)
+ 
+ error:
+ 	if (interpreter) {
+-		allow_write_access(interpreter);
++		exe_file_allow_write_access(interpreter);
+ 		fput(interpreter);
+ 	}
+ 	kfree(interpreter_name);
+diff --git a/fs/binfmt_misc.c b/fs/binfmt_misc.c
+index 3b96c7ca7cfcd7..bf68e3b4cbb80b 100644
+--- a/fs/binfmt_misc.c
++++ b/fs/binfmt_misc.c
+@@ -163,8 +163,10 @@ static Node *get_binfmt_handler(struct linux_binprm *bprm)
+ static void put_binfmt_handler(Node *e)
+ {
+ 	if (refcount_dec_and_test(&e->users)) {
+-		if (e->flags & MISC_FMT_OPEN_FILE)
++		if (e->flags & MISC_FMT_OPEN_FILE) {
++			exe_file_allow_write_access(e->interp_file);
+ 			filp_close(e->interp_file, NULL);
++		}
+ 		kfree(e);
+ 	}
+ }
+@@ -218,8 +220,14 @@ static int load_misc_binary(struct linux_binprm *bprm)
+ 
+ 	if (fmt->flags & MISC_FMT_OPEN_FILE) {
+ 		interp_file = file_clone_open(fmt->interp_file);
+-		if (!IS_ERR(interp_file))
+-			deny_write_access(interp_file);
++		if (!IS_ERR(interp_file)) {
++			int err = exe_file_deny_write_access(interp_file);
++
++			if (err) {
++				fput(interp_file);
++				interp_file = ERR_PTR(err);
++			}
++		}
+ 	} else {
+ 		interp_file = open_exec(fmt->interpreter);
+ 	}
+diff --git a/fs/btrfs/block-group.c b/fs/btrfs/block-group.c
+index 3bc6c99ed2e38d..a78b233cb89813 100644
+--- a/fs/btrfs/block-group.c
++++ b/fs/btrfs/block-group.c
+@@ -2929,6 +2929,7 @@ int btrfs_inc_block_group_ro(struct btrfs_block_group *cache,
+ 			     bool do_chunk_alloc)
+ {
+ 	struct btrfs_fs_info *fs_info = cache->fs_info;
++	struct btrfs_space_info *space_info = cache->space_info;
+ 	struct btrfs_trans_handle *trans;
+ 	struct btrfs_root *root = btrfs_block_group_root(fs_info);
+ 	u64 alloc_flags;
+@@ -2981,7 +2982,7 @@ int btrfs_inc_block_group_ro(struct btrfs_block_group *cache,
+ 		 */
+ 		alloc_flags = btrfs_get_alloc_profile(fs_info, cache->flags);
+ 		if (alloc_flags != cache->flags) {
+-			ret = btrfs_chunk_alloc(trans, alloc_flags,
++			ret = btrfs_chunk_alloc(trans, space_info, alloc_flags,
+ 						CHUNK_ALLOC_FORCE);
+ 			/*
+ 			 * ENOSPC is allowed here, we may have enough space
+@@ -3009,15 +3010,15 @@ int btrfs_inc_block_group_ro(struct btrfs_block_group *cache,
+ 	    (cache->flags & BTRFS_BLOCK_GROUP_SYSTEM))
+ 		goto unlock_out;
+ 
+-	alloc_flags = btrfs_get_alloc_profile(fs_info, cache->space_info->flags);
+-	ret = btrfs_chunk_alloc(trans, alloc_flags, CHUNK_ALLOC_FORCE);
++	alloc_flags = btrfs_get_alloc_profile(fs_info, space_info->flags);
++	ret = btrfs_chunk_alloc(trans, space_info, alloc_flags, CHUNK_ALLOC_FORCE);
+ 	if (ret < 0)
+ 		goto out;
+ 	/*
+ 	 * We have allocated a new chunk. We also need to activate that chunk to
+ 	 * grant metadata tickets for zoned filesystem.
+ 	 */
+-	ret = btrfs_zoned_activate_one_bg(fs_info, cache->space_info, true);
++	ret = btrfs_zoned_activate_one_bg(space_info, true);
+ 	if (ret < 0)
+ 		goto out;
+ 
+@@ -3875,8 +3876,15 @@ static int should_alloc_chunk(const struct btrfs_fs_info *fs_info,
+ int btrfs_force_chunk_alloc(struct btrfs_trans_handle *trans, u64 type)
+ {
+ 	u64 alloc_flags = btrfs_get_alloc_profile(trans->fs_info, type);
++	struct btrfs_space_info *space_info;
++
++	space_info = btrfs_find_space_info(trans->fs_info, type);
++	if (!space_info) {
++		DEBUG_WARN();
++		return -EINVAL;
++	}
+ 
+-	return btrfs_chunk_alloc(trans, alloc_flags, CHUNK_ALLOC_FORCE);
++	return btrfs_chunk_alloc(trans, space_info, alloc_flags, CHUNK_ALLOC_FORCE);
+ }
+ 
+ static struct btrfs_block_group *do_chunk_alloc(struct btrfs_trans_handle *trans, u64 flags)
+@@ -4072,6 +4080,8 @@ out:
+  *
+  * This function, btrfs_chunk_alloc(), belongs to phase 1.
+  *
++ * @space_info: specify which space_info the new chunk should belong to.
++ *
+  * If @force is CHUNK_ALLOC_FORCE:
+  *    - return 1 if it successfully allocates a chunk,
+  *    - return errors including -ENOSPC otherwise.
+@@ -4080,11 +4090,11 @@ out:
+  *    - return 1 if it successfully allocates a chunk,
+  *    - return errors including -ENOSPC otherwise.
+  */
+-int btrfs_chunk_alloc(struct btrfs_trans_handle *trans, u64 flags,
++int btrfs_chunk_alloc(struct btrfs_trans_handle *trans,
++		      struct btrfs_space_info *space_info, u64 flags,
+ 		      enum btrfs_chunk_alloc_enum force)
+ {
+ 	struct btrfs_fs_info *fs_info = trans->fs_info;
+-	struct btrfs_space_info *space_info;
+ 	struct btrfs_block_group *ret_bg;
+ 	bool wait_for_alloc = false;
+ 	bool should_alloc = false;
+@@ -4123,9 +4133,6 @@ int btrfs_chunk_alloc(struct btrfs_trans_handle *trans, u64 flags,
+ 	if (flags & BTRFS_BLOCK_GROUP_SYSTEM)
+ 		return -ENOSPC;
+ 
+-	space_info = btrfs_find_space_info(fs_info, flags);
+-	ASSERT(space_info);
+-
+ 	do {
+ 		spin_lock(&space_info->lock);
+ 		if (force < space_info->force_alloc)
+@@ -4273,25 +4280,29 @@ static void reserve_chunk_space(struct btrfs_trans_handle *trans,
+ 		if (IS_ERR(bg)) {
+ 			ret = PTR_ERR(bg);
+ 		} else {
++			int activate_ret;
++
+ 			/*
+ 			 * We have a new chunk. We also need to activate it for
+ 			 * zoned filesystem.
+ 			 */
+-			ret = btrfs_zoned_activate_one_bg(fs_info, info, true);
+-			if (ret < 0)
+-				return;
+-
+-			/*
+-			 * If we fail to add the chunk item here, we end up
+-			 * trying again at phase 2 of chunk allocation, at
+-			 * btrfs_create_pending_block_groups(). So ignore
+-			 * any error here. An ENOSPC here could happen, due to
+-			 * the cases described at do_chunk_alloc() - the system
+-			 * block group we just created was just turned into RO
+-			 * mode by a scrub for example, or a running discard
+-			 * temporarily removed its free space entries, etc.
+-			 */
+-			btrfs_chunk_alloc_add_chunk_item(trans, bg);
++			activate_ret = btrfs_zoned_activate_one_bg(info, true);
++			if (activate_ret < 0) {
++				ret = activate_ret;
++			} else {
++				/*
++				 * If we fail to add the chunk item here, we end
++				 * up trying again at phase 2 of chunk allocation,
++				 * at btrfs_create_pending_block_groups(). So
++				 * ignore any error here. An ENOSPC here could
++				 * happen, due to the cases described at
++				 * do_chunk_alloc() - the system block group we
++				 * just created was just turned into RO mode by a
++				 * scrub for example, or a running discard
++				 * temporarily removed its free space entries, etc.
++				 */
++				btrfs_chunk_alloc_add_chunk_item(trans, bg);
++			}
+ 		}
+ 	}
+ 
+diff --git a/fs/btrfs/block-group.h b/fs/btrfs/block-group.h
+index a8a6a21e393d2e..509c963e4e1e20 100644
+--- a/fs/btrfs/block-group.h
++++ b/fs/btrfs/block-group.h
+@@ -327,7 +327,8 @@ int btrfs_add_reserved_bytes(struct btrfs_block_group *cache,
+ 			     bool force_wrong_size_class);
+ void btrfs_free_reserved_bytes(struct btrfs_block_group *cache,
+ 			       u64 num_bytes, int delalloc);
+-int btrfs_chunk_alloc(struct btrfs_trans_handle *trans, u64 flags,
++int btrfs_chunk_alloc(struct btrfs_trans_handle *trans,
++		      struct btrfs_space_info *space_info, u64 flags,
+ 		      enum btrfs_chunk_alloc_enum force);
+ int btrfs_force_chunk_alloc(struct btrfs_trans_handle *trans, u64 type);
+ void check_system_chunk(struct btrfs_trans_handle *trans, const u64 type);
+diff --git a/fs/btrfs/extent-tree.c b/fs/btrfs/extent-tree.c
+index 72d32a254cdb5c..ebb94ec9f3d702 100644
+--- a/fs/btrfs/extent-tree.c
++++ b/fs/btrfs/extent-tree.c
+@@ -4034,6 +4034,7 @@ static int can_allocate_chunk(struct btrfs_fs_info *fs_info,
+ static int find_free_extent_update_loop(struct btrfs_fs_info *fs_info,
+ 					struct btrfs_key *ins,
+ 					struct find_free_extent_ctl *ffe_ctl,
++					struct btrfs_space_info *space_info,
+ 					bool full_search)
+ {
+ 	struct btrfs_root *root = fs_info->chunk_root;
+@@ -4088,7 +4089,7 @@ static int find_free_extent_update_loop(struct btrfs_fs_info *fs_info,
+ 				return ret;
+ 			}
+ 
+-			ret = btrfs_chunk_alloc(trans, ffe_ctl->flags,
++			ret = btrfs_chunk_alloc(trans, space_info, ffe_ctl->flags,
+ 						CHUNK_ALLOC_FORCE_FOR_EXTENT);
+ 
+ 			/* Do not bail out on ENOSPC since we can do more. */
+@@ -4488,7 +4489,8 @@ loop:
+ 	}
+ 	up_read(&space_info->groups_sem);
+ 
+-	ret = find_free_extent_update_loop(fs_info, ins, ffe_ctl, full_search);
++	ret = find_free_extent_update_loop(fs_info, ins, ffe_ctl, space_info,
++					   full_search);
+ 	if (ret > 0)
+ 		goto search;
+ 
+diff --git a/fs/btrfs/messages.h b/fs/btrfs/messages.h
+index 1ae6f8e23e071c..dd3647f5530ac2 100644
+--- a/fs/btrfs/messages.h
++++ b/fs/btrfs/messages.h
+@@ -181,6 +181,13 @@ do {								\
+ #define ASSERT(expr)	(void)(expr)
+ #endif
+ 
++#ifdef CONFIG_BTRFS_DEBUG
++/* Verbose warning only under debug build. */
++#define DEBUG_WARN(args...)			WARN(1, KERN_ERR args)
++#else
++#define DEBUG_WARN(...)				do {} while(0)
++#endif
++
+ __printf(5, 6)
+ __cold
+ void __btrfs_handle_fs_error(struct btrfs_fs_info *fs_info, const char *function,
+diff --git a/fs/btrfs/space-info.c b/fs/btrfs/space-info.c
+index a54649a5e07855..a50f0db7563375 100644
+--- a/fs/btrfs/space-info.c
++++ b/fs/btrfs/space-info.c
+@@ -807,7 +807,7 @@ static void flush_space(struct btrfs_fs_info *fs_info,
+ 			ret = PTR_ERR(trans);
+ 			break;
+ 		}
+-		ret = btrfs_chunk_alloc(trans,
++		ret = btrfs_chunk_alloc(trans, space_info,
+ 				btrfs_get_alloc_profile(fs_info, space_info->flags),
+ 				(state == ALLOC_CHUNK) ? CHUNK_ALLOC_NO_FORCE :
+ 					CHUNK_ALLOC_FORCE);
+diff --git a/fs/btrfs/transaction.c b/fs/btrfs/transaction.c
+index 8de686b83adbf2..04367e5dc96a9f 100644
+--- a/fs/btrfs/transaction.c
++++ b/fs/btrfs/transaction.c
+@@ -729,9 +729,10 @@ got_it:
+ 	 * value here.
+ 	 */
+ 	if (do_chunk_alloc && num_bytes) {
+-		u64 flags = h->block_rsv->space_info->flags;
++		struct btrfs_space_info *space_info = h->block_rsv->space_info;
++		u64 flags = space_info->flags;
+ 
+-		btrfs_chunk_alloc(h, btrfs_get_alloc_profile(fs_info, flags),
++		btrfs_chunk_alloc(h, space_info, btrfs_get_alloc_profile(fs_info, flags),
+ 				  CHUNK_ALLOC_NO_FORCE);
+ 	}
+ 
+diff --git a/fs/btrfs/zoned.c b/fs/btrfs/zoned.c
+index 9962ae292b1289..b704df009fc5a2 100644
+--- a/fs/btrfs/zoned.c
++++ b/fs/btrfs/zoned.c
+@@ -2457,10 +2457,9 @@ int btrfs_zone_finish_one_bg(struct btrfs_fs_info *fs_info)
+ 	return ret < 0 ? ret : 1;
+ }
+ 
+-int btrfs_zoned_activate_one_bg(struct btrfs_fs_info *fs_info,
+-				struct btrfs_space_info *space_info,
+-				bool do_finish)
++int btrfs_zoned_activate_one_bg(struct btrfs_space_info *space_info, bool do_finish)
+ {
++	struct btrfs_fs_info *fs_info = space_info->fs_info;
+ 	struct btrfs_block_group *bg;
+ 	int index;
+ 
+diff --git a/fs/btrfs/zoned.h b/fs/btrfs/zoned.h
+index c18f31d3dc25f6..2cc73218dcd517 100644
+--- a/fs/btrfs/zoned.h
++++ b/fs/btrfs/zoned.h
+@@ -81,8 +81,7 @@ bool btrfs_zoned_should_reclaim(const struct btrfs_fs_info *fs_info);
+ void btrfs_zoned_release_data_reloc_bg(struct btrfs_fs_info *fs_info, u64 logical,
+ 				       u64 length);
+ int btrfs_zone_finish_one_bg(struct btrfs_fs_info *fs_info);
+-int btrfs_zoned_activate_one_bg(struct btrfs_fs_info *fs_info,
+-				struct btrfs_space_info *space_info, bool do_finish);
++int btrfs_zoned_activate_one_bg(struct btrfs_space_info *space_info, bool do_finish);
+ void btrfs_check_active_zone_reservation(struct btrfs_fs_info *fs_info);
+ #else /* CONFIG_BLK_DEV_ZONED */
+ static inline int btrfs_get_dev_zone(struct btrfs_device *device, u64 pos,
+@@ -253,8 +252,7 @@ static inline int btrfs_zone_finish_one_bg(struct btrfs_fs_info *fs_info)
+ 	return 1;
+ }
+ 
+-static inline int btrfs_zoned_activate_one_bg(struct btrfs_fs_info *fs_info,
+-					      struct btrfs_space_info *space_info,
++static inline int btrfs_zoned_activate_one_bg(struct btrfs_space_info *space_info,
+ 					      bool do_finish)
+ {
+ 	/* Consider all the block groups are active */
+diff --git a/fs/ceph/addr.c b/fs/ceph/addr.c
+index 6e0f8c1a844786..7d04b301ea3cfd 100644
+--- a/fs/ceph/addr.c
++++ b/fs/ceph/addr.c
+@@ -810,32 +810,6 @@ static int writepage_nounlock(struct page *page, struct writeback_control *wbc)
+ 	return err;
+ }
+ 
+-static int ceph_writepage(struct page *page, struct writeback_control *wbc)
+-{
+-	int err;
+-	struct inode *inode = page->mapping->host;
+-	BUG_ON(!inode);
+-	ihold(inode);
+-
+-	if (wbc->sync_mode == WB_SYNC_NONE &&
+-	    ceph_inode_to_fs_client(inode)->write_congested) {
+-		redirty_page_for_writepage(wbc, page);
+-		return AOP_WRITEPAGE_ACTIVATE;
+-	}
+-
+-	wait_on_page_fscache(page);
+-
+-	err = writepage_nounlock(page, wbc);
+-	if (err == -ERESTARTSYS) {
+-		/* direct memory reclaimer was killed by SIGKILL. return 0
+-		 * to prevent caller from setting mapping/page error */
+-		err = 0;
+-	}
+-	unlock_page(page);
+-	iput(inode);
+-	return err;
+-}
+-
+ /*
+  * async writeback completion handler.
+  *
+@@ -1586,7 +1560,6 @@ out:
+ const struct address_space_operations ceph_aops = {
+ 	.read_folio = netfs_read_folio,
+ 	.readahead = netfs_readahead,
+-	.writepage = ceph_writepage,
+ 	.writepages = ceph_writepages_start,
+ 	.write_begin = ceph_write_begin,
+ 	.write_end = ceph_write_end,
+@@ -1594,6 +1567,7 @@ const struct address_space_operations ceph_aops = {
+ 	.invalidate_folio = ceph_invalidate_folio,
+ 	.release_folio = ceph_release_folio,
+ 	.direct_IO = noop_direct_IO,
++	.migrate_folio = filemap_migrate_folio,
+ };
+ 
+ static void ceph_block_sigs(sigset_t *oldset)
+@@ -1710,8 +1684,8 @@ static vm_fault_t ceph_page_mkwrite(struct vm_fault *vmf)
+ 	struct ceph_inode_info *ci = ceph_inode(inode);
+ 	struct ceph_file_info *fi = vma->vm_file->private_data;
+ 	struct ceph_cap_flush *prealloc_cf;
+-	struct page *page = vmf->page;
+-	loff_t off = page_offset(page);
++	struct folio *folio = page_folio(vmf->page);
++	loff_t off = folio_pos(folio);
+ 	loff_t size = i_size_read(inode);
+ 	size_t len;
+ 	int want, got, err;
+@@ -1728,10 +1702,10 @@ static vm_fault_t ceph_page_mkwrite(struct vm_fault *vmf)
+ 	sb_start_pagefault(inode->i_sb);
+ 	ceph_block_sigs(&oldset);
+ 
+-	if (off + thp_size(page) <= size)
+-		len = thp_size(page);
++	if (off + folio_size(folio) <= size)
++		len = folio_size(folio);
+ 	else
+-		len = offset_in_thp(page, size);
++		len = offset_in_folio(folio, size);
+ 
+ 	doutc(cl, "%llx.%llx %llu~%zd getting caps i_size %llu\n",
+ 	      ceph_vinop(inode), off, len, size);
+@@ -1748,30 +1722,30 @@ static vm_fault_t ceph_page_mkwrite(struct vm_fault *vmf)
+ 	doutc(cl, "%llx.%llx %llu~%zd got cap refs on %s\n", ceph_vinop(inode),
+ 	      off, len, ceph_cap_string(got));
+ 
+-	/* Update time before taking page lock */
++	/* Update time before taking folio lock */
+ 	file_update_time(vma->vm_file);
+ 	inode_inc_iversion_raw(inode);
+ 
+ 	do {
+ 		struct ceph_snap_context *snapc;
+ 
+-		lock_page(page);
++		folio_lock(folio);
+ 
+-		if (page_mkwrite_check_truncate(page, inode) < 0) {
+-			unlock_page(page);
++		if (folio_mkwrite_check_truncate(folio, inode) < 0) {
++			folio_unlock(folio);
+ 			ret = VM_FAULT_NOPAGE;
+ 			break;
+ 		}
+ 
+-		snapc = ceph_find_incompatible(page);
++		snapc = ceph_find_incompatible(&folio->page);
+ 		if (!snapc) {
+-			/* success.  we'll keep the page locked. */
+-			set_page_dirty(page);
++			/* success.  we'll keep the folio locked. */
++			folio_mark_dirty(folio);
+ 			ret = VM_FAULT_LOCKED;
+ 			break;
+ 		}
+ 
+-		unlock_page(page);
++		folio_unlock(folio);
+ 
+ 		if (IS_ERR(snapc)) {
+ 			ret = VM_FAULT_SIGBUS;
+diff --git a/fs/ceph/caps.c b/fs/ceph/caps.c
+index 941799cb53319a..dd667358e1fa79 100644
+--- a/fs/ceph/caps.c
++++ b/fs/ceph/caps.c
+@@ -3091,7 +3091,19 @@ int __ceph_get_caps(struct inode *inode, struct ceph_file_info *fi, int need,
+ 					ret = -ERESTARTSYS;
+ 					break;
+ 				}
+-				wait_woken(&wait, TASK_INTERRUPTIBLE, MAX_SCHEDULE_TIMEOUT);
++
++				/*
++				 * If a cap update is lost after
++				 * mds_wanted was raised, waiting
++				 * forever will never make progress.
++				 * Retry the renew path periodically
++				 * so we can resend synchronously.
++				 */
++				if (!wait_woken(&wait, TASK_INTERRUPTIBLE,
++						CEPH_GET_CAPS_WAIT_TIMEOUT)) {
++					ret = -EUCLEAN;
++					break;
++				}
+ 			}
+ 
+ 			remove_wait_queue(&ci->i_cap_wq, &wait);
+@@ -3123,7 +3135,8 @@ int __ceph_get_caps(struct inode *inode, struct ceph_file_info *fi, int need,
+ 				continue;
+ 			}
+ 			if (ret == -EUCLEAN) {
+-				/* session was killed, try renew caps */
++				/* session was killed or a waited cap
++				 * request needs a retry */
+ 				ret = ceph_renew_caps(inode, flags);
+ 				if (ret == 0)
+ 					continue;
+diff --git a/fs/ceph/file.c b/fs/ceph/file.c
+index bd74e8ffe6af7d..cecaabd7388c08 100644
+--- a/fs/ceph/file.c
++++ b/fs/ceph/file.c
+@@ -294,7 +294,7 @@ static int ceph_init_file(struct inode *inode, struct file *file, int fmode)
+ }
+ 
+ /*
+- * try renew caps after session gets killed.
++ * Retry cap acquisition after a stale session or a lost cap update.
+  */
+ int ceph_renew_caps(struct inode *inode, int fmode)
+ {
+@@ -302,14 +302,15 @@ int ceph_renew_caps(struct inode *inode, int fmode)
+ 	struct ceph_client *cl = mdsc->fsc->client;
+ 	struct ceph_inode_info *ci = ceph_inode(inode);
+ 	struct ceph_mds_request *req;
+-	int err, flags, wanted;
++	int err, flags, wanted, issued;
+ 
+ 	spin_lock(&ci->i_ceph_lock);
+ 	__ceph_touch_fmode(ci, mdsc, fmode);
+ 	wanted = __ceph_caps_file_wanted(ci);
++	issued = __ceph_caps_issued(ci, NULL);
+ 	if (__ceph_is_any_real_caps(ci) &&
+-	    (!(wanted & CEPH_CAP_ANY_WR) || ci->i_auth_cap)) {
+-		int issued = __ceph_caps_issued(ci, NULL);
++	    (!(wanted & CEPH_CAP_ANY_WR) || ci->i_auth_cap) &&
++	    (issued & wanted) == wanted) {
+ 		spin_unlock(&ci->i_ceph_lock);
+ 		doutc(cl, "%p %llx.%llx want %s issued %s updating mds_wanted\n",
+ 		      inode, ceph_vinop(inode), ceph_cap_string(wanted),
+diff --git a/fs/ceph/mds_client.c b/fs/ceph/mds_client.c
+index a83aca62ded91f..b49f304170479f 100644
+--- a/fs/ceph/mds_client.c
++++ b/fs/ceph/mds_client.c
+@@ -6,6 +6,7 @@
+ #include <linux/slab.h>
+ #include <linux/gfp.h>
+ #include <linux/sched.h>
++#include <linux/sched/mm.h>
+ #include <linux/debugfs.h>
+ #include <linux/seq_file.h>
+ #include <linux/ratelimit.h>
+@@ -3675,6 +3676,7 @@ static void handle_reply(struct ceph_mds_session *session, struct ceph_msg *msg)
+ 	struct ceph_mds_reply_head *head = msg->front.iov_base;
+ 	struct ceph_mds_reply_info_parsed *rinfo;  /* parsed reply info */
+ 	struct ceph_snap_realm *realm;
++	unsigned int nofs_flags;
+ 	u64 tid;
+ 	int err, result;
+ 	int mds = session->s_mds;
+@@ -3817,6 +3819,14 @@ static void handle_reply(struct ceph_mds_session *session, struct ceph_msg *msg)
+ 
+ 	/* insert trace into our cache */
+ 	mutex_lock(&req->r_fill_mutex);
++
++	/* disable fs reclaim while we are using current->journal_info
++	 * for our own purposes, or else shrinkers of other
++	 * filesystems might dereference this pointer as a different
++	 * type
++	 */
++	nofs_flags = memalloc_nofs_save();
++
+ 	current->journal_info = req;
+ 	err = ceph_fill_trace(mdsc->fsc->sb, req);
+ 	if (err == 0) {
+@@ -3825,6 +3835,7 @@ static void handle_reply(struct ceph_mds_session *session, struct ceph_msg *msg)
+ 			err = ceph_readdir_prepopulate(req, req->r_session);
+ 	}
+ 	current->journal_info = NULL;
++	memalloc_nofs_restore(nofs_flags);
+ 	mutex_unlock(&req->r_fill_mutex);
+ 
+ 	up_read(&mdsc->snap_rwsem);
+diff --git a/fs/ceph/mds_client.h b/fs/ceph/mds_client.h
+index d930eb79dc380f..4237c6615a3f49 100644
+--- a/fs/ceph/mds_client.h
++++ b/fs/ceph/mds_client.h
+@@ -68,6 +68,8 @@ enum ceph_feature_type {
+ struct ceph_fs_client;
+ struct ceph_cap;
+ 
++#define CEPH_GET_CAPS_WAIT_TIMEOUT (5 * HZ)
++
+ /*
+  * parsed info about a single inode.  pointers are into the encoded
+  * on-wire structures within the mds reply message payload.
+diff --git a/fs/ceph/mdsmap.c b/fs/ceph/mdsmap.c
+index a476d5e6d39f46..03634d721c5210 100644
+--- a/fs/ceph/mdsmap.c
++++ b/fs/ceph/mdsmap.c
+@@ -15,7 +15,7 @@
+ #include "super.h"
+ 
+ #define CEPH_MDS_IS_READY(i, ignore_laggy) \
+-	(m->m_info[i].state > 0 && ignore_laggy ? true : !m->m_info[i].laggy)
++	(m->m_info[i].state > 0 && (ignore_laggy ? true : !m->m_info[i].laggy))
+ 
+ static int __mdsmap_get_random_mds(struct ceph_mdsmap *m, bool ignore_laggy)
+ {
+diff --git a/fs/erofs/Kconfig b/fs/erofs/Kconfig
+index 2f0ae58b31eb50..baabc37c71b319 100644
+--- a/fs/erofs/Kconfig
++++ b/fs/erofs/Kconfig
+@@ -103,7 +103,8 @@ config EROFS_FS_ZIP_LZMA
+ config EROFS_FS_ZIP_LZMA_DEFAULT_MAX_STREAMS
+ 	int "EROFS LZMA default maximum decompression streams"
+ 	depends on EROFS_FS_ZIP_LZMA
+-	range 1 NR_CPUS
++	range 1 NR_CPUS if SMP
++	range 1 1 if !SMP
+ 	default 16
+ 	help
+ 	  By default EROFS allocates one LZMA decompression stream per CPU.
+diff --git a/fs/exec.c b/fs/exec.c
+index 9d3e2eda9d55e9..359158943746b6 100644
+--- a/fs/exec.c
++++ b/fs/exec.c
+@@ -935,7 +935,7 @@ static struct file *do_open_execat(int fd, struct filename *name, int flags)
+ 	    path_noexec(&file->f_path))
+ 		goto exit;
+ 
+-	err = deny_write_access(file);
++	err = exe_file_deny_write_access(file);
+ 	if (err)
+ 		goto exit;
+ 
+@@ -1521,7 +1521,7 @@ static void free_bprm(struct linux_binprm *bprm)
+ 		abort_creds(bprm->cred);
+ 	}
+ 	if (bprm->file) {
+-		allow_write_access(bprm->file);
++		exe_file_allow_write_access(bprm->file);
+ 		fput(bprm->file);
+ 	}
+ 	if (bprm->executable)
+@@ -1824,7 +1824,7 @@ static int exec_binprm(struct linux_binprm *bprm)
+ 		bprm->file = bprm->interpreter;
+ 		bprm->interpreter = NULL;
+ 
+-		allow_write_access(exec);
++		exe_file_allow_write_access(exec);
+ 		if (unlikely(bprm->have_execfd)) {
+ 			if (bprm->executable) {
+ 				fput(exec);
+diff --git a/fs/f2fs/data.c b/fs/f2fs/data.c
+index af1438277575d8..d068111436d799 100644
+--- a/fs/f2fs/data.c
++++ b/fs/f2fs/data.c
+@@ -948,7 +948,7 @@ alloc_new:
+ 	if (fio->io_wbc)
+ 		wbc_account_cgroup_owner(fio->io_wbc, fio->page, PAGE_SIZE);
+ 
+-	inc_page_count(fio->sbi, WB_DATA_TYPE(page, false));
++	inc_page_count(fio->sbi, WB_DATA_TYPE(fio->page, false));
+ 
+ 	*fio->last_block = fio->new_blkaddr;
+ 	*fio->bio = bio;
+diff --git a/fs/iomap/buffered-io.c b/fs/iomap/buffered-io.c
+index bc7d176c4cf139..549490acb229eb 100644
+--- a/fs/iomap/buffered-io.c
++++ b/fs/iomap/buffered-io.c
+@@ -57,30 +57,34 @@ static inline bool ifs_block_is_uptodate(struct iomap_folio_state *ifs,
+ 	return test_bit(block, ifs->state);
+ }
+ 
+-static void ifs_set_range_uptodate(struct folio *folio,
++static bool ifs_set_range_uptodate(struct folio *folio,
+ 		struct iomap_folio_state *ifs, size_t off, size_t len)
+ {
+ 	struct inode *inode = folio->mapping->host;
+-	unsigned int first_blk = off >> inode->i_blkbits;
+-	unsigned int last_blk = (off + len - 1) >> inode->i_blkbits;
+-	unsigned int nr_blks = last_blk - first_blk + 1;
+-	unsigned long flags;
++	unsigned int first_blk, last_blk;
+ 
+-	spin_lock_irqsave(&ifs->state_lock, flags);
+-	bitmap_set(ifs->state, first_blk, nr_blks);
+-	if (ifs_is_fully_uptodate(folio, ifs))
+-		folio_mark_uptodate(folio);
+-	spin_unlock_irqrestore(&ifs->state_lock, flags);
++	if (len) {
++		first_blk = off >> inode->i_blkbits;
++		last_blk = (off + len - 1) >> inode->i_blkbits;
++		bitmap_set(ifs->state, first_blk, last_blk - first_blk + 1);
++	}
++	return ifs_is_fully_uptodate(folio, ifs);
+ }
+ 
+ static void iomap_set_range_uptodate(struct folio *folio, size_t off,
+ 		size_t len)
+ {
+ 	struct iomap_folio_state *ifs = folio->private;
++	unsigned long flags;
++	bool uptodate = true;
+ 
+-	if (ifs)
+-		ifs_set_range_uptodate(folio, ifs, off, len);
+-	else
++	if (ifs) {
++		spin_lock_irqsave(&ifs->state_lock, flags);
++		uptodate = ifs_set_range_uptodate(folio, ifs, off, len);
++		spin_unlock_irqrestore(&ifs->state_lock, flags);
++	}
++
++	if (uptodate)
+ 		folio_mark_uptodate(folio);
+ }
+ 
+@@ -125,13 +129,17 @@ static void ifs_set_range_dirty(struct folio *folio,
+ {
+ 	struct inode *inode = folio->mapping->host;
+ 	unsigned int blks_per_folio = i_blocks_per_folio(inode, folio);
+-	unsigned int first_blk = (off >> inode->i_blkbits);
+-	unsigned int last_blk = (off + len - 1) >> inode->i_blkbits;
+-	unsigned int nr_blks = last_blk - first_blk + 1;
++	unsigned int first_blk, last_blk;
+ 	unsigned long flags;
+ 
++	if (!len)
++		return;
++
++	first_blk = off >> inode->i_blkbits;
++	last_blk = (off + len - 1) >> inode->i_blkbits;
+ 	spin_lock_irqsave(&ifs->state_lock, flags);
+-	bitmap_set(ifs->state, first_blk + blks_per_folio, nr_blks);
++	bitmap_set(ifs->state, first_blk + blks_per_folio,
++		   last_blk - first_blk + 1);
+ 	spin_unlock_irqrestore(&ifs->state_lock, flags);
+ }
+ 
+diff --git a/fs/smb/client/cifsglob.h b/fs/smb/client/cifsglob.h
+index 97f70d437a7eb1..a4e0618c58efcf 100644
+--- a/fs/smb/client/cifsglob.h
++++ b/fs/smb/client/cifsglob.h
+@@ -606,27 +606,6 @@ struct smb_version_operations {
+ 				      const char *symname);
+ };
+ 
+-struct smb_version_values {
+-	char		*version_string;
+-	__u16		protocol_id;
+-	__u32		req_capabilities;
+-	__u32		large_lock_type;
+-	__u32		exclusive_lock_type;
+-	__u32		shared_lock_type;
+-	__u32		unlock_lock_type;
+-	size_t		header_preamble_size;
+-	size_t		header_size;
+-	size_t		max_header_size;
+-	size_t		read_rsp_size;
+-	__le16		lock_cmd;
+-	unsigned int	cap_unix;
+-	unsigned int	cap_nt_find;
+-	unsigned int	cap_large_files;
+-	__u16		signing_enabled;
+-	__u16		signing_required;
+-	size_t		create_lease_size;
+-};
+-
+ #define HEADER_SIZE(server) (server->vals->header_size)
+ #define MAX_HEADER_SIZE(server) (server->vals->max_header_size)
+ #define HEADER_PREAMBLE_SIZE(server) (server->vals->header_preamble_size)
+@@ -664,12 +643,6 @@ struct cifs_mnt_data {
+ 	int flags;
+ };
+ 
+-static inline unsigned int
+-get_rfc1002_length(void *buf)
+-{
+-	return be32_to_cpu(*((__be32 *)buf)) & 0xffffff;
+-}
+-
+ struct TCP_Server_Info {
+ 	struct list_head tcp_ses_list;
+ 	struct list_head smb_ses_list;
+diff --git a/fs/smb/client/cifssmb.c b/fs/smb/client/cifssmb.c
+index 877b4ad03fe9c0..e7df15011ae332 100644
+--- a/fs/smb/client/cifssmb.c
++++ b/fs/smb/client/cifssmb.c
+@@ -595,7 +595,7 @@ CIFSSMBEcho(struct TCP_Server_Info *server)
+ 
+ 	iov[0].iov_len = 4;
+ 	iov[0].iov_base = smb;
+-	iov[1].iov_len = get_rfc1002_length(smb);
++	iov[1].iov_len = get_rfc1002_len(smb);
+ 	iov[1].iov_base = (char *)smb + 4;
+ 
+ 	rc = cifs_call_async(server, &rqst, NULL, cifs_echo_callback, NULL,
+@@ -1363,7 +1363,7 @@ cifs_async_readv(struct cifs_readdata *rdata)
+ 	rdata->iov[0].iov_base = smb;
+ 	rdata->iov[0].iov_len = 4;
+ 	rdata->iov[1].iov_base = (char *)smb + 4;
+-	rdata->iov[1].iov_len = get_rfc1002_length(smb);
++	rdata->iov[1].iov_len = get_rfc1002_len(smb);
+ 
+ 	kref_get(&rdata->refcount);
+ 	rc = cifs_call_async(tcon->ses->server, &rqst, cifs_readv_receive,
+@@ -1707,7 +1707,7 @@ cifs_async_writev(struct cifs_writedata *wdata,
+ 	/* 4 for RFC1001 length + 1 for BCC */
+ 	iov[0].iov_len = 4;
+ 	iov[0].iov_base = smb;
+-	iov[1].iov_len = get_rfc1002_length(smb) + 1;
++	iov[1].iov_len = get_rfc1002_len(smb) + 1;
+ 	iov[1].iov_base = (char *)smb + 4;
+ 
+ 	rqst.rq_iov = iov;
+diff --git a/fs/smb/client/connect.c b/fs/smb/client/connect.c
+index fe5d21f174c47e..68a000956d9575 100644
+--- a/fs/smb/client/connect.c
++++ b/fs/smb/client/connect.c
+@@ -1230,7 +1230,7 @@ cifs_demultiplex_thread(void *p)
+ 		 * The right amount was read from socket - 4 bytes,
+ 		 * so we can now interpret the length field.
+ 		 */
+-		pdu_length = get_rfc1002_length(buf);
++		pdu_length = get_rfc1002_len(buf);
+ 
+ 		cifs_dbg(FYI, "RFC1002 header 0x%x\n", pdu_length);
+ 		if (!is_smb_response(server, buf[0]))
+diff --git a/fs/smb/client/transport.c b/fs/smb/client/transport.c
+index 1eb25603b6e838..a47242a0f5c6df 100644
+--- a/fs/smb/client/transport.c
++++ b/fs/smb/client/transport.c
+@@ -882,7 +882,7 @@ SendReceiveNoRsp(const unsigned int xid, struct cifs_ses *ses,
+ 	int resp_buf_type;
+ 
+ 	iov[0].iov_base = in_buf;
+-	iov[0].iov_len = get_rfc1002_length(in_buf) + 4;
++	iov[0].iov_len = get_rfc1002_len(in_buf) + 4;
+ 	flags |= CIFS_NO_RSP_BUF;
+ 	rc = SendReceive2(xid, ses, iov, 1, &resp_buf_type, flags, &rsp_iov);
+ 	cifs_dbg(NOISY, "SendRcvNoRsp flags %d rc %d\n", flags, rc);
+@@ -942,7 +942,7 @@ int
+ cifs_check_receive(struct mid_q_entry *mid, struct TCP_Server_Info *server,
+ 		   bool log_error)
+ {
+-	unsigned int len = get_rfc1002_length(mid->resp_buf) + 4;
++	unsigned int len = get_rfc1002_len(mid->resp_buf) + 4;
+ 
+ 	dump_smb(mid->resp_buf, min_t(u32, 92, len));
+ 
+@@ -1462,7 +1462,7 @@ SendReceive(const unsigned int xid, struct cifs_ses *ses,
+ 		goto out;
+ 	}
+ 
+-	*pbytes_returned = get_rfc1002_length(midQ->resp_buf);
++	*pbytes_returned = get_rfc1002_len(midQ->resp_buf);
+ 	memcpy(out_buf, midQ->resp_buf, *pbytes_returned + 4);
+ 	rc = cifs_check_receive(midQ, server, 0);
+ out:
+@@ -1647,7 +1647,7 @@ SendReceiveBlockingLock(const unsigned int xid, struct cifs_tcon *tcon,
+ 		goto out;
+ 	}
+ 
+-	*pbytes_returned = get_rfc1002_length(midQ->resp_buf);
++	*pbytes_returned = get_rfc1002_len(midQ->resp_buf);
+ 	memcpy(out_buf, midQ->resp_buf, *pbytes_returned + 4);
+ 	rc = cifs_check_receive(midQ, server, 0);
+ out:
+diff --git a/fs/smb/common/cifsglob.h b/fs/smb/common/cifsglob.h
+index 00fd215e3eb547..371160fec1cdfd 100644
+--- a/fs/smb/common/cifsglob.h
++++ b/fs/smb/common/cifsglob.h
+@@ -9,6 +9,42 @@
+ #ifndef _COMMON_CIFS_GLOB_H
+ #define _COMMON_CIFS_GLOB_H
+ 
++struct smb_version_values {
++	char		*version_string;
++	__u16		protocol_id;
++	__le16		lock_cmd;
++	__u32		req_capabilities;
++	__u32		max_read_size;
++	__u32		max_write_size;
++	__u32		max_trans_size;
++	__u32		max_credits;
++	__u32		large_lock_type;
++	__u32		exclusive_lock_type;
++	__u32		shared_lock_type;
++	__u32		unlock_lock_type;
++	size_t		header_preamble_size;
++	size_t		header_size;
++	size_t		max_header_size;
++	size_t		read_rsp_size;
++	unsigned int	cap_unix;
++	unsigned int	cap_nt_find;
++	unsigned int	cap_large_files;
++	unsigned int	cap_unicode;
++	__u16		signing_enabled;
++	__u16		signing_required;
++	size_t		create_lease_size;
++	size_t		create_durable_size;
++	size_t		create_durable_v2_size;
++	size_t		create_mxac_size;
++	size_t		create_disk_id_size;
++	size_t		create_posix_size;
++};
++
++static inline unsigned int get_rfc1002_len(void *buf)
++{
++	return be32_to_cpu(*((__be32 *)buf)) & 0xffffff;
++}
++
+ static inline void inc_rfc1001_len(void *buf, int count)
+ {
+ 	be32_add_cpu((__be32 *)buf, count);
+diff --git a/fs/smb/server/auth.c b/fs/smb/server/auth.c
+index 825cc03692754a..bb8332caa9a715 100644
+--- a/fs/smb/server/auth.c
++++ b/fs/smb/server/auth.c
+@@ -920,7 +920,7 @@ int ksmbd_gen_preauth_integrity_hash(struct ksmbd_conn *conn, char *buf,
+ 				     __u8 *pi_hash)
+ {
+ 	int rc;
+-	struct smb2_hdr *rcv_hdr = smb2_get_msg(buf);
++	struct smb2_hdr *rcv_hdr = smb_get_msg(buf);
+ 	char *all_bytes_msg = (char *)&rcv_hdr->ProtocolId;
+ 	int msg_size = get_rfc1002_len(buf);
+ 	struct ksmbd_crypto_ctx *ctx = NULL;
+@@ -1107,7 +1107,7 @@ int ksmbd_crypt_message(struct ksmbd_work *work, struct kvec *iov,
+ 			unsigned int nvec, int enc)
+ {
+ 	struct ksmbd_conn *conn = work->conn;
+-	struct smb2_transform_hdr *tr_hdr = smb2_get_msg(iov[0].iov_base);
++	struct smb2_transform_hdr *tr_hdr = smb_get_msg(iov[0].iov_base);
+ 	unsigned int assoc_data_len = sizeof(struct smb2_transform_hdr) - 20;
+ 	int rc;
+ 	DECLARE_CRYPTO_WAIT(wait);
+diff --git a/fs/smb/server/connection.c b/fs/smb/server/connection.c
+index cdc1edeefeb331..8a19058efc3f7d 100644
+--- a/fs/smb/server/connection.c
++++ b/fs/smb/server/connection.c
+@@ -376,8 +376,11 @@ bool ksmbd_conn_alive(struct ksmbd_conn *conn)
+ 	return true;
+ }
+ 
+-#define SMB1_MIN_SUPPORTED_HEADER_SIZE (sizeof(struct smb_hdr))
+-#define SMB2_MIN_SUPPORTED_HEADER_SIZE (sizeof(struct smb2_hdr) + 4)
++/* "+2" for BCC field (ByteCount, 2 bytes) */
++#define SMB1_MIN_SUPPORTED_PDU_SIZE (sizeof(struct smb_hdr) + 2)
++#define SMB2_MIN_SUPPORTED_PDU_SIZE (sizeof(struct smb2_pdu))
++#define SMB2_TRANSFORM_MIN_SUPPORTED_PDU_SIZE	\
++	(sizeof(struct smb2_transform_hdr) + sizeof(struct smb2_hdr))
+ 
+ /**
+  * ksmbd_conn_handler_loop() - session thread to listen on new smb requests
+@@ -392,6 +395,7 @@ int ksmbd_conn_handler_loop(void *p)
+ 	struct ksmbd_conn *conn = (struct ksmbd_conn *)p;
+ 	struct ksmbd_transport *t = conn->transport;
+ 	unsigned int pdu_size, max_allowed_pdu_size, max_req;
++	__le32 proto;
+ 	char hdr_buf[4] = {0,};
+ 	int size;
+ 
+@@ -444,7 +448,7 @@ recheck:
+ 		if (pdu_size > MAX_STREAM_PROT_LEN)
+ 			break;
+ 
+-		if (pdu_size < SMB1_MIN_SUPPORTED_HEADER_SIZE)
++		if (pdu_size < SMB1_MIN_SUPPORTED_PDU_SIZE)
+ 			break;
+ 
+ 		/* 4 for rfc1002 length field */
+@@ -475,11 +479,14 @@ recheck:
+ 		if (!ksmbd_smb_request(conn))
+ 			break;
+ 
+-		if (((struct smb2_hdr *)smb2_get_msg(conn->request_buf))->ProtocolId ==
+-		    SMB2_PROTO_NUMBER) {
+-			if (pdu_size < SMB2_MIN_SUPPORTED_HEADER_SIZE)
+-				break;
+-		}
++		proto = *(__le32 *)smb_get_msg(conn->request_buf);
++		if (proto == SMB2_PROTO_NUMBER &&
++		    pdu_size < SMB2_MIN_SUPPORTED_PDU_SIZE)
++			break;
++
++		if (proto == SMB2_TRANSFORM_PROTO_NUM &&
++		    pdu_size < SMB2_TRANSFORM_MIN_SUPPORTED_PDU_SIZE)
++			break;
+ 
+ 		if (!default_conn_ops.process_fn) {
+ 			pr_err("No connection request callback\n");
+diff --git a/fs/smb/server/connection.h b/fs/smb/server/connection.h
+index e00bfda0a5bd0b..e277c224ef34c9 100644
+--- a/fs/smb/server/connection.h
++++ b/fs/smb/server/connection.h
+@@ -194,6 +194,11 @@ void ksmbd_conn_r_count_dec(struct ksmbd_conn *conn);
+  * This is a hack. We will move status to a proper place once we land
+  * a multi-sessions support.
+  */
++static inline bool ksmbd_conn_new(struct ksmbd_conn *conn)
++{
++	return READ_ONCE(conn->status) == KSMBD_SESS_NEW;
++}
++
+ static inline bool ksmbd_conn_good(struct ksmbd_conn *conn)
+ {
+ 	return READ_ONCE(conn->status) == KSMBD_SESS_GOOD;
+diff --git a/fs/smb/server/oplock.c b/fs/smb/server/oplock.c
+index 109bb71d06adff..6f595756c41fd8 100644
+--- a/fs/smb/server/oplock.c
++++ b/fs/smb/server/oplock.c
+@@ -663,7 +663,7 @@ static void __smb2_oplock_break_noti(struct work_struct *wk)
+ 		goto out;
+ 	}
+ 
+-	rsp_hdr = smb2_get_msg(work->response_buf);
++	rsp_hdr = smb_get_msg(work->response_buf);
+ 	memset(rsp_hdr, 0, sizeof(struct smb2_hdr) + 2);
+ 	rsp_hdr->ProtocolId = SMB2_PROTO_NUMBER;
+ 	rsp_hdr->StructureSize = SMB2_HEADER_STRUCTURE_SIZE;
+@@ -677,7 +677,7 @@ static void __smb2_oplock_break_noti(struct work_struct *wk)
+ 	rsp_hdr->SessionId = 0;
+ 	memset(rsp_hdr->Signature, 0, 16);
+ 
+-	rsp = smb2_get_msg(work->response_buf);
++	rsp = smb_get_msg(work->response_buf);
+ 
+ 	rsp->StructureSize = cpu_to_le16(24);
+ 	if (!br_info->open_trunc &&
+@@ -776,7 +776,7 @@ static void __smb2_lease_break_noti(struct work_struct *wk)
+ 		goto out;
+ 	}
+ 
+-	rsp_hdr = smb2_get_msg(work->response_buf);
++	rsp_hdr = smb_get_msg(work->response_buf);
+ 	memset(rsp_hdr, 0, sizeof(struct smb2_hdr) + 2);
+ 	rsp_hdr->ProtocolId = SMB2_PROTO_NUMBER;
+ 	rsp_hdr->StructureSize = SMB2_HEADER_STRUCTURE_SIZE;
+@@ -790,7 +790,7 @@ static void __smb2_lease_break_noti(struct work_struct *wk)
+ 	rsp_hdr->SessionId = 0;
+ 	memset(rsp_hdr->Signature, 0, 16);
+ 
+-	rsp = smb2_get_msg(work->response_buf);
++	rsp = smb_get_msg(work->response_buf);
+ 	rsp->StructureSize = cpu_to_le16(44);
+ 	rsp->Epoch = br_info->epoch;
+ 	rsp->Flags = 0;
+diff --git a/fs/smb/server/smb2misc.c b/fs/smb/server/smb2misc.c
+index ffbddf00d24e95..6a4f1b8a0b13c9 100644
+--- a/fs/smb/server/smb2misc.c
++++ b/fs/smb/server/smb2misc.c
+@@ -465,7 +465,7 @@ int ksmbd_smb2_check_message(struct ksmbd_work *work)
+ 	}
+ 
+ validate_credit:
+-	if ((work->conn->vals->capabilities & SMB2_GLOBAL_CAP_LARGE_MTU) &&
++	if ((work->conn->vals->req_capabilities & SMB2_GLOBAL_CAP_LARGE_MTU) &&
+ 	    smb2_validate_credit_charge(work->conn, hdr))
+ 		return 1;
+ 
+diff --git a/fs/smb/server/smb2ops.c b/fs/smb/server/smb2ops.c
+index 606aa3c5189a28..bcf05caa2304d9 100644
+--- a/fs/smb/server/smb2ops.c
++++ b/fs/smb/server/smb2ops.c
+@@ -15,7 +15,7 @@
+ static struct smb_version_values smb21_server_values = {
+ 	.version_string = SMB21_VERSION_STRING,
+ 	.protocol_id = SMB21_PROT_ID,
+-	.capabilities = SMB2_GLOBAL_CAP_LARGE_MTU,
++	.req_capabilities = SMB2_GLOBAL_CAP_LARGE_MTU,
+ 	.max_read_size = SMB21_DEFAULT_IOSIZE,
+ 	.max_write_size = SMB21_DEFAULT_IOSIZE,
+ 	.max_trans_size = SMB21_DEFAULT_IOSIZE,
+@@ -41,7 +41,7 @@ static struct smb_version_values smb21_server_values = {
+ static struct smb_version_values smb30_server_values = {
+ 	.version_string = SMB30_VERSION_STRING,
+ 	.protocol_id = SMB30_PROT_ID,
+-	.capabilities = SMB2_GLOBAL_CAP_LARGE_MTU,
++	.req_capabilities = SMB2_GLOBAL_CAP_LARGE_MTU,
+ 	.max_read_size = SMB3_DEFAULT_IOSIZE,
+ 	.max_write_size = SMB3_DEFAULT_IOSIZE,
+ 	.max_trans_size = SMB3_DEFAULT_TRANS_SIZE,
+@@ -68,7 +68,7 @@ static struct smb_version_values smb30_server_values = {
+ static struct smb_version_values smb302_server_values = {
+ 	.version_string = SMB302_VERSION_STRING,
+ 	.protocol_id = SMB302_PROT_ID,
+-	.capabilities = SMB2_GLOBAL_CAP_LARGE_MTU,
++	.req_capabilities = SMB2_GLOBAL_CAP_LARGE_MTU,
+ 	.max_read_size = SMB3_DEFAULT_IOSIZE,
+ 	.max_write_size = SMB3_DEFAULT_IOSIZE,
+ 	.max_trans_size = SMB3_DEFAULT_TRANS_SIZE,
+@@ -95,7 +95,7 @@ static struct smb_version_values smb302_server_values = {
+ static struct smb_version_values smb311_server_values = {
+ 	.version_string = SMB311_VERSION_STRING,
+ 	.protocol_id = SMB311_PROT_ID,
+-	.capabilities = SMB2_GLOBAL_CAP_LARGE_MTU,
++	.req_capabilities = SMB2_GLOBAL_CAP_LARGE_MTU,
+ 	.max_read_size = SMB3_DEFAULT_IOSIZE,
+ 	.max_write_size = SMB3_DEFAULT_IOSIZE,
+ 	.max_trans_size = SMB3_DEFAULT_TRANS_SIZE,
+@@ -204,7 +204,7 @@ void init_smb2_1_server(struct ksmbd_conn *conn)
+ 	conn->signing_algorithm = SIGNING_ALG_HMAC_SHA256_LE;
+ 
+ 	if (server_conf.flags & KSMBD_GLOBAL_FLAG_SMB2_LEASES)
+-		conn->vals->capabilities |= SMB2_GLOBAL_CAP_LEASING;
++		conn->vals->req_capabilities |= SMB2_GLOBAL_CAP_LEASING;
+ }
+ 
+ /**
+@@ -221,20 +221,20 @@ void init_smb3_0_server(struct ksmbd_conn *conn)
+ 	conn->signing_algorithm = SIGNING_ALG_AES_CMAC_LE;
+ 
+ 	if (server_conf.flags & KSMBD_GLOBAL_FLAG_SMB2_LEASES)
+-		conn->vals->capabilities |= SMB2_GLOBAL_CAP_LEASING |
++		conn->vals->req_capabilities |= SMB2_GLOBAL_CAP_LEASING |
+ 			SMB2_GLOBAL_CAP_DIRECTORY_LEASING;
+ 
+ 	if (server_conf.flags & KSMBD_GLOBAL_FLAG_SMB2_ENCRYPTION &&
+ 	    conn->cli_cap & SMB2_GLOBAL_CAP_ENCRYPTION)
+-		conn->vals->capabilities |= SMB2_GLOBAL_CAP_ENCRYPTION;
++		conn->vals->req_capabilities |= SMB2_GLOBAL_CAP_ENCRYPTION;
+ 
+ 	if (server_conf.flags & KSMBD_GLOBAL_FLAG_SMB2_ENCRYPTION ||
+ 	    (!(server_conf.flags & KSMBD_GLOBAL_FLAG_SMB2_ENCRYPTION_OFF) &&
+ 	     conn->cli_cap & SMB2_GLOBAL_CAP_ENCRYPTION))
+-		conn->vals->capabilities |= SMB2_GLOBAL_CAP_ENCRYPTION;
++		conn->vals->req_capabilities |= SMB2_GLOBAL_CAP_ENCRYPTION;
+ 
+ 	if (server_conf.flags & KSMBD_GLOBAL_FLAG_SMB3_MULTICHANNEL)
+-		conn->vals->capabilities |= SMB2_GLOBAL_CAP_MULTI_CHANNEL;
++		conn->vals->req_capabilities |= SMB2_GLOBAL_CAP_MULTI_CHANNEL;
+ }
+ 
+ /**
+@@ -251,19 +251,19 @@ void init_smb3_02_server(struct ksmbd_conn *conn)
+ 	conn->signing_algorithm = SIGNING_ALG_AES_CMAC_LE;
+ 
+ 	if (server_conf.flags & KSMBD_GLOBAL_FLAG_SMB2_LEASES)
+-		conn->vals->capabilities |= SMB2_GLOBAL_CAP_LEASING |
++		conn->vals->req_capabilities |= SMB2_GLOBAL_CAP_LEASING |
+ 			SMB2_GLOBAL_CAP_DIRECTORY_LEASING;
+ 
+ 	if (server_conf.flags & KSMBD_GLOBAL_FLAG_SMB2_ENCRYPTION ||
+ 	    (!(server_conf.flags & KSMBD_GLOBAL_FLAG_SMB2_ENCRYPTION_OFF) &&
+ 	     conn->cli_cap & SMB2_GLOBAL_CAP_ENCRYPTION))
+-		conn->vals->capabilities |= SMB2_GLOBAL_CAP_ENCRYPTION;
++		conn->vals->req_capabilities |= SMB2_GLOBAL_CAP_ENCRYPTION;
+ 
+ 	if (server_conf.flags & KSMBD_GLOBAL_FLAG_SMB3_MULTICHANNEL)
+-		conn->vals->capabilities |= SMB2_GLOBAL_CAP_MULTI_CHANNEL;
++		conn->vals->req_capabilities |= SMB2_GLOBAL_CAP_MULTI_CHANNEL;
+ 
+ 	if (server_conf.flags & KSMBD_GLOBAL_FLAG_DURABLE_HANDLE)
+-		conn->vals->capabilities |= SMB2_GLOBAL_CAP_PERSISTENT_HANDLES;
++		conn->vals->req_capabilities |= SMB2_GLOBAL_CAP_PERSISTENT_HANDLES;
+ }
+ 
+ /**
+@@ -280,14 +280,14 @@ int init_smb3_11_server(struct ksmbd_conn *conn)
+ 	conn->signing_algorithm = SIGNING_ALG_AES_CMAC_LE;
+ 
+ 	if (server_conf.flags & KSMBD_GLOBAL_FLAG_SMB2_LEASES)
+-		conn->vals->capabilities |= SMB2_GLOBAL_CAP_LEASING |
++		conn->vals->req_capabilities |= SMB2_GLOBAL_CAP_LEASING |
+ 			SMB2_GLOBAL_CAP_DIRECTORY_LEASING;
+ 
+ 	if (server_conf.flags & KSMBD_GLOBAL_FLAG_SMB3_MULTICHANNEL)
+-		conn->vals->capabilities |= SMB2_GLOBAL_CAP_MULTI_CHANNEL;
++		conn->vals->req_capabilities |= SMB2_GLOBAL_CAP_MULTI_CHANNEL;
+ 
+ 	if (server_conf.flags & KSMBD_GLOBAL_FLAG_DURABLE_HANDLE)
+-		conn->vals->capabilities |= SMB2_GLOBAL_CAP_PERSISTENT_HANDLES;
++		conn->vals->req_capabilities |= SMB2_GLOBAL_CAP_PERSISTENT_HANDLES;
+ 
+ 	INIT_LIST_HEAD(&conn->preauth_sess_table);
+ 	return 0;
+diff --git a/fs/smb/server/smb2pdu.c b/fs/smb/server/smb2pdu.c
+index 41bc4b06fad08a..0343360b3445b0 100644
+--- a/fs/smb/server/smb2pdu.c
++++ b/fs/smb/server/smb2pdu.c
+@@ -47,8 +47,8 @@ static void __wbuf(struct ksmbd_work *work, void **req, void **rsp)
+ 		*req = ksmbd_req_buf_next(work);
+ 		*rsp = ksmbd_resp_buf_next(work);
+ 	} else {
+-		*req = smb2_get_msg(work->request_buf);
+-		*rsp = smb2_get_msg(work->response_buf);
++		*req = smb_get_msg(work->request_buf);
++		*rsp = smb_get_msg(work->response_buf);
+ 	}
+ }
+ 
+@@ -148,7 +148,7 @@ void smb2_set_err_rsp(struct ksmbd_work *work)
+ 	if (work->next_smb2_rcv_hdr_off)
+ 		err_rsp = ksmbd_resp_buf_next(work);
+ 	else
+-		err_rsp = smb2_get_msg(work->response_buf);
++		err_rsp = smb_get_msg(work->response_buf);
+ 
+ 	if (err_rsp->hdr.Status != STATUS_STOPPED_ON_SYMLINK) {
+ 		int err;
+@@ -174,7 +174,7 @@ void smb2_set_err_rsp(struct ksmbd_work *work)
+  */
+ bool is_smb2_neg_cmd(struct ksmbd_work *work)
+ {
+-	struct smb2_hdr *hdr = smb2_get_msg(work->request_buf);
++	struct smb2_hdr *hdr = smb_get_msg(work->request_buf);
+ 
+ 	/* is it SMB2 header ? */
+ 	if (hdr->ProtocolId != SMB2_PROTO_NUMBER)
+@@ -198,7 +198,7 @@ bool is_smb2_neg_cmd(struct ksmbd_work *work)
+  */
+ bool is_smb2_rsp(struct ksmbd_work *work)
+ {
+-	struct smb2_hdr *hdr = smb2_get_msg(work->response_buf);
++	struct smb2_hdr *hdr = smb_get_msg(work->response_buf);
+ 
+ 	/* is it SMB2 header ? */
+ 	if (hdr->ProtocolId != SMB2_PROTO_NUMBER)
+@@ -224,7 +224,7 @@ u16 get_smb2_cmd_val(struct ksmbd_work *work)
+ 	if (work->next_smb2_rcv_hdr_off)
+ 		rcv_hdr = ksmbd_req_buf_next(work);
+ 	else
+-		rcv_hdr = smb2_get_msg(work->request_buf);
++		rcv_hdr = smb_get_msg(work->request_buf);
+ 	return le16_to_cpu(rcv_hdr->Command);
+ }
+ 
+@@ -237,7 +237,7 @@ void set_smb2_rsp_status(struct ksmbd_work *work, __le32 err)
+ {
+ 	struct smb2_hdr *rsp_hdr;
+ 
+-	rsp_hdr = smb2_get_msg(work->response_buf);
++	rsp_hdr = smb_get_msg(work->response_buf);
+ 	rsp_hdr->Status = err;
+ 
+ 	work->iov_idx = 0;
+@@ -260,7 +260,7 @@ int init_smb2_neg_rsp(struct ksmbd_work *work)
+ 	struct ksmbd_conn *conn = work->conn;
+ 	int err;
+ 
+-	rsp_hdr = smb2_get_msg(work->response_buf);
++	rsp_hdr = smb_get_msg(work->response_buf);
+ 	memset(rsp_hdr, 0, sizeof(struct smb2_hdr) + 2);
+ 	rsp_hdr->ProtocolId = SMB2_PROTO_NUMBER;
+ 	rsp_hdr->StructureSize = SMB2_HEADER_STRUCTURE_SIZE;
+@@ -274,7 +274,7 @@ int init_smb2_neg_rsp(struct ksmbd_work *work)
+ 	rsp_hdr->SessionId = 0;
+ 	memset(rsp_hdr->Signature, 0, 16);
+ 
+-	rsp = smb2_get_msg(work->response_buf);
++	rsp = smb_get_msg(work->response_buf);
+ 
+ 	WARN_ON(ksmbd_conn_good(conn));
+ 
+@@ -284,7 +284,7 @@ int init_smb2_neg_rsp(struct ksmbd_work *work)
+ 	/* Not setting conn guid rsp->ServerGUID, as it
+ 	 * not used by client for identifying connection
+ 	 */
+-	rsp->Capabilities = cpu_to_le32(conn->vals->capabilities);
++	rsp->Capabilities = cpu_to_le32(conn->vals->req_capabilities);
+ 	/* Default Max Message Size till SMB2.0, 64K*/
+ 	rsp->MaxTransactSize = cpu_to_le32(conn->vals->max_trans_size);
+ 	rsp->MaxReadSize = cpu_to_le32(conn->vals->max_read_size);
+@@ -448,7 +448,7 @@ static void init_chained_smb2_rsp(struct ksmbd_work *work)
+  */
+ bool is_chained_smb2_message(struct ksmbd_work *work)
+ {
+-	struct smb2_hdr *hdr = smb2_get_msg(work->request_buf);
++	struct smb2_hdr *hdr = smb_get_msg(work->request_buf);
+ 	unsigned int len, next_cmd;
+ 
+ 	if (hdr->ProtocolId != SMB2_PROTO_NUMBER)
+@@ -499,8 +499,8 @@ bool is_chained_smb2_message(struct ksmbd_work *work)
+  */
+ int init_smb2_rsp_hdr(struct ksmbd_work *work)
+ {
+-	struct smb2_hdr *rsp_hdr = smb2_get_msg(work->response_buf);
+-	struct smb2_hdr *rcv_hdr = smb2_get_msg(work->request_buf);
++	struct smb2_hdr *rsp_hdr = smb_get_msg(work->response_buf);
++	struct smb2_hdr *rcv_hdr = smb_get_msg(work->request_buf);
+ 
+ 	memset(rsp_hdr, 0, sizeof(struct smb2_hdr) + 2);
+ 	rsp_hdr->ProtocolId = rcv_hdr->ProtocolId;
+@@ -529,7 +529,7 @@ int init_smb2_rsp_hdr(struct ksmbd_work *work)
+  */
+ int smb2_allocate_rsp_buf(struct ksmbd_work *work)
+ {
+-	struct smb2_hdr *hdr = smb2_get_msg(work->request_buf);
++	struct smb2_hdr *hdr = smb_get_msg(work->request_buf);
+ 	size_t small_sz = MAX_CIFS_SMALL_BUFFER_SIZE;
+ 	size_t large_sz = small_sz + work->conn->vals->max_trans_size;
+ 	size_t sz = small_sz;
+@@ -545,7 +545,7 @@ int smb2_allocate_rsp_buf(struct ksmbd_work *work)
+ 		    offsetof(struct smb2_query_info_req, OutputBufferLength))
+ 			return -EINVAL;
+ 
+-		req = smb2_get_msg(work->request_buf);
++		req = smb_get_msg(work->request_buf);
+ 		if ((req->InfoType == SMB2_O_INFO_FILE &&
+ 		     (req->FileInfoClass == FILE_FULL_EA_INFORMATION ||
+ 		     req->FileInfoClass == FILE_ALL_INFORMATION)) ||
+@@ -719,10 +719,10 @@ void smb2_send_interim_resp(struct ksmbd_work *work, __le32 status)
+ 	}
+ 
+ 	in_work->conn = work->conn;
+-	memcpy(smb2_get_msg(in_work->response_buf), ksmbd_resp_buf_next(work),
++	memcpy(smb_get_msg(in_work->response_buf), ksmbd_resp_buf_next(work),
+ 	       __SMB2_HEADER_STRUCTURE_SIZE);
+ 
+-	rsp_hdr = smb2_get_msg(in_work->response_buf);
++	rsp_hdr = smb_get_msg(in_work->response_buf);
+ 	rsp_hdr->Flags |= SMB2_FLAGS_ASYNC_COMMAND;
+ 	rsp_hdr->Id.AsyncId = cpu_to_le64(work->async_id);
+ 	smb2_set_err_rsp(in_work);
+@@ -963,7 +963,7 @@ bool smb3_encryption_negotiated(struct ksmbd_conn *conn)
+ 	 * SMB 3.0 and 3.0.2 dialects use the SMB2_GLOBAL_CAP_ENCRYPTION flag.
+ 	 * SMB 3.1.1 uses the cipher_type field.
+ 	 */
+-	return (conn->vals->capabilities & SMB2_GLOBAL_CAP_ENCRYPTION) ||
++	return (conn->vals->req_capabilities & SMB2_GLOBAL_CAP_ENCRYPTION) ||
+ 	    conn->cipher_type;
+ }
+ 
+@@ -1095,25 +1095,21 @@ static __le32 deassemble_neg_contexts(struct ksmbd_conn *conn,
+  * smb2_handle_negotiate() - handler for smb2 negotiate command
+  * @work:	smb work containing smb request buffer
+  *
++ * The caller holds conn->srv_mutex.
++ *
+  * Return:      0
+  */
+ int smb2_handle_negotiate(struct ksmbd_work *work)
+ {
+ 	struct ksmbd_conn *conn = work->conn;
+-	struct smb2_negotiate_req *req = smb2_get_msg(work->request_buf);
+-	struct smb2_negotiate_rsp *rsp = smb2_get_msg(work->response_buf);
++	struct smb2_negotiate_req *req = smb_get_msg(work->request_buf);
++	struct smb2_negotiate_rsp *rsp = smb_get_msg(work->response_buf);
+ 	int rc = 0;
+ 	unsigned int smb2_buf_len, smb2_neg_size, neg_ctxt_len = 0;
+ 	__le32 status;
+ 
+ 	ksmbd_debug(SMB, "Received negotiate request\n");
+ 	conn->need_neg = false;
+-	if (ksmbd_conn_good(conn)) {
+-		pr_err("conn->tcp_status is already in CifsGood State\n");
+-		work->send_no_response = 1;
+-		return rc;
+-	}
+-
+ 	smb2_buf_len = get_rfc1002_len(work->request_buf);
+ 	smb2_neg_size = offsetof(struct smb2_negotiate_req, Dialects);
+ 	if (smb2_neg_size > smb2_buf_len) {
+@@ -1216,7 +1212,7 @@ int smb2_handle_negotiate(struct ksmbd_work *work)
+ 		rc = -EINVAL;
+ 		goto err_out;
+ 	}
+-	rsp->Capabilities = cpu_to_le32(conn->vals->capabilities);
++	rsp->Capabilities = cpu_to_le32(conn->vals->req_capabilities);
+ 
+ 	/* For stats */
+ 	conn->connection_type = conn->dialect;
+@@ -3480,7 +3476,7 @@ int smb2_open(struct ksmbd_work *work)
+ 	share_ret = ksmbd_smb_check_shared_mode(fp->filp, fp);
+ 	if (!test_share_config_flag(work->tcon->share_conf, KSMBD_SHARE_FLAG_OPLOCKS) ||
+ 	    (req_op_level == SMB2_OPLOCK_LEVEL_LEASE &&
+-	     !(conn->vals->capabilities & SMB2_GLOBAL_CAP_LEASING))) {
++	     !(conn->vals->req_capabilities & SMB2_GLOBAL_CAP_LEASING))) {
+ 		if (share_ret < 0 && !S_ISDIR(file_inode(fp->filp)->i_mode)) {
+ 			rc = share_ret;
+ 			goto err_out1;
+@@ -6048,7 +6044,7 @@ out:
+  */
+ int smb2_echo(struct ksmbd_work *work)
+ {
+-	struct smb2_echo_rsp *rsp = smb2_get_msg(work->response_buf);
++	struct smb2_echo_rsp *rsp = smb_get_msg(work->response_buf);
+ 
+ 	if (work->next_smb2_rcv_hdr_off)
+ 		rsp = ksmbd_resp_buf_next(work);
+@@ -6614,8 +6610,8 @@ int smb2_set_info(struct ksmbd_work *work)
+ 			pid = work->compound_pfid;
+ 		}
+ 	} else {
+-		req = smb2_get_msg(work->request_buf);
+-		rsp = smb2_get_msg(work->response_buf);
++		req = smb_get_msg(work->request_buf);
++		rsp = smb_get_msg(work->response_buf);
+ 	}
+ 
+ 	if (!test_tree_conn_flag(work->tcon, KSMBD_TREE_CONN_FLAG_WRITABLE)) {
+@@ -6841,8 +6837,8 @@ int smb2_read(struct ksmbd_work *work)
+ 			pid = work->compound_pfid;
+ 		}
+ 	} else {
+-		req = smb2_get_msg(work->request_buf);
+-		rsp = smb2_get_msg(work->response_buf);
++		req = smb_get_msg(work->request_buf);
++		rsp = smb_get_msg(work->response_buf);
+ 	}
+ 
+ 	if (!has_file_id(id)) {
+@@ -7260,7 +7256,7 @@ out:
+ int smb2_cancel(struct ksmbd_work *work)
+ {
+ 	struct ksmbd_conn *conn = work->conn;
+-	struct smb2_hdr *hdr = smb2_get_msg(work->request_buf);
++	struct smb2_hdr *hdr = smb_get_msg(work->request_buf);
+ 	struct smb2_hdr *chdr;
+ 	struct ksmbd_work *iter;
+ 	struct list_head *command_list;
+@@ -7277,7 +7273,7 @@ int smb2_cancel(struct ksmbd_work *work)
+ 		spin_lock(&conn->request_lock);
+ 		list_for_each_entry(iter, command_list,
+ 				    async_request_entry) {
+-			chdr = smb2_get_msg(iter->request_buf);
++			chdr = smb_get_msg(iter->request_buf);
+ 
+ 			if (iter->async_id !=
+ 			    le64_to_cpu(hdr->Id.AsyncId))
+@@ -7309,7 +7305,7 @@ int smb2_cancel(struct ksmbd_work *work)
+ 
+ 		spin_lock(&conn->request_lock);
+ 		list_for_each_entry(iter, command_list, request_entry) {
+-			chdr = smb2_get_msg(iter->request_buf);
++			chdr = smb_get_msg(iter->request_buf);
+ 
+ 			if (chdr->MessageId != hdr->MessageId ||
+ 			    iter == work)
+@@ -8081,7 +8077,7 @@ static int fsctl_validate_negotiate_info(struct ksmbd_conn *conn,
+ 		goto err_out;
+ 	}
+ 
+-	neg_rsp->Capabilities = cpu_to_le32(conn->vals->capabilities);
++	neg_rsp->Capabilities = cpu_to_le32(conn->vals->req_capabilities);
+ 	memset(neg_rsp->Guid, 0, SMB2_CLIENT_GUID_SIZE);
+ 	neg_rsp->SecurityMode = cpu_to_le16(conn->srv_sec_mode);
+ 	neg_rsp->Dialect = cpu_to_le16(conn->dialect);
+@@ -8265,8 +8261,8 @@ int smb2_ioctl(struct ksmbd_work *work)
+ 			id = work->compound_fid;
+ 		}
+ 	} else {
+-		req = smb2_get_msg(work->request_buf);
+-		rsp = smb2_get_msg(work->response_buf);
++		req = smb_get_msg(work->request_buf);
++		rsp = smb_get_msg(work->response_buf);
+ 	}
+ 
+ 	if (!has_file_id(id))
+@@ -8948,7 +8944,7 @@ int smb2_notify(struct ksmbd_work *work)
+  */
+ bool smb2_is_sign_req(struct ksmbd_work *work, unsigned int command)
+ {
+-	struct smb2_hdr *rcv_hdr2 = smb2_get_msg(work->request_buf);
++	struct smb2_hdr *rcv_hdr2 = smb_get_msg(work->request_buf);
+ 
+ 	if ((rcv_hdr2->Flags & SMB2_FLAGS_SIGNED) &&
+ 	    command != SMB2_NEGOTIATE_HE &&
+@@ -8973,7 +8969,7 @@ int smb2_check_sign_req(struct ksmbd_work *work)
+ 	struct kvec iov[1];
+ 	size_t len;
+ 
+-	hdr = smb2_get_msg(work->request_buf);
++	hdr = smb_get_msg(work->request_buf);
+ 	if (work->next_smb2_rcv_hdr_off)
+ 		hdr = ksmbd_req_buf_next(work);
+ 
+@@ -9048,7 +9044,7 @@ int smb3_check_sign_req(struct ksmbd_work *work)
+ 	struct kvec iov[1];
+ 	size_t len;
+ 
+-	hdr = smb2_get_msg(work->request_buf);
++	hdr = smb_get_msg(work->request_buf);
+ 	if (work->next_smb2_rcv_hdr_off)
+ 		hdr = ksmbd_req_buf_next(work);
+ 
+@@ -9184,7 +9180,7 @@ void smb3_preauth_hash_rsp(struct ksmbd_work *work)
+ static void fill_transform_hdr(void *tr_buf, char *old_buf, __le16 cipher_type)
+ {
+ 	struct smb2_transform_hdr *tr_hdr = tr_buf + 4;
+-	struct smb2_hdr *hdr = smb2_get_msg(old_buf);
++	struct smb2_hdr *hdr = smb_get_msg(old_buf);
+ 	unsigned int orig_len = get_rfc1002_len(old_buf);
+ 
+ 	/* tr_buf must be cleared by the caller */
+@@ -9223,7 +9219,7 @@ int smb3_encrypt_resp(struct ksmbd_work *work)
+ 
+ bool smb3_is_transform_hdr(void *buf)
+ {
+-	struct smb2_transform_hdr *trhdr = smb2_get_msg(buf);
++	struct smb2_transform_hdr *trhdr = smb_get_msg(buf);
+ 
+ 	return trhdr->ProtocolId == SMB2_TRANSFORM_PROTO_NUM;
+ }
+@@ -9235,7 +9231,7 @@ int smb3_decrypt_req(struct ksmbd_work *work)
+ 	unsigned int pdu_length = get_rfc1002_len(buf);
+ 	struct kvec iov[2];
+ 	int buf_data_size = pdu_length - sizeof(struct smb2_transform_hdr);
+-	struct smb2_transform_hdr *tr_hdr = smb2_get_msg(buf);
++	struct smb2_transform_hdr *tr_hdr = smb_get_msg(buf);
+ 	int rc = 0;
+ 
+ 	if (pdu_length < sizeof(struct smb2_transform_hdr) ||
+@@ -9276,7 +9272,7 @@ bool smb3_11_final_sess_setup_resp(struct ksmbd_work *work)
+ {
+ 	struct ksmbd_conn *conn = work->conn;
+ 	struct ksmbd_session *sess = work->sess;
+-	struct smb2_hdr *rsp = smb2_get_msg(work->response_buf);
++	struct smb2_hdr *rsp = smb_get_msg(work->response_buf);
+ 
+ 	if (conn->dialect < SMB30_PROT_ID)
+ 		return false;
+diff --git a/fs/smb/server/smb2pdu.h b/fs/smb/server/smb2pdu.h
+index ad02d0a3760252..dd1c25279d4a0a 100644
+--- a/fs/smb/server/smb2pdu.h
++++ b/fs/smb/server/smb2pdu.h
+@@ -496,15 +496,6 @@ int smb2_ioctl(struct ksmbd_work *work);
+ int smb2_oplock_break(struct ksmbd_work *work);
+ int smb2_notify(struct ksmbd_work *ksmbd_work);
+ 
+-/*
+- * Get the body of the smb2 message excluding the 4 byte rfc1002 headers
+- * from request/response buffer.
+- */
+-static inline void *smb2_get_msg(void *buf)
+-{
+-	return buf + 4;
+-}
+-
+ #define POSIX_TYPE_FILE		0
+ #define POSIX_TYPE_DIR		1
+ #define POSIX_TYPE_SYMLINK	2
+diff --git a/fs/smb/server/smb_common.c b/fs/smb/server/smb_common.c
+index c64d1fc34d6bf3..d1a181fec84a8d 100644
+--- a/fs/smb/server/smb_common.c
++++ b/fs/smb/server/smb_common.c
+@@ -163,7 +163,7 @@ bool ksmbd_smb_request(struct ksmbd_conn *conn)
+ 	if (conn->request_buf[0] != 0)
+ 		return false;
+ 
+-	proto = (__le32 *)smb2_get_msg(conn->request_buf);
++	proto = (__le32 *)smb_get_msg(conn->request_buf);
+ 	if (*proto == SMB2_COMPRESSION_TRANSFORM_ID) {
+ 		pr_err_ratelimited("smb2 compression not support yet");
+ 		return false;
+@@ -259,14 +259,14 @@ int ksmbd_lookup_dialect_by_id(__le16 *cli_dialects, __le16 dialects_count)
+ static int ksmbd_negotiate_smb_dialect(void *buf)
+ {
+ 	int smb_buf_length = get_rfc1002_len(buf);
+-	__le32 proto = ((struct smb2_hdr *)smb2_get_msg(buf))->ProtocolId;
++	__le32 proto = ((struct smb2_hdr *)smb_get_msg(buf))->ProtocolId;
+ 
+ 	if (proto == SMB2_PROTO_NUMBER) {
+ 		struct smb2_negotiate_req *req;
+ 		int smb2_neg_size =
+ 			offsetof(struct smb2_negotiate_req, Dialects);
+ 
+-		req = (struct smb2_negotiate_req *)smb2_get_msg(buf);
++		req = (struct smb2_negotiate_req *)smb_get_msg(buf);
+ 		if (smb2_neg_size > smb_buf_length)
+ 			goto err_out;
+ 
+@@ -592,23 +592,46 @@ int ksmbd_smb_negotiate_common(struct ksmbd_work *work, unsigned int command)
+ 	struct ksmbd_conn *conn = work->conn;
+ 	int ret;
+ 
+-	conn->dialect =
+-		ksmbd_negotiate_smb_dialect(work->request_buf);
+-	ksmbd_debug(SMB, "conn->dialect 0x%x\n", conn->dialect);
+-
+ 	if (command == SMB2_NEGOTIATE_HE) {
++		/*
++		 * An SMB2 NEGOTIATE is valid for a new connection, or after an
++		 * SMB1 multi-protocol negotiate has selected SMB2. Do not allow
++		 * a second SMB2 NEGOTIATE to replace connection-wide state
++		 * while a session setup is pending. KSMBD_SESS_NEED_RECONNECT
++		 * is a transient session state and does not restart transport
++		 * negotiation.
++		 */
++		ksmbd_conn_lock(conn);
++		if (!ksmbd_conn_new(conn) &&
++		    !ksmbd_conn_need_negotiate(conn)) {
++			work->send_no_response = 1;
++			ksmbd_conn_set_exiting(conn);
++			ksmbd_conn_unlock(conn);
++			return 0;
++		}
++
++		conn->dialect =
++			ksmbd_negotiate_smb_dialect(work->request_buf);
++		ksmbd_debug(SMB, "conn->dialect 0x%x\n", conn->dialect);
+ 		ret = smb2_handle_negotiate(work);
++		ksmbd_conn_unlock(conn);
+ 		return ret;
+ 	}
+ 
+ 	if (command == SMB_COM_NEGOTIATE) {
++		ksmbd_conn_lock(conn);
++		conn->dialect =
++			ksmbd_negotiate_smb_dialect(work->request_buf);
++		ksmbd_debug(SMB, "conn->dialect 0x%x\n", conn->dialect);
+ 		if (__smb2_negotiate(conn)) {
+ 			init_smb3_11_server(conn);
+-			init_smb2_neg_rsp(work);
++			ret = init_smb2_neg_rsp(work);
+ 			ksmbd_debug(SMB, "Upgrade to SMB2 negotiation\n");
+-			return 0;
++		} else {
++			ret = smb_handle_negotiate(work);
+ 		}
+-		return smb_handle_negotiate(work);
++		ksmbd_conn_unlock(conn);
++		return ret;
+ 	}
+ 
+ 	pr_err("Unknown SMB negotiation command: %u\n", command);
+diff --git a/fs/smb/server/smb_common.h b/fs/smb/server/smb_common.h
+index 3f274af060dab9..8693b5f5b4ac2b 100644
+--- a/fs/smb/server/smb_common.h
++++ b/fs/smb/server/smb_common.h
+@@ -3,8 +3,8 @@
+  *   Copyright (C) 2018 Samsung Electronics Co., Ltd.
+  */
+ 
+-#ifndef __SMB_COMMON_H__
+-#define __SMB_COMMON_H__
++#ifndef __SMB_SERVER_COMMON_H__
++#define __SMB_SERVER_COMMON_H__
+ 
+ #include <linux/kernel.h>
+ 
+@@ -336,35 +336,6 @@ struct file_id_full_dir_info {
+ 	char FileName[];
+ } __packed; /* level 0x105 FF rsp data */
+ 
+-struct smb_version_values {
+-	char		*version_string;
+-	__u16		protocol_id;
+-	__le16		lock_cmd;
+-	__u32		capabilities;
+-	__u32		max_read_size;
+-	__u32		max_write_size;
+-	__u32		max_trans_size;
+-	__u32		max_credits;
+-	__u32		large_lock_type;
+-	__u32		exclusive_lock_type;
+-	__u32		shared_lock_type;
+-	__u32		unlock_lock_type;
+-	size_t		header_size;
+-	size_t		max_header_size;
+-	size_t		read_rsp_size;
+-	unsigned int	cap_unix;
+-	unsigned int	cap_nt_find;
+-	unsigned int	cap_large_files;
+-	__u16		signing_enabled;
+-	__u16		signing_required;
+-	size_t		create_lease_size;
+-	size_t		create_durable_size;
+-	size_t		create_durable_v2_size;
+-	size_t		create_mxac_size;
+-	size_t		create_disk_id_size;
+-	size_t		create_posix_size;
+-};
+-
+ struct filesystem_posix_info {
+ 	/* For undefined recommended transfer size return -1 in that field */
+ 	__le32 OptimalTransferSize;  /* bsize on some os, iosize on other os */
+@@ -451,8 +422,12 @@ unsigned int ksmbd_server_side_copy_max_total_size(void);
+ bool is_asterisk(char *p);
+ __le32 smb_map_generic_desired_access(__le32 daccess);
+ 
+-static inline unsigned int get_rfc1002_len(void *buf)
++/*
++ * Get the body of the smb message excluding the 4 byte rfc1002 headers
++ * from request/response buffer.
++ */
++static inline void *smb_get_msg(void *buf)
+ {
+-	return be32_to_cpu(*((__be32 *)buf)) & 0xffffff;
++	return buf + 4;
+ }
+-#endif /* __SMB_COMMON_H__ */
++#endif /* __SMB_SERVER_COMMON_H__ */
+diff --git a/fs/super.c b/fs/super.c
+index b142e71eb8dfdd..f8fe07501c9ff8 100644
+--- a/fs/super.c
++++ b/fs/super.c
+@@ -1217,16 +1217,24 @@ void emergency_remount(void)
+ 
+ static void do_thaw_all_callback(struct super_block *sb)
+ {
+-	bool born = super_lock_excl(sb);
++	bool active = false;
++
++	if (super_lock_excl(sb))
++		active = atomic_inc_not_zero(&sb->s_active);
++	super_unlock_excl(sb);
++	if (!active)
++		return;
+ 
+-	if (born && sb->s_root) {
+-		if (IS_ENABLED(CONFIG_BLOCK))
+-			while (sb->s_bdev && !thaw_bdev(sb->s_bdev))
+-				pr_warn("Emergency Thaw on %pg\n", sb->s_bdev);
++	/* thaw_bdev() acquires s_umount so it must not be held here */
++	if (IS_ENABLED(CONFIG_BLOCK))
++		while (sb->s_bdev && !thaw_bdev(sb->s_bdev))
++			pr_warn("Emergency Thaw on %pg\n", sb->s_bdev);
++
++	if (super_lock_excl(sb))
+ 		thaw_super_locked(sb, FREEZE_HOLDER_USERSPACE);
+-	} else {
++	else
+ 		super_unlock_excl(sb);
+-	}
++	deactivate_super(sb);
+ }
+ 
+ static void do_thaw_all(struct work_struct *work)
+diff --git a/fs/userfaultfd.c b/fs/userfaultfd.c
+index 49f07426259818..0ebdf3c2c9ee6e 100644
+--- a/fs/userfaultfd.c
++++ b/fs/userfaultfd.c
+@@ -1354,9 +1354,9 @@ static int userfaultfd_register(struct userfaultfd_ctx *ctx,
+ 	if (uffdio_register.mode & UFFDIO_REGISTER_MODE_MISSING)
+ 		vm_flags |= VM_UFFD_MISSING;
+ 	if (uffdio_register.mode & UFFDIO_REGISTER_MODE_WP) {
+-#ifndef CONFIG_HAVE_ARCH_USERFAULTFD_WP
+-		goto out;
+-#endif
++		if (!pgtable_supports_uffd_wp())
++			goto out;
++
+ 		vm_flags |= VM_UFFD_WP;
+ 	}
+ 	if (uffdio_register.mode & UFFDIO_REGISTER_MODE_MINOR) {
+@@ -2068,13 +2068,13 @@ static int userfaultfd_api(struct userfaultfd_ctx *ctx,
+ 	uffdio_api.features &=
+ 		~(UFFD_FEATURE_MINOR_HUGETLBFS | UFFD_FEATURE_MINOR_SHMEM);
+ #endif
+-#ifndef CONFIG_HAVE_ARCH_USERFAULTFD_WP
+-	uffdio_api.features &= ~UFFD_FEATURE_PAGEFAULT_FLAG_WP;
+-#endif
+-#ifndef CONFIG_PTE_MARKER_UFFD_WP
+-	uffdio_api.features &= ~UFFD_FEATURE_WP_HUGETLBFS_SHMEM;
+-	uffdio_api.features &= ~UFFD_FEATURE_WP_UNPOPULATED;
+-#endif
++	if (!pgtable_supports_uffd_wp())
++		uffdio_api.features &= ~UFFD_FEATURE_PAGEFAULT_FLAG_WP;
++
++	if (!uffd_supports_wp_marker()) {
++		uffdio_api.features &= ~UFFD_FEATURE_WP_HUGETLBFS_SHMEM;
++		uffdio_api.features &= ~UFFD_FEATURE_WP_UNPOPULATED;
++	}
+ 
+ 	ret = -EINVAL;
+ 	if (features & ~uffdio_api.features)
+diff --git a/fs/xfs/libxfs/xfs_sb.c b/fs/xfs/libxfs/xfs_sb.c
+index 50dd27b0f21577..f4656d17121ebe 100644
+--- a/fs/xfs/libxfs/xfs_sb.c
++++ b/fs/xfs/libxfs/xfs_sb.c
+@@ -865,10 +865,10 @@ xfs_sb_read_verify(
+ 	 * because _verify_common checks the on-disk values.
+ 	 */
+ 	__xfs_sb_from_disk(&sb, dsb, false);
+-	error = xfs_validate_sb_common(mp, bp, &sb);
++	error = xfs_validate_sb_read(mp, &sb);
+ 	if (error)
+ 		goto out_error;
+-	error = xfs_validate_sb_read(mp, &sb);
++	error = xfs_validate_sb_common(mp, bp, &sb);
+ 
+ out_error:
+ 	if (error == -EFSCORRUPTED || error == -EFSBADCRC)
+diff --git a/fs/xfs/scrub/alloc.c b/fs/xfs/scrub/alloc.c
+index 279af72b1671d9..c3813666edb433 100644
+--- a/fs/xfs/scrub/alloc.c
++++ b/fs/xfs/scrub/alloc.c
+@@ -124,7 +124,7 @@ xchk_allocbt_rec(
+ 	const union xfs_btree_rec	*rec)
+ {
+ 	struct xfs_alloc_rec_incore	irec;
+-	struct xchk_alloc	*ca = bs->private;
++	struct xchk_alloc		*ca = bs->private;
+ 
+ 	xfs_alloc_btrec_to_irec(rec, &irec);
+ 	if (xfs_alloc_check_irec(bs->cur, &irec) != NULL) {
+@@ -132,7 +132,8 @@ xchk_allocbt_rec(
+ 		return 0;
+ 	}
+ 
+-	xchk_allocbt_mergeable(bs, ca, &irec);
++	if (bs->sc->sm->sm_type == XFS_SCRUB_TYPE_BNOBT)
++		xchk_allocbt_mergeable(bs, ca, &irec);
+ 	xchk_allocbt_xref(bs->sc, &irec);
+ 
+ 	return 0;
+diff --git a/fs/xfs/xfs_dquot.c b/fs/xfs/xfs_dquot.c
+index fa9a34790aa9ce..5fb8663b90935d 100644
+--- a/fs/xfs/xfs_dquot.c
++++ b/fs/xfs/xfs_dquot.c
+@@ -723,7 +723,7 @@ xfs_dq_get_next_id(
+ 	lock_flags = xfs_ilock_data_map_shared(quotip);
+ 	error = xfs_iread_extents(NULL, quotip, XFS_DATA_FORK);
+ 	if (error)
+-		return error;
++		goto out_unlock;
+ 
+ 	if (xfs_iext_lookup_extent(quotip, &quotip->i_df, start, &cur, &got)) {
+ 		/* contiguous chunk, bump startoff for the id calculation */
+@@ -734,6 +734,7 @@ xfs_dq_get_next_id(
+ 		error = -ENOENT;
+ 	}
+ 
++out_unlock:
+ 	xfs_iunlock(quotip, lock_flags);
+ 
+ 	return error;
+diff --git a/fs/xfs/xfs_dquot_item_recover.c b/fs/xfs/xfs_dquot_item_recover.c
+index 2c2720ce692382..adda4e0dc41c44 100644
+--- a/fs/xfs/xfs_dquot_item_recover.c
++++ b/fs/xfs/xfs_dquot_item_recover.c
+@@ -173,7 +173,7 @@ xlog_recover_dquot_commit_pass2(
+ 
+ out_release:
+ 	xfs_buf_relse(bp);
+-	return 0;
++	return error;
+ }
+ 
+ const struct xlog_recover_item_ops xlog_dquot_item_ops = {
+diff --git a/include/asm-generic/pgtable_uffd.h b/include/asm-generic/pgtable_uffd.h
+index 828966d4c28115..0d85791efdf778 100644
+--- a/include/asm-generic/pgtable_uffd.h
++++ b/include/asm-generic/pgtable_uffd.h
+@@ -1,6 +1,23 @@
+ #ifndef _ASM_GENERIC_PGTABLE_UFFD_H
+ #define _ASM_GENERIC_PGTABLE_UFFD_H
+ 
++/*
++ * Some platforms can customize the uffd-wp bit, making it unavailable
++ * even if the architecture provides the resource.
++ * Adding this API allows architectures to add their own checks for the
++ * devices on which the kernel is running.
++ * Note: When overriding it, please make sure the
++ * CONFIG_HAVE_ARCH_USERFAULTFD_WP is part of this macro.
++ */
++#ifndef pgtable_supports_uffd_wp
++#define pgtable_supports_uffd_wp()	IS_ENABLED(CONFIG_HAVE_ARCH_USERFAULTFD_WP)
++#endif
++
++static inline bool uffd_supports_wp_marker(void)
++{
++	return pgtable_supports_uffd_wp() && IS_ENABLED(CONFIG_PTE_MARKER_UFFD_WP);
++}
++
+ #ifndef CONFIG_HAVE_ARCH_USERFAULTFD_WP
+ static __always_inline int pte_uffd_wp(pte_t pte)
+ {
+diff --git a/include/linux/fs.h b/include/linux/fs.h
+index e6b2e2749e3791..12ea9af49a89af 100644
+--- a/include/linux/fs.h
++++ b/include/linux/fs.h
+@@ -2824,6 +2824,18 @@ static inline void allow_write_access(struct file *file)
+ 	if (file)
+ 		atomic_inc(&file_inode(file)->i_writecount);
+ }
++
++static inline int exe_file_deny_write_access(struct file *exe_file)
++{
++	return deny_write_access(exe_file);
++}
++static inline void exe_file_allow_write_access(struct file *exe_file)
++{
++	if (unlikely(!exe_file))
++		return;
++	allow_write_access(exe_file);
++}
++
+ static inline bool inode_is_open_for_write(const struct inode *inode)
+ {
+ 	return atomic_read(&inode->i_writecount) > 0;
+diff --git a/include/linux/mm_inline.h b/include/linux/mm_inline.h
+index 96b1c157554c08..4fbf25c45ec918 100644
+--- a/include/linux/mm_inline.h
++++ b/include/linux/mm_inline.h
+@@ -547,7 +547,6 @@ static inline pte_marker copy_pte_marker(
+ 
+ 	return dstm;
+ }
+-#endif
+ 
+ /*
+  * If this pte is wr-protected by uffd-wp in any form, arm the special pte to
+@@ -565,9 +564,11 @@ static inline void
+ pte_install_uffd_wp_if_needed(struct vm_area_struct *vma, unsigned long addr,
+ 			      pte_t *pte, pte_t pteval)
+ {
+-#ifdef CONFIG_PTE_MARKER_UFFD_WP
+ 	bool arm_uffd_pte = false;
+ 
++	if (!uffd_supports_wp_marker())
++		return;
++
+ 	/* The current status of the pte should be "cleared" before calling */
+ 	WARN_ON_ONCE(!pte_none(ptep_get(pte)));
+ 
+@@ -594,7 +595,6 @@ pte_install_uffd_wp_if_needed(struct vm_area_struct *vma, unsigned long addr,
+ 	if (unlikely(arm_uffd_pte))
+ 		set_pte_at(vma->vm_mm, addr, pte,
+ 			   make_pte_marker(PTE_MARKER_UFFD_WP));
+-#endif
+ }
+ 
+ static inline bool vma_has_recency(struct vm_area_struct *vma)
+@@ -607,5 +607,6 @@ static inline bool vma_has_recency(struct vm_area_struct *vma)
+ 
+ 	return true;
+ }
++#endif
+ 
+ #endif
+diff --git a/include/linux/mmap_lock.h b/include/linux/mmap_lock.h
+index 153e0186779099..0aad8789a62ddf 100644
+--- a/include/linux/mmap_lock.h
++++ b/include/linux/mmap_lock.h
+@@ -173,6 +173,10 @@ static inline void mmap_read_unlock(struct mm_struct *mm)
+ 	up_read(&mm->mmap_lock);
+ }
+ 
++DEFINE_GUARD(mmap_read_lock, struct mm_struct *,
++	     mmap_read_lock(_T), mmap_read_unlock(_T))
++DEFINE_GUARD_COND(mmap_read_lock, _try, mmap_read_trylock(_T))
++
+ static inline void mmap_read_unlock_non_owner(struct mm_struct *mm)
+ {
+ 	__mmap_lock_trace_released(mm, false);
+diff --git a/include/linux/netdevice.h b/include/linux/netdevice.h
+index 4901f765a14d3e..eefbe40295b1c6 100644
+--- a/include/linux/netdevice.h
++++ b/include/linux/netdevice.h
+@@ -2748,12 +2748,12 @@ struct pcpu_sw_netstats {
+ } __aligned(4 * sizeof(u64));
+ 
+ struct pcpu_dstats {
+-	u64			rx_packets;
+-	u64			rx_bytes;
+-	u64			rx_drops;
+-	u64			tx_packets;
+-	u64			tx_bytes;
+-	u64			tx_drops;
++	u64_stats_t		rx_packets;
++	u64_stats_t		rx_bytes;
++	u64_stats_t		tx_packets;
++	u64_stats_t		tx_bytes;
++	u64_stats_t		rx_drops;
++	u64_stats_t		tx_drops;
+ 	struct u64_stats_sync	syncp;
+ } __aligned(8 * sizeof(u64));
+ 
+@@ -2797,6 +2797,46 @@ static inline void dev_lstats_add(struct net_device *dev, unsigned int len)
+ 	u64_stats_update_end(&lstats->syncp);
+ }
+ 
++static inline void dev_dstats_rx_add(struct net_device *dev,
++				     unsigned int len)
++{
++	struct pcpu_dstats *dstats = this_cpu_ptr(dev->dstats);
++
++	u64_stats_update_begin(&dstats->syncp);
++	u64_stats_inc(&dstats->rx_packets);
++	u64_stats_add(&dstats->rx_bytes, len);
++	u64_stats_update_end(&dstats->syncp);
++}
++
++static inline void dev_dstats_rx_dropped(struct net_device *dev)
++{
++	struct pcpu_dstats *dstats = this_cpu_ptr(dev->dstats);
++
++	u64_stats_update_begin(&dstats->syncp);
++	u64_stats_inc(&dstats->rx_drops);
++	u64_stats_update_end(&dstats->syncp);
++}
++
++static inline void dev_dstats_tx_add(struct net_device *dev,
++				     unsigned int len)
++{
++	struct pcpu_dstats *dstats = this_cpu_ptr(dev->dstats);
++
++	u64_stats_update_begin(&dstats->syncp);
++	u64_stats_inc(&dstats->tx_packets);
++	u64_stats_add(&dstats->tx_bytes, len);
++	u64_stats_update_end(&dstats->syncp);
++}
++
++static inline void dev_dstats_tx_dropped(struct net_device *dev)
++{
++	struct pcpu_dstats *dstats = this_cpu_ptr(dev->dstats);
++
++	u64_stats_update_begin(&dstats->syncp);
++	u64_stats_inc(&dstats->tx_drops);
++	u64_stats_update_end(&dstats->syncp);
++}
++
+ #define __netdev_alloc_pcpu_stats(type, gfp)				\
+ ({									\
+ 	typeof(type) __percpu *pcpu_stats = alloc_percpu_gfp(type, gfp);\
+diff --git a/include/linux/pagewalk.h b/include/linux/pagewalk.h
+index 27cd1e59ccf777..49bf5308786f96 100644
+--- a/include/linux/pagewalk.h
++++ b/include/linux/pagewalk.h
+@@ -117,10 +117,9 @@ struct mm_walk {
+ int walk_page_range(struct mm_struct *mm, unsigned long start,
+ 		unsigned long end, const struct mm_walk_ops *ops,
+ 		void *private);
+-int walk_page_range_novma(struct mm_struct *mm, unsigned long start,
+-			  unsigned long end, const struct mm_walk_ops *ops,
+-			  pgd_t *pgd,
+-			  void *private);
++int walk_kernel_page_table_range(unsigned long start,
++		unsigned long end, const struct mm_walk_ops *ops,
++		pgd_t *pgd, void *private);
+ int walk_page_range_vma(struct vm_area_struct *vma, unsigned long start,
+ 			unsigned long end, const struct mm_walk_ops *ops,
+ 			void *private);
+diff --git a/include/linux/userfaultfd_k.h b/include/linux/userfaultfd_k.h
+index ac8c6854097cd7..67ff2889374f19 100644
+--- a/include/linux/userfaultfd_k.h
++++ b/include/linux/userfaultfd_k.h
+@@ -160,24 +160,7 @@ static inline bool userfaultfd_armed(struct vm_area_struct *vma)
+ 	return vma->vm_flags & __VM_UFFD_FLAGS;
+ }
+ 
+-static inline bool vma_can_userfault(struct vm_area_struct *vma,
+-				     unsigned long vm_flags)
+-{
+-	if ((vm_flags & VM_UFFD_MINOR) &&
+-	    (!is_vm_hugetlb_page(vma) && !vma_is_shmem(vma)))
+-		return false;
+-#ifndef CONFIG_PTE_MARKER_UFFD_WP
+-	/*
+-	 * If user requested uffd-wp but not enabled pte markers for
+-	 * uffd-wp, then shmem & hugetlbfs are not supported but only
+-	 * anonymous.
+-	 */
+-	if ((vm_flags & VM_UFFD_WP) && !vma_is_anonymous(vma))
+-		return false;
+-#endif
+-	return vma_is_anonymous(vma) || is_vm_hugetlb_page(vma) ||
+-	    vma_is_shmem(vma);
+-}
++bool vma_can_userfault(struct vm_area_struct *vma, unsigned long vm_flags);
+ 
+ extern int dup_userfaultfd(struct vm_area_struct *, struct list_head *);
+ extern void dup_userfaultfd_complete(struct list_head *);
+diff --git a/include/net/dropreason-core.h b/include/net/dropreason-core.h
+index a587e83fc16941..e88e785d221bb0 100644
+--- a/include/net/dropreason-core.h
++++ b/include/net/dropreason-core.h
+@@ -80,6 +80,10 @@
+ 	FN(IPV6_NDISC_BAD_OPTIONS)	\
+ 	FN(IPV6_NDISC_NS_OTHERHOST)	\
+ 	FN(QUEUE_PURGE)			\
++	FN(TC_COOKIE_ERROR)		\
++	FN(PACKET_SOCK_ERROR)		\
++	FN(TC_CHAIN_NOTFOUND)		\
++	FN(TC_RECLASSIFY_LOOP)		\
+ 	FNe(MAX)
+ 
+ /**
+@@ -345,6 +349,23 @@ enum skb_drop_reason {
+ 	SKB_DROP_REASON_IPV6_NDISC_NS_OTHERHOST,
+ 	/** @SKB_DROP_REASON_QUEUE_PURGE: bulk free. */
+ 	SKB_DROP_REASON_QUEUE_PURGE,
++	/**
++	 * @SKB_DROP_REASON_TC_COOKIE_ERROR: An error occurred whilst
++	 * processing a tc ext cookie.
++	 */
++	SKB_DROP_REASON_TC_COOKIE_ERROR,
++	/**
++	 * @SKB_DROP_REASON_PACKET_SOCK_ERROR: generic packet socket errors
++	 * after its filter matches an incoming packet.
++	 */
++	SKB_DROP_REASON_PACKET_SOCK_ERROR,
++	/** @SKB_DROP_REASON_TC_CHAIN_NOTFOUND: tc chain lookup failed. */
++	SKB_DROP_REASON_TC_CHAIN_NOTFOUND,
++	/**
++	 * @SKB_DROP_REASON_TC_RECLASSIFY_LOOP: tc exceeded max reclassify loop
++	 * iterations.
++	 */
++	SKB_DROP_REASON_TC_RECLASSIFY_LOOP,
+ 	/**
+ 	 * @SKB_DROP_REASON_MAX: the maximum of core drop reasons, which
+ 	 * shouldn't be used as a real 'reason' - only for tracing code gen
+diff --git a/include/net/gro.h b/include/net/gro.h
+index 9260ed367c9190..439aa18578f690 100644
+--- a/include/net/gro.h
++++ b/include/net/gro.h
+@@ -442,6 +442,7 @@ static inline __wsum ip6_gro_compute_pseudo(struct sk_buff *skb, int proto)
+ }
+ 
+ int skb_gro_receive(struct sk_buff *p, struct sk_buff *skb);
++int skb_gro_receive_list(struct sk_buff *p, struct sk_buff *skb);
+ 
+ /* Pass the currently batched GRO_NORMAL SKBs up to the stack. */
+ static inline void gro_normal_list(struct napi_struct *napi)
+diff --git a/include/net/ip_vs.h b/include/net/ip_vs.h
+index e0077fd28ad1cc..35f012f6201506 100644
+--- a/include/net/ip_vs.h
++++ b/include/net/ip_vs.h
+@@ -34,6 +34,12 @@
+ #define IP_VS_HDR_INVERSE	1
+ #define IP_VS_HDR_ICMP		2
+ 
++/* Destination Server Flags */
++#define IP_VS_DEST_F_OVERLOAD	0x0002		/* server is overloaded */
++
++/* Destination Server Config Flags */
++#define IP_VS_DEST_CF_AVAILABLE	0x0001		/* server is available */
++
+ /* Generic access of ipvs struct */
+ static inline struct netns_ipvs *net_ipvs(struct net* net)
+ {
+@@ -725,6 +731,7 @@ struct ip_vs_dest {
+ 	volatile unsigned int	flags;		/* dest status flags */
+ 	atomic_t		conn_flags;	/* flags to copy to conn */
+ 	atomic_t		weight;		/* server weight */
++	unsigned long		cflags;		/* config flags */
+ 	atomic_t		last_weight;	/* server latest weight */
+ 	__u16			tun_type;	/* tunnel type */
+ 	__be16			tun_port;	/* tunnel port */
+diff --git a/include/net/pkt_cls.h b/include/net/pkt_cls.h
+index 307478c2332234..325a8553853df6 100644
+--- a/include/net/pkt_cls.h
++++ b/include/net/pkt_cls.h
+@@ -163,6 +163,22 @@ __cls_set_class(unsigned long *clp, unsigned long cl)
+ 	return xchg(clp, cl);
+ }
+ 
++struct tc_skb_cb;
++
++static inline struct tc_skb_cb *tc_skb_cb(const struct sk_buff *skb);
++
++static inline enum skb_drop_reason
++tcf_get_drop_reason(const struct sk_buff *skb)
++{
++	return tc_skb_cb(skb)->drop_reason;
++}
++
++static inline void tcf_set_drop_reason(const struct sk_buff *skb,
++				       enum skb_drop_reason reason)
++{
++	tc_skb_cb(skb)->drop_reason = reason;
++}
++
+ static inline void
+ __tcf_bind_filter(struct Qdisc *q, struct tcf_result *r, unsigned long base)
+ {
+diff --git a/include/net/pkt_sched.h b/include/net/pkt_sched.h
+index 4d72d24b1f33e7..9b5698b86986c7 100644
+--- a/include/net/pkt_sched.h
++++ b/include/net/pkt_sched.h
+@@ -276,12 +276,13 @@ static inline void skb_txtime_consumed(struct sk_buff *skb)
+ 
+ struct tc_skb_cb {
+ 	struct qdisc_skb_cb qdisc_cb;
++	u32 drop_reason;
+ 
++	u16 zone; /* Only valid if post_ct = true */
+ 	u16 mru;
+ 	u8 post_ct:1;
+ 	u8 post_ct_snat:1;
+ 	u8 post_ct_dnat:1;
+-	u16 zone; /* Only valid if post_ct = true */
+ };
+ 
+ static inline struct tc_skb_cb *tc_skb_cb(const struct sk_buff *skb)
+diff --git a/include/net/sch_generic.h b/include/net/sch_generic.h
+index 8ad29d2c210abd..4a157ab9a724f8 100644
+--- a/include/net/sch_generic.h
++++ b/include/net/sch_generic.h
+@@ -326,7 +326,6 @@ struct Qdisc_ops {
+ 	struct module		*owner;
+ };
+ 
+-
+ struct tcf_result {
+ 	union {
+ 		struct {
+@@ -334,7 +333,6 @@ struct tcf_result {
+ 			u32		classid;
+ 		};
+ 		const struct tcf_proto *goto_tp;
+-
+ 	};
+ };
+ 
+diff --git a/include/net/tcp.h b/include/net/tcp.h
+index 0eb9341f748887..23d830a7a6c822 100644
+--- a/include/net/tcp.h
++++ b/include/net/tcp.h
+@@ -615,7 +615,7 @@ void tcp_send_fin(struct sock *sk);
+ void tcp_send_active_reset(struct sock *sk, gfp_t priority);
+ int tcp_send_synack(struct sock *);
+ void tcp_push_one(struct sock *, unsigned int mss_now);
+-void __tcp_send_ack(struct sock *sk, u32 rcv_nxt);
++void __tcp_send_ack(struct sock *sk, u32 rcv_nxt, u16 flags);
+ void tcp_send_ack(struct sock *sk);
+ void tcp_send_delayed_ack(struct sock *sk);
+ void tcp_send_loss_probe(struct sock *sk);
+@@ -715,33 +715,6 @@ static inline u32 __tcp_set_rto(const struct tcp_sock *tp)
+ 	return usecs_to_jiffies((tp->srtt_us >> 3) + tp->rttvar_us);
+ }
+ 
+-static inline void __tcp_fast_path_on(struct tcp_sock *tp, u32 snd_wnd)
+-{
+-	/* mptcp hooks are only on the slow path */
+-	if (sk_is_mptcp((struct sock *)tp))
+-		return;
+-
+-	tp->pred_flags = htonl((tp->tcp_header_len << 26) |
+-			       ntohl(TCP_FLAG_ACK) |
+-			       snd_wnd);
+-}
+-
+-static inline void tcp_fast_path_on(struct tcp_sock *tp)
+-{
+-	__tcp_fast_path_on(tp, tp->snd_wnd >> tp->rx_opt.snd_wscale);
+-}
+-
+-static inline void tcp_fast_path_check(struct sock *sk)
+-{
+-	struct tcp_sock *tp = tcp_sk(sk);
+-
+-	if (RB_EMPTY_ROOT(&tp->out_of_order_queue) &&
+-	    tp->rcv_wnd &&
+-	    atomic_read(&sk->sk_rmem_alloc) < sk->sk_rcvbuf &&
+-	    !tp->urg_data)
+-		tcp_fast_path_on(tp);
+-}
+-
+ u32 tcp_delack_max(const struct sock *sk);
+ 
+ /* Compute the actual rto_min value */
+@@ -1658,8 +1631,37 @@ static inline bool tcp_paws_reject(const struct tcp_options_received *rx_opt,
+ 	return true;
+ }
+ 
++static inline void __tcp_fast_path_on(struct tcp_sock *tp, u32 snd_wnd)
++{
++	/* mptcp hooks are only on the slow path */
++	if (sk_is_mptcp((struct sock *)tp))
++		return;
++
++	tp->pred_flags = htonl((tp->tcp_header_len << 26) |
++			       ntohl(TCP_FLAG_ACK) |
++			       snd_wnd);
++}
++
++static inline void tcp_fast_path_on(struct tcp_sock *tp)
++{
++	__tcp_fast_path_on(tp, tp->snd_wnd >> tp->rx_opt.snd_wscale);
++}
++
++static inline void tcp_fast_path_check(struct sock *sk)
++{
++	struct tcp_sock *tp = tcp_sk(sk);
++
++	if (RB_EMPTY_ROOT(&tp->out_of_order_queue) &&
++	    tp->rcv_wnd &&
++	    atomic_read(&sk->sk_rmem_alloc) < sk->sk_rcvbuf &&
++	    !tp->urg_data)
++		tcp_fast_path_on(tp);
++}
++
+ bool tcp_oow_rate_limited(struct net *net, const struct sk_buff *skb,
+ 			  int mib_idx, u32 *last_oow_ack_time);
++void tcp_reqsk_send_challenge_ack(struct sock *sk, struct sk_buff *skb,
++				  struct request_sock *req);
+ 
+ static inline void tcp_mib_init(struct net *net)
+ {
+diff --git a/include/uapi/linux/ip_vs.h b/include/uapi/linux/ip_vs.h
+index 1ed234e7f25136..2c37c6ac7525a5 100644
+--- a/include/uapi/linux/ip_vs.h
++++ b/include/uapi/linux/ip_vs.h
+@@ -28,12 +28,6 @@
+ #define IP_VS_SVC_F_SCHED_SH_FALLBACK	IP_VS_SVC_F_SCHED1 /* SH fallback */
+ #define IP_VS_SVC_F_SCHED_SH_PORT	IP_VS_SVC_F_SCHED2 /* SH use port */
+ 
+-/*
+- *      Destination Server Flags
+- */
+-#define IP_VS_DEST_F_AVAILABLE	0x0001		/* server is available */
+-#define IP_VS_DEST_F_OVERLOAD	0x0002		/* server is overloaded */
+-
+ /*
+  *      IPVS sync daemon states
+  */
+diff --git a/kernel/dma/Kconfig b/kernel/dma/Kconfig
+index f488997b071712..66f036eeeb18bc 100644
+--- a/kernel/dma/Kconfig
++++ b/kernel/dma/Kconfig
+@@ -142,6 +142,15 @@ config DMA_DIRECT_REMAP
+ 	select DMA_COHERENT_POOL
+ 	select DMA_NONCOHERENT_MMAP
+ 
++#
++# Fallback to arch code for DMA allocations.  This should eventually go away.
++#
++config ARCH_HAS_DMA_ALLOC
++	depends on !ARCH_HAS_DMA_SET_UNCACHED
++	depends on !DMA_DIRECT_REMAP
++	depends on !DMA_GLOBAL_POOL
++	bool
++
+ config DMA_CMA
+ 	bool "DMA Contiguous Memory Allocator"
+ 	depends on HAVE_DMA_CONTIGUOUS && CMA
+diff --git a/kernel/dma/direct.c b/kernel/dma/direct.c
+index fc2d10b2aca6fc..91915d351e1235 100644
+--- a/kernel/dma/direct.c
++++ b/kernel/dma/direct.c
+@@ -220,13 +220,7 @@ void *dma_direct_alloc(struct device *dev, size_t size,
+ 		return dma_direct_alloc_no_mapping(dev, size, dma_handle, gfp);
+ 
+ 	if (!dev_is_dma_coherent(dev)) {
+-		/*
+-		 * Fallback to the arch handler if it exists.  This should
+-		 * eventually go away.
+-		 */
+-		if (!IS_ENABLED(CONFIG_ARCH_HAS_DMA_SET_UNCACHED) &&
+-		    !IS_ENABLED(CONFIG_DMA_DIRECT_REMAP) &&
+-		    !IS_ENABLED(CONFIG_DMA_GLOBAL_POOL) &&
++		if (IS_ENABLED(CONFIG_ARCH_HAS_DMA_ALLOC) &&
+ 		    !is_swiotlb_for_alloc(dev))
+ 			return arch_dma_alloc(dev, size, dma_handle, gfp,
+ 					      attrs);
+@@ -332,9 +326,7 @@ void dma_direct_free(struct device *dev, size_t size,
+ 		return;
+ 	}
+ 
+-	if (!IS_ENABLED(CONFIG_ARCH_HAS_DMA_SET_UNCACHED) &&
+-	    !IS_ENABLED(CONFIG_DMA_DIRECT_REMAP) &&
+-	    !IS_ENABLED(CONFIG_DMA_GLOBAL_POOL) &&
++	if (IS_ENABLED(CONFIG_ARCH_HAS_DMA_ALLOC) &&
+ 	    !dev_is_dma_coherent(dev) &&
+ 	    !is_swiotlb_for_alloc(dev)) {
+ 		arch_dma_free(dev, size, cpu_addr, dma_addr, attrs);
+diff --git a/kernel/fork.c b/kernel/fork.c
+index 36854aaec482d6..73e8a6b430a05f 100644
+--- a/kernel/fork.c
++++ b/kernel/fork.c
+@@ -640,8 +640,8 @@ static void dup_mm_exe_file(struct mm_struct *mm, struct mm_struct *oldmm)
+ 	 * We depend on the oldmm having properly denied write access to the
+ 	 * exe_file already.
+ 	 */
+-	if (exe_file && deny_write_access(exe_file))
+-		pr_warn_once("deny_write_access() failed in %s\n", __func__);
++	if (exe_file && exe_file_deny_write_access(exe_file))
++		pr_warn_once("exe_file_deny_write_access() failed in %s\n", __func__);
+ }
+ 
+ #ifdef CONFIG_MMU
+@@ -1431,13 +1431,13 @@ int set_mm_exe_file(struct mm_struct *mm, struct file *new_exe_file)
+ 		 * We expect the caller (i.e., sys_execve) to already denied
+ 		 * write access, so this is unlikely to fail.
+ 		 */
+-		if (unlikely(deny_write_access(new_exe_file)))
++		if (unlikely(exe_file_deny_write_access(new_exe_file)))
+ 			return -EACCES;
+ 		get_file(new_exe_file);
+ 	}
+ 	rcu_assign_pointer(mm->exe_file, new_exe_file);
+ 	if (old_exe_file) {
+-		allow_write_access(old_exe_file);
++		exe_file_allow_write_access(old_exe_file);
+ 		fput(old_exe_file);
+ 	}
+ 	return 0;
+@@ -1476,7 +1476,7 @@ int replace_mm_exe_file(struct mm_struct *mm, struct file *new_exe_file)
+ 			return ret;
+ 	}
+ 
+-	ret = deny_write_access(new_exe_file);
++	ret = exe_file_deny_write_access(new_exe_file);
+ 	if (ret)
+ 		return -EACCES;
+ 	get_file(new_exe_file);
+@@ -1488,7 +1488,7 @@ int replace_mm_exe_file(struct mm_struct *mm, struct file *new_exe_file)
+ 	mmap_write_unlock(mm);
+ 
+ 	if (old_exe_file) {
+-		allow_write_access(old_exe_file);
++		exe_file_allow_write_access(old_exe_file);
+ 		fput(old_exe_file);
+ 	}
+ 	return 0;
+diff --git a/kernel/trace/ftrace.c b/kernel/trace/ftrace.c
+index dbdd147f16e9d8..a5ddc3f7aefaaf 100644
+--- a/kernel/trace/ftrace.c
++++ b/kernel/trace/ftrace.c
+@@ -2562,7 +2562,8 @@ unsigned long ftrace_find_rec_direct(unsigned long ip)
+ {
+ 	struct ftrace_func_entry *entry;
+ 
+-	entry = __ftrace_lookup_ip(direct_functions, ip);
++	guard(preempt_notrace)();
++	entry = __ftrace_lookup_ip(rcu_dereference_sched(direct_functions), ip);
+ 	if (!entry)
+ 		return 0;
+ 
+@@ -7249,7 +7250,8 @@ static void add_to_clear_hash_list(struct list_head *clear_list,
+ void ftrace_free_mem(struct module *mod, void *start_ptr, void *end_ptr)
+ {
+ 	unsigned long start = (unsigned long)(start_ptr);
+-	unsigned long end = (unsigned long)(end_ptr);
++	/* end is inclusive and end_ptr is exclusive */
++	unsigned long end = (unsigned long)(end_ptr) - 1;
+ 	struct ftrace_page **last_pg = &ftrace_pages_start;
+ 	struct ftrace_page *tmp_page = NULL;
+ 	struct ftrace_page *pg;
+@@ -7259,6 +7261,9 @@ void ftrace_free_mem(struct module *mod, void *start_ptr, void *end_ptr)
+ 	struct ftrace_init_func *func, *func_next;
+ 	LIST_HEAD(clear_hash);
+ 
++	if (start_ptr >= end_ptr)
++		return;
++
+ 	key.ip = start;
+ 	key.flags = end;	/* overload flags, as it is unsigned long */
+ 
+diff --git a/kernel/trace/ring_buffer.c b/kernel/trace/ring_buffer.c
+index 0b2ed121741e15..6b36bf7bb6b378 100644
+--- a/kernel/trace/ring_buffer.c
++++ b/kernel/trace/ring_buffer.c
+@@ -5458,32 +5458,30 @@ int ring_buffer_swap_cpu(struct trace_buffer *buffer_a,
+ {
+ 	struct ring_buffer_per_cpu *cpu_buffer_a;
+ 	struct ring_buffer_per_cpu *cpu_buffer_b;
+-	int ret = -EINVAL;
++	int ret = -EBUSY;
+ 
+ 	if (!cpumask_test_cpu(cpu, buffer_a->cpumask) ||
+ 	    !cpumask_test_cpu(cpu, buffer_b->cpumask))
+-		goto out;
++		return -EINVAL;
+ 
+ 	cpu_buffer_a = buffer_a->buffers[cpu];
+ 	cpu_buffer_b = buffer_b->buffers[cpu];
+ 
+ 	/* At least make sure the two buffers are somewhat the same */
+ 	if (cpu_buffer_a->nr_pages != cpu_buffer_b->nr_pages)
+-		goto out;
+-
+-	ret = -EAGAIN;
++		return -EINVAL;
+ 
+ 	if (atomic_read(&buffer_a->record_disabled))
+-		goto out;
++		return -EAGAIN;
+ 
+ 	if (atomic_read(&buffer_b->record_disabled))
+-		goto out;
++		return -EAGAIN;
+ 
+ 	if (atomic_read(&cpu_buffer_a->record_disabled))
+-		goto out;
++		return -EAGAIN;
+ 
+ 	if (atomic_read(&cpu_buffer_b->record_disabled))
+-		goto out;
++		return -EAGAIN;
+ 
+ 	/*
+ 	 * We can't do a synchronize_rcu here because this
+@@ -5494,10 +5492,10 @@ int ring_buffer_swap_cpu(struct trace_buffer *buffer_a,
+ 	atomic_inc(&cpu_buffer_a->record_disabled);
+ 	atomic_inc(&cpu_buffer_b->record_disabled);
+ 
+-	ret = -EBUSY;
+-	if (local_read(&cpu_buffer_a->committing))
++	/* Do not swap if either buffer is in the process of writing */
++	if (cpu_buffer_a->current_context)
+ 		goto out_dec;
+-	if (local_read(&cpu_buffer_b->committing))
++	if (cpu_buffer_b->current_context)
+ 		goto out_dec;
+ 
+ 	/*
+@@ -5520,7 +5518,6 @@ int ring_buffer_swap_cpu(struct trace_buffer *buffer_a,
+ out_dec:
+ 	atomic_dec(&cpu_buffer_a->record_disabled);
+ 	atomic_dec(&cpu_buffer_b->record_disabled);
+-out:
+ 	return ret;
+ }
+ EXPORT_SYMBOL_GPL(ring_buffer_swap_cpu);
+diff --git a/mm/huge_memory.c b/mm/huge_memory.c
+index ff95a802d1582c..7ab67798492438 100644
+--- a/mm/huge_memory.c
++++ b/mm/huge_memory.c
+@@ -38,6 +38,7 @@
+ #include <linux/sched/sysctl.h>
+ #include <linux/memory-tiers.h>
+ #include <linux/compat.h>
++#include <linux/cleanup.h>
+ 
+ #include <asm/tlb.h>
+ #include <asm/pgalloc.h>
+@@ -69,6 +70,7 @@ unsigned long transparent_hugepage_flags __read_mostly =
+ static struct shrinker deferred_split_shrinker;
+ 
+ static atomic_t huge_zero_refcount;
++static DEFINE_SPINLOCK(huge_zero_lock);
+ struct page *huge_zero_page __read_mostly;
+ unsigned long huge_zero_pfn __read_mostly = ~0UL;
+ 
+@@ -144,7 +146,8 @@ bool hugepage_vma_check(struct vm_area_struct *vma, unsigned long vm_flags,
+ static bool get_huge_zero_page(void)
+ {
+ 	struct page *zero_page;
+-retry:
++
++	/* Paired with atomic_set_release(). */
+ 	if (likely(atomic_inc_not_zero(&huge_zero_refcount)))
+ 		return true;
+ 
+@@ -154,17 +157,22 @@ retry:
+ 		count_vm_event(THP_ZERO_PAGE_ALLOC_FAILED);
+ 		return false;
+ 	}
+-	preempt_disable();
+-	if (cmpxchg(&huge_zero_page, NULL, zero_page)) {
+-		preempt_enable();
++
++	/* Paired with critical section in shrink_huge_zero_page_scan(). */
++	spin_lock(&huge_zero_lock);
++	if (huge_zero_page) {
++		/* Somebody else already installed it. */
++		atomic_inc(&huge_zero_refcount);
++		spin_unlock(&huge_zero_lock);
+ 		__free_pages(zero_page, compound_order(zero_page));
+-		goto retry;
++		return true;
+ 	}
++	WRITE_ONCE(huge_zero_page, zero_page);
+ 	WRITE_ONCE(huge_zero_pfn, page_to_pfn(zero_page));
++	/* Paired with atomic_inc_not_zero(). +1 for shrinker pin. */
++	atomic_set_release(&huge_zero_refcount, 2);
++	spin_unlock(&huge_zero_lock);
+ 
+-	/* We take additional reference here. It will be put back by shrinker */
+-	atomic_set(&huge_zero_refcount, 2);
+-	preempt_enable();
+ 	count_vm_event(THP_ZERO_PAGE_ALLOC);
+ 	return true;
+ }
+@@ -208,15 +216,22 @@ static unsigned long shrink_huge_zero_page_count(struct shrinker *shrink,
+ static unsigned long shrink_huge_zero_page_scan(struct shrinker *shrink,
+ 				       struct shrink_control *sc)
+ {
+-	if (atomic_cmpxchg(&huge_zero_refcount, 1, 0) == 1) {
+-		struct page *zero_page = xchg(&huge_zero_page, NULL);
+-		BUG_ON(zero_page == NULL);
++	struct page *zero_page;
++
++	/* Paired with critical section in get_huge_zero_page(). */
++	scoped_guard(spinlock, &huge_zero_lock) {
++		/* Paired with atomic_inc_not_zero() in get_huge_zero_page(). */
++		if (atomic_cmpxchg(&huge_zero_refcount, 1, 0) != 1)
++			return 0;
++
++		zero_page = huge_zero_page;
++		VM_WARN_ON_ONCE(!zero_page);
++		WRITE_ONCE(huge_zero_page, NULL);
+ 		WRITE_ONCE(huge_zero_pfn, ~0UL);
+-		__free_pages(zero_page, compound_order(zero_page));
+-		return HPAGE_PMD_NR;
+ 	}
+ 
+-	return 0;
++	__free_pages(zero_page, compound_order(zero_page));
++	return HPAGE_PMD_NR;
+ }
+ 
+ static struct shrinker huge_zero_page_shrinker = {
+diff --git a/mm/internal.h b/mm/internal.h
+index f773db493a99d0..03cfd9f7365976 100644
+--- a/mm/internal.h
++++ b/mm/internal.h
+@@ -10,6 +10,7 @@
+ #include <linux/fs.h>
+ #include <linux/mm.h>
+ #include <linux/pagemap.h>
++#include <linux/pagewalk.h>
+ #include <linux/rmap.h>
+ #include <linux/tracepoint-defs.h>
+ 
+@@ -1229,4 +1230,10 @@ struct vma_prepare {
+ 	struct vm_area_struct *remove;
+ 	struct vm_area_struct *remove2;
+ };
++
++/* pagewalk.c */
++int walk_page_range_debug(struct mm_struct *mm, unsigned long start,
++			  unsigned long end, const struct mm_walk_ops *ops,
++			  pgd_t *pgd, void *private);
++
+ #endif	/* __MM_INTERNAL_H */
+diff --git a/mm/migrate_device.c b/mm/migrate_device.c
+index f209dc512d8216..d4ee7ab735a384 100644
+--- a/mm/migrate_device.c
++++ b/mm/migrate_device.c
+@@ -194,7 +194,8 @@ again:
+ 			bool anon_exclusive;
+ 			pte_t swp_pte;
+ 
+-			flush_cache_page(vma, addr, pte_pfn(pte));
++			if (pte_present(pte))
++				flush_cache_page(vma, addr, pte_pfn(pte));
+ 			anon_exclusive = PageAnon(page) && PageAnonExclusive(page);
+ 			if (anon_exclusive) {
+ 				pte = ptep_clear_flush(vma, addr, ptep);
+@@ -213,7 +214,7 @@ again:
+ 			migrate->cpages++;
+ 
+ 			/* Set the dirty flag on the folio now the pte is gone. */
+-			if (pte_dirty(pte))
++			if (pte_present(pte) && pte_dirty(pte))
+ 				folio_mark_dirty(page_folio(page));
+ 
+ 			/* Setup special migration page table entry */
+diff --git a/mm/pagewalk.c b/mm/pagewalk.c
+index b7d7e4fcfad7aa..ffb583e0b0c7e0 100644
+--- a/mm/pagewalk.c
++++ b/mm/pagewalk.c
+@@ -527,8 +527,7 @@ int walk_page_range(struct mm_struct *mm, unsigned long start,
+ }
+ 
+ /**
+- * walk_page_range_novma - walk a range of pagetables not backed by a vma
+- * @mm:		mm_struct representing the target process of page table walk
++ * walk_kernel_page_table_range - walk a range of kernel pagetables.
+  * @start:	start address of the virtual address range
+  * @end:	end address of the virtual address range
+  * @ops:	operation to call during the walk
+@@ -538,13 +537,17 @@ int walk_page_range(struct mm_struct *mm, unsigned long start,
+  * Similar to walk_page_range() but can walk any page tables even if they are
+  * not backed by VMAs. Because 'unusual' entries may be walked this function
+  * will also not lock the PTEs for the pte_entry() callback. This is useful for
+- * walking the kernel pages tables or page tables for firmware.
++ * walking kernel pages tables or page tables for firmware.
++ *
++ * Note: Be careful to walk the kernel pages tables, the caller may be need to
++ * take other effective approaches (mmap lock may be insufficient) to prevent
++ * the intermediate kernel page tables belonging to the specified address range
++ * from being freed (e.g. memory hot-remove).
+  */
+-int walk_page_range_novma(struct mm_struct *mm, unsigned long start,
+-			  unsigned long end, const struct mm_walk_ops *ops,
+-			  pgd_t *pgd,
+-			  void *private)
++int walk_kernel_page_table_range(unsigned long start, unsigned long end,
++		const struct mm_walk_ops *ops, pgd_t *pgd, void *private)
+ {
++	struct mm_struct *mm = &init_mm;
+ 	struct mm_walk walk = {
+ 		.ops		= ops,
+ 		.mm		= mm,
+@@ -553,10 +556,71 @@ int walk_page_range_novma(struct mm_struct *mm, unsigned long start,
+ 		.no_vma		= true
+ 	};
+ 
+-	if (start >= end || !walk.mm)
++	if (start >= end)
+ 		return -EINVAL;
+ 
+-	mmap_assert_write_locked(walk.mm);
++	/*
++	 * Kernel intermediate page tables are usually not freed, so the mmap
++	 * read lock is sufficient. But there are some exceptions.
++	 * E.g. memory hot-remove. In which case, the mmap lock is insufficient
++	 * to prevent the intermediate kernel pages tables belonging to the
++	 * specified address range from being freed. The caller should take
++	 * other actions to prevent this race.
++	 */
++	mmap_assert_locked(mm);
++
++	return walk_pgd_range(start, end, &walk);
++}
++
++/**
++ * walk_page_range_debug - walk a range of pagetables not backed by a vma
++ * @mm:		mm_struct representing the target process of page table walk
++ * @start:	start address of the virtual address range
++ * @end:	end address of the virtual address range
++ * @ops:	operation to call during the walk
++ * @pgd:	pgd to walk if different from mm->pgd
++ * @private:	private data for callbacks' usage
++ *
++ * Similar to walk_page_range() but can walk any page tables even if they are
++ * not backed by VMAs. Because 'unusual' entries may be walked this function
++ * will also not lock the PTEs for the pte_entry() callback.
++ *
++ * This is for debugging purposes ONLY.
++ *
++ * The mmap write lock must be held.
++ */
++int walk_page_range_debug(struct mm_struct *mm, unsigned long start,
++			  unsigned long end, const struct mm_walk_ops *ops,
++			  pgd_t *pgd, void *private)
++{
++	struct mm_walk walk = {
++		.ops		= ops,
++		.mm		= mm,
++		.pgd		= pgd,
++		.private	= private,
++		.no_vma		= true
++	};
++
++	/*
++	 * When walking userland page tables, an mmap write lock must be held to
++	 * account for munmap() downgrading to an mmap read lock when tearing
++	 * down page tables.
++	 *
++	 * When walking kernel page tables, an mmap write lock must also be held
++	 * to account for page table freeing on vmap huge page mapping.
++	 */
++	mmap_assert_write_locked(mm);
++	/*
++	 * x86, arm64 ptdump allow walks of efi mm's and x86 ptdump allows walks
++	 * of arbitrary mm's.
++	 *
++	 * However, they both must also hold the init_mm lock to account for
++	 * concurrent kernel page table freeing.
++	 */
++	mmap_assert_write_locked(&init_mm);
++
++	if (start >= end)
++		return -EINVAL;
+ 
+ 	return walk_pgd_range(start, end, &walk);
+ }
+diff --git a/mm/ptdump.c b/mm/ptdump.c
+index e46df2c24d8583..48d1bcdc79a739 100644
+--- a/mm/ptdump.c
++++ b/mm/ptdump.c
+@@ -3,6 +3,7 @@
+ #include <linux/pagewalk.h>
+ #include <linux/ptdump.h>
+ #include <linux/kasan.h>
++#include "internal.h"
+ 
+ #if defined(CONFIG_KASAN_GENERIC) || defined(CONFIG_KASAN_SW_TAGS)
+ /*
+@@ -154,11 +155,18 @@ void ptdump_walk_pgd(struct ptdump_state *st, struct mm_struct *mm, pgd_t *pgd)
+ 
+ 	get_online_mems();
+ 	mmap_write_lock(mm);
++	/* To stabilise kernel page tables we must hold the init_mm lock too. */
++	if (mm != &init_mm)
++		mmap_write_lock_nested(&init_mm, SINGLE_DEPTH_NESTING);
++
+ 	while (range->start != range->end) {
+-		walk_page_range_novma(mm, range->start, range->end,
++		walk_page_range_debug(mm, range->start, range->end,
+ 				      &ptdump_ops, pgd, st);
+ 		range++;
+ 	}
++
++	if (mm != &init_mm)
++		mmap_write_unlock(&init_mm);
+ 	mmap_write_unlock(mm);
+ 	put_online_mems();
+ 
+diff --git a/mm/userfaultfd.c b/mm/userfaultfd.c
+index 92fe2a76f4b512..99438f0950e3c2 100644
+--- a/mm/userfaultfd.c
++++ b/mm/userfaultfd.c
+@@ -891,3 +891,29 @@ out_unlock:
+ 	mmap_read_unlock(dst_mm);
+ 	return err;
+ }
++
++bool vma_can_userfault(struct vm_area_struct *vma, unsigned long vm_flags)
++{
++	if (vma->vm_flags & VM_SHADOW_STACK)
++		return false;
++
++	if (!is_vm_hugetlb_page(vma) && (vma->vm_flags & VM_SPECIAL))
++		return false;
++
++	if ((vm_flags & VM_UFFD_MINOR) &&
++	    (!is_vm_hugetlb_page(vma) && !vma_is_shmem(vma)))
++		return false;
++
++	/*
++	 * If user requested uffd-wp but not enabled pte markers for
++	 * uffd-wp, then shmem & hugetlbfs are not supported but only
++	 * anonymous.
++	 */
++	if (!uffd_supports_wp_marker() && (vm_flags & VM_UFFD_WP) &&
++	    !vma_is_anonymous(vma))
++		return false;
++
++	/* By default, allow any of anon|shmem|hugetlb */
++	return vma_is_anonymous(vma) || is_vm_hugetlb_page(vma) ||
++	    vma_is_shmem(vma);
++}
+diff --git a/mm/vmalloc.c b/mm/vmalloc.c
+index ed47962a8a0bfd..3681f0207b218e 100644
+--- a/mm/vmalloc.c
++++ b/mm/vmalloc.c
+@@ -42,6 +42,7 @@
+ #include <linux/sched/mm.h>
+ #include <asm/tlbflush.h>
+ #include <asm/shmparam.h>
++#include <linux/cleanup.h>
+ 
+ #define CREATE_TRACE_POINTS
+ #include <trace/events/vmalloc.h>
+@@ -142,10 +143,24 @@ static int vmap_try_huge_pmd(pmd_t *pmd, unsigned long addr, unsigned long end,
+ 	if (!IS_ALIGNED(phys_addr, PMD_SIZE))
+ 		return 0;
+ 
+-	if (pmd_present(*pmd) && !pmd_free_pte_page(pmd, addr))
+-		return 0;
++	if (!pmd_present(*pmd))
++		return pmd_set_huge(pmd, phys_addr, prot);
+ 
+-	return pmd_set_huge(pmd, phys_addr, prot);
++	/*
++	 * Acquire the mmap read lock to exclude ptdump, which walks
++	 * kernel page tables it does not own under the mmap write lock.
++	 *
++	 * Concurrent read lock holders are safe: each exclusively owns
++	 * the range it operates on and cannot reach this page table.
++	 */
++#ifndef CONFIG_ARM64
++	scoped_cond_guard(mmap_read_lock_try, return 0, &init_mm)
++#endif
++	{
++		if (!pmd_free_pte_page(pmd, addr))
++			return 0;
++		return pmd_set_huge(pmd, phys_addr, prot);
++	}
+ }
+ 
+ static int vmap_pmd_range(pud_t *pud, unsigned long addr, unsigned long end,
+@@ -192,10 +207,18 @@ static int vmap_try_huge_pud(pud_t *pud, unsigned long addr, unsigned long end,
+ 	if (!IS_ALIGNED(phys_addr, PUD_SIZE))
+ 		return 0;
+ 
+-	if (pud_present(*pud) && !pud_free_pmd_page(pud, addr))
+-		return 0;
++	if (!pud_present(*pud))
++		return pud_set_huge(pud, phys_addr, prot);
+ 
+-	return pud_set_huge(pud, phys_addr, prot);
++	/* See comment in vmap_try_huge_pmd(). */
++#ifndef CONFIG_ARM64
++	scoped_cond_guard(mmap_read_lock_try, return 0, &init_mm)
++#endif
++	{
++		if (!pud_free_pmd_page(pud, addr))
++			return 0;
++		return pud_set_huge(pud, phys_addr, prot);
++	}
+ }
+ 
+ static int vmap_pud_range(p4d_t *p4d, unsigned long addr, unsigned long end,
+@@ -243,10 +266,18 @@ static int vmap_try_huge_p4d(p4d_t *p4d, unsigned long addr, unsigned long end,
+ 	if (!IS_ALIGNED(phys_addr, P4D_SIZE))
+ 		return 0;
+ 
+-	if (p4d_present(*p4d) && !p4d_free_pud_page(p4d, addr))
+-		return 0;
++	if (!p4d_present(*p4d))
++		return p4d_set_huge(p4d, phys_addr, prot);
+ 
+-	return p4d_set_huge(p4d, phys_addr, prot);
++	/* See comment in vmap_try_huge_pmd(). */
++#ifndef CONFIG_ARM64
++	scoped_cond_guard(mmap_read_lock_try, return 0, &init_mm)
++#endif
++	{
++		if (!p4d_free_pud_page(p4d, addr))
++			return 0;
++		return p4d_set_huge(p4d, phys_addr, prot);
++	}
+ }
+ 
+ static int vmap_p4d_range(pgd_t *pgd, unsigned long addr, unsigned long end,
+diff --git a/net/ceph/cls_lock_client.c b/net/ceph/cls_lock_client.c
+index 66136a4c1ce7fe..a9655678be6fdd 100644
+--- a/net/ceph/cls_lock_client.c
++++ b/net/ceph/cls_lock_client.c
+@@ -259,7 +259,8 @@ static int decode_locker(void **p, void *end, struct ceph_locker *locker)
+ 	if (ret)
+ 		return ret;
+ 
+-	ceph_decode_copy(p, &locker->id.name, sizeof(locker->id.name));
++	ceph_decode_copy_safe(p, end, &locker->id.name,
++			      sizeof(locker->id.name), bad);
+ 	s = ceph_extract_encoded_string(p, end, NULL, GFP_NOIO);
+ 	if (IS_ERR(s))
+ 		return PTR_ERR(s);
+@@ -270,19 +271,23 @@ static int decode_locker(void **p, void *end, struct ceph_locker *locker)
+ 	if (ret)
+ 		return ret;
+ 
+-	*p += sizeof(struct ceph_timespec); /* skip expiration */
++	/* skip expiration */
++	ceph_decode_skip_n(p, end, sizeof(struct ceph_timespec), bad);
+ 
+ 	ret = ceph_decode_entity_addr(p, end, &locker->info.addr);
+ 	if (ret)
+ 		return ret;
+ 
+-	len = ceph_decode_32(p);
+-	*p += len; /* skip description */
++	/* skip description */
++	ceph_decode_skip_string(p, end, bad);
+ 
+ 	dout("%s %s%llu cookie %s addr %s\n", __func__,
+ 	     ENTITY_NAME(locker->id.name), locker->id.cookie,
+ 	     ceph_pr_addr(&locker->info.addr));
+ 	return 0;
++
++bad:
++	return -EINVAL;
+ }
+ 
+ static int decode_lockers(void **p, void *end, u8 *type, char **tag,
+@@ -299,7 +304,7 @@ static int decode_lockers(void **p, void *end, u8 *type, char **tag,
+ 	if (ret)
+ 		return ret;
+ 
+-	*num_lockers = ceph_decode_32(p);
++	ceph_decode_32_safe(p, end, *num_lockers, err_inval);
+ 	*lockers = kcalloc(*num_lockers, sizeof(**lockers), GFP_NOIO);
+ 	if (!*lockers)
+ 		return -ENOMEM;
+@@ -310,7 +315,8 @@ static int decode_lockers(void **p, void *end, u8 *type, char **tag,
+ 			goto err_free_lockers;
+ 	}
+ 
+-	*type = ceph_decode_8(p);
++	ret = -EINVAL;
++	ceph_decode_8_safe(p, end, *type, err_free_lockers);
+ 	s = ceph_extract_encoded_string(p, end, NULL, GFP_NOIO);
+ 	if (IS_ERR(s)) {
+ 		ret = PTR_ERR(s);
+@@ -320,6 +326,9 @@ static int decode_lockers(void **p, void *end, u8 *type, char **tag,
+ 	*tag = s;
+ 	return 0;
+ 
++err_inval:
++	return -EINVAL;
++
+ err_free_lockers:
+ 	ceph_free_lockers(*lockers, *num_lockers);
+ 	return ret;
+diff --git a/net/ceph/decode.c b/net/ceph/decode.c
+index bc109a1a4616fa..2f21af38cd9a5b 100644
+--- a/net/ceph/decode.c
++++ b/net/ceph/decode.c
+@@ -87,8 +87,9 @@ bad:
+ EXPORT_SYMBOL(ceph_decode_entity_addr);
+ 
+ /*
+- * Return addr of desired type (MSGR2 or LEGACY) or error.
+- * Make sure there is only one match.
++ * Return addr of desired type (MSGR2 or LEGACY) or error.  In case of
++ * multiple matches, use the first one for compatibility with userspace
++ * messenger.
+  *
+  * Assume encoding with MSG_ADDR2.
+  */
+@@ -121,14 +122,13 @@ int ceph_decode_entity_addrvec(void **p, void *end, bool msgr2,
+ 
+ 		dout("%s i %d addr %s\n", __func__, i, ceph_pr_addr(&tmp_addr));
+ 		if (tmp_addr.type == my_type) {
+-			if (found) {
+-				pr_err("another match of type %d in addrvec\n",
+-				       le32_to_cpu(my_type));
+-				return -EINVAL;
++			if (!found) {
++				memcpy(addr, &tmp_addr, sizeof(*addr));
++				found = true;
++			} else {
++				dout("%s skipping extra match of type %d in addrvec\n",
++				     __func__, le32_to_cpu(my_type));
+ 			}
+-
+-			memcpy(addr, &tmp_addr, sizeof(*addr));
+-			found = true;
+ 		}
+ 	}
+ 
+diff --git a/net/ceph/osdmap.c b/net/ceph/osdmap.c
+index 30d75970be4496..ff06ba2965cf9c 100644
+--- a/net/ceph/osdmap.c
++++ b/net/ceph/osdmap.c
+@@ -1440,7 +1440,7 @@ static struct ceph_pg_mapping *__decode_pg_temp(void **p, void *end,
+ 	ceph_decode_32_safe(p, end, len, e_inval);
+ 	if (len == 0 && incremental)
+ 		return NULL;	/* new_pg_temp: [] to remove */
+-	if (len > (SIZE_MAX - sizeof(*pg)) / sizeof(u32))
++	if (len > CEPH_PG_MAX_SIZE)
+ 		return ERR_PTR(-EINVAL);
+ 
+ 	ceph_decode_need(p, end, len * sizeof(u32), e_inval);
+@@ -1621,7 +1621,7 @@ static struct ceph_pg_mapping *__decode_pg_upmap_items(void **p, void *end,
+ 	u32 len, i;
+ 
+ 	ceph_decode_32_safe(p, end, len, e_inval);
+-	if (len > (SIZE_MAX - sizeof(*pg)) / (2 * sizeof(u32)))
++	if (len > CEPH_PG_MAX_SIZE)
+ 		return ERR_PTR(-EINVAL);
+ 
+ 	ceph_decode_need(p, end, 2 * len * sizeof(u32), e_inval);
+@@ -2811,9 +2811,10 @@ static void get_temp_osds(struct ceph_osdmap *osdmap,
+ 		}
+ 	}
+ 
+-	/* primary_temp? */
++	/* primary_temp? (shouldn't ever be a nonexistent or down OSD) */
+ 	pg = lookup_pg_mapping(&osdmap->primary_temp, pgid);
+-	if (pg)
++	if (pg && !WARN_ON_ONCE(ceph_osd_is_down(osdmap,
++						 pg->primary_temp.osd)))
+ 		temp->primary = pg->primary_temp.osd;
+ }
+ 
+diff --git a/net/core/dev.c b/net/core/dev.c
+index 0fa5431de2cc09..8b0a0d449afdf6 100644
+--- a/net/core/dev.c
++++ b/net/core/dev.c
+@@ -4025,7 +4025,8 @@ EXPORT_SYMBOL_GPL(netdev_xmit_skip_txqueue);
+ #endif /* CONFIG_NET_EGRESS */
+ 
+ #ifdef CONFIG_NET_XGRESS
+-static int tc_run(struct tcx_entry *entry, struct sk_buff *skb)
++static int tc_run(struct tcx_entry *entry, struct sk_buff *skb,
++		  enum skb_drop_reason *drop_reason)
+ {
+ 	int ret = TC_ACT_UNSPEC;
+ #ifdef CONFIG_NET_CLS_ACT
+@@ -4045,12 +4046,14 @@ static int tc_run(struct tcx_entry *entry, struct sk_buff *skb)
+ 
+ 	tc_skb_cb(skb)->mru = 0;
+ 	tc_skb_cb(skb)->post_ct = false;
++	tcf_set_drop_reason(skb, *drop_reason);
+ 
+ 	mini_qdisc_bstats_cpu_update(miniq, skb);
+ 	ret = tcf_classify(skb, miniq->block, miniq->filter_list, &res, false);
+ 	/* Only tcf related quirks below. */
+ 	switch (ret) {
+ 	case TC_ACT_SHOT:
++		*drop_reason = tcf_get_drop_reason(skb);
+ 		mini_qdisc_qstats_cpu_drop(miniq);
+ 		break;
+ 	case TC_ACT_OK:
+@@ -4100,6 +4103,7 @@ sch_handle_ingress(struct sk_buff *skb, struct packet_type **pt_prev, int *ret,
+ 		   struct net_device *orig_dev, bool *another)
+ {
+ 	struct bpf_mprog_entry *entry = rcu_dereference_bh(skb->dev->tcx_ingress);
++	enum skb_drop_reason drop_reason = SKB_DROP_REASON_TC_INGRESS;
+ 	int sch_ret;
+ 
+ 	if (!entry)
+@@ -4117,7 +4121,7 @@ sch_handle_ingress(struct sk_buff *skb, struct packet_type **pt_prev, int *ret,
+ 		if (sch_ret != TC_ACT_UNSPEC)
+ 			goto ingress_verdict;
+ 	}
+-	sch_ret = tc_run(tcx_entry(entry), skb);
++	sch_ret = tc_run(tcx_entry(entry), skb, &drop_reason);
+ ingress_verdict:
+ 	switch (sch_ret) {
+ 	case TC_ACT_REDIRECT:
+@@ -4134,7 +4138,7 @@ ingress_verdict:
+ 		*ret = NET_RX_SUCCESS;
+ 		return NULL;
+ 	case TC_ACT_SHOT:
+-		kfree_skb_reason(skb, SKB_DROP_REASON_TC_INGRESS);
++		kfree_skb_reason(skb, drop_reason);
+ 		*ret = NET_RX_DROP;
+ 		return NULL;
+ 	/* used by tc_run */
+@@ -4155,6 +4159,7 @@ static __always_inline struct sk_buff *
+ sch_handle_egress(struct sk_buff *skb, int *ret, struct net_device *dev)
+ {
+ 	struct bpf_mprog_entry *entry = rcu_dereference_bh(dev->tcx_egress);
++	enum skb_drop_reason drop_reason = SKB_DROP_REASON_TC_EGRESS;
+ 	int sch_ret;
+ 
+ 	if (!entry)
+@@ -4168,7 +4173,7 @@ sch_handle_egress(struct sk_buff *skb, int *ret, struct net_device *dev)
+ 		if (sch_ret != TC_ACT_UNSPEC)
+ 			goto egress_verdict;
+ 	}
+-	sch_ret = tc_run(tcx_entry(entry), skb);
++	sch_ret = tc_run(tcx_entry(entry), skb, &drop_reason);
+ egress_verdict:
+ 	switch (sch_ret) {
+ 	case TC_ACT_REDIRECT:
+@@ -4177,7 +4182,7 @@ egress_verdict:
+ 		*ret = NET_XMIT_SUCCESS;
+ 		return NULL;
+ 	case TC_ACT_SHOT:
+-		kfree_skb_reason(skb, SKB_DROP_REASON_TC_EGRESS);
++		kfree_skb_reason(skb, drop_reason);
+ 		*ret = NET_XMIT_DROP;
+ 		return NULL;
+ 	/* used by tc_run */
+@@ -10705,6 +10710,20 @@ struct rtnl_link_stats64 *dev_get_stats(struct net_device *dev,
+ 	const struct net_device_ops *ops = dev->netdev_ops;
+ 	const struct net_device_core_stats __percpu *p;
+ 
++	/*
++	 * IPv{4,6} and udp tunnels share common stat helpers and use
++	 * different stat type (NETDEV_PCPU_STAT_TSTATS vs
++	 * NETDEV_PCPU_STAT_DSTATS). Ensure the accounting is consistent.
++	 */
++	BUILD_BUG_ON(offsetof(struct pcpu_sw_netstats, rx_bytes) !=
++		     offsetof(struct pcpu_dstats, rx_bytes));
++	BUILD_BUG_ON(offsetof(struct pcpu_sw_netstats, rx_packets) !=
++		     offsetof(struct pcpu_dstats, rx_packets));
++	BUILD_BUG_ON(offsetof(struct pcpu_sw_netstats, tx_bytes) !=
++		     offsetof(struct pcpu_dstats, tx_bytes));
++	BUILD_BUG_ON(offsetof(struct pcpu_sw_netstats, tx_packets) !=
++		     offsetof(struct pcpu_dstats, tx_packets));
++
+ 	if (ops->ndo_get_stats64) {
+ 		memset(storage, 0, sizeof(*storage));
+ 		ops->ndo_get_stats64(dev, storage);
+diff --git a/net/core/gro.c b/net/core/gro.c
+index 1555e6bb5c9d72..e9ed98dc628d82 100644
+--- a/net/core/gro.c
++++ b/net/core/gro.c
+@@ -230,6 +230,37 @@ done:
+ 	return 0;
+ }
+ 
++int skb_gro_receive_list(struct sk_buff *p, struct sk_buff *skb)
++{
++	/* make sure to check flush flag and to not merge */
++	if (unlikely(p->len + skb->len >= 65536 ||
++		     NAPI_GRO_CB(skb)->flush))
++		return -E2BIG;
++
++	if (NAPI_GRO_CB(p)->last == p)
++		skb_shinfo(p)->frag_list = skb;
++	else
++		NAPI_GRO_CB(p)->last->next = skb;
++
++	skb_pull(skb, skb_gro_offset(skb));
++
++	NAPI_GRO_CB(p)->last = skb;
++	NAPI_GRO_CB(p)->count++;
++	p->data_len += skb->len;
++
++	/* sk ownership - if any - completely transferred to the aggregated packet */
++	skb->destructor = NULL;
++	skb->sk = NULL;
++	p->truesize += skb->truesize;
++	p->len += skb->len;
++
++	skb_shinfo(p)->flags |= skb_shinfo(skb)->flags & SKBFL_SHARED_FRAG;
++
++	NAPI_GRO_CB(skb)->same_flow = 1;
++
++	return 0;
++}
++
+ 
+ static void napi_gro_complete(struct napi_struct *napi, struct sk_buff *skb)
+ {
+diff --git a/net/core/pktgen.c b/net/core/pktgen.c
+index 6afea369ca2132..cbb916f9edcac3 100644
+--- a/net/core/pktgen.c
++++ b/net/core/pktgen.c
+@@ -284,7 +284,8 @@ struct pktgen_dev {
+ 	int pkt_overhead;	/* overhead for MPLS, VLANs, IPSEC etc */
+ 	int nfrags;
+ 	int removal_mark;	/* non-zero => the device is marked for
+-				 * removal by worker thread */
++				 * removal by worker thread
++				 */
+ 
+ 	struct page *page;
+ 	u64 delay;		/* nano-seconds */
+@@ -347,10 +348,12 @@ struct pktgen_dev {
+ 	__u16 udp_dst_max;	/* exclusive, dest UDP port */
+ 
+ 	/* DSCP + ECN */
+-	__u8 tos;            /* six MSB of (former) IPv4 TOS
+-				are for dscp codepoint */
+-	__u8 traffic_class;  /* ditto for the (former) Traffic Class in IPv6
+-				(see RFC 3260, sec. 4) */
++	__u8 tos;		/* six MSB of (former) IPv4 TOS
++				 * are for dscp codepoint
++				 */
++	__u8 traffic_class;	/* ditto for the (former) Traffic Class in IPv6
++				 * (see RFC 3260, sec. 4)
++				 */
+ 
+ 	/* IMIX */
+ 	unsigned int n_imix_entries;
+@@ -390,12 +393,12 @@ struct pktgen_dev {
+ 
+ 	__u8 hh[14];
+ 	/* = {
+-	   0x00, 0x80, 0xC8, 0x79, 0xB3, 0xCB,
+-
+-	   We fill in SRC address later
+-	   0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+-	   0x08, 0x00
+-	   };
++	 * 0x00, 0x80, 0xC8, 0x79, 0xB3, 0xCB,
++	 *
++	 * We fill in SRC address later
++	 * 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
++	 * 0x08, 0x00
++	 * };
+ 	 */
+ 	__u16 pad;		/* pad out the hh struct to an even 16 bytes */
+ 
+@@ -459,7 +462,8 @@ struct pktgen_thread {
+ 	char result[512];
+ 
+ 	/* Field for thread to receive "posted" events terminate,
+-	   stop ifs etc. */
++	 * stop ifs etc.
++	 */
+ 
+ 	u32 control;
+ 	int cpu;
+@@ -2343,7 +2347,7 @@ static inline int f_pick(struct pktgen_dev *pkt_dev)
+ #ifdef CONFIG_XFRM
+ /* If there was already an IPSEC SA, we keep it as is, else
+  * we go look for it ...
+-*/
++ */
+ #define DUMMY_MARK 0
+ static void get_ipsec_sa(struct pktgen_dev *pkt_dev, int flow)
+ {
+@@ -2642,7 +2646,8 @@ static int pktgen_output_ipsec(struct sk_buff *skb, struct pktgen_dev *pkt_dev)
+ 	if (!x)
+ 		return 0;
+ 	/* XXX: we dont support tunnel mode for now until
+-	 * we resolve the dst issue */
++	 * we resolve the dst issue
++	 */
+ 	if ((x->props.mode != XFRM_MODE_TRANSPORT) && (pkt_dev->spi == 0))
+ 		return 0;
+ 
+@@ -3710,7 +3715,8 @@ static int add_dev_to_thread(struct pktgen_thread *t,
+ 	 * userspace on another CPU than the kthread.  The if_lock()
+ 	 * is used here to sync with concurrent instances of
+ 	 * _rem_dev_from_if_list() invoked via kthread, which is also
+-	 * updating the if_list */
++	 * updating the if_list
++	 */
+ 	if_lock(t);
+ 
+ 	if (pkt_dev->pg_thread) {
+@@ -3880,6 +3886,7 @@ static void _rem_dev_from_if_list(struct pktgen_thread *t,
+ 	struct pktgen_dev *p;
+ 
+ 	if_lock(t);
++	proc_remove(pkt_dev->entry);
+ 	list_for_each_safe(q, n, &t->if_list) {
+ 		p = list_entry(q, struct pktgen_dev, list);
+ 		if (p == pkt_dev)
+@@ -3907,10 +3914,8 @@ static int pktgen_remove_device(struct pktgen_thread *t,
+ 
+ 	/* Remove proc before if_list entry, because add_device uses
+ 	 * list to determine if interface already exist, avoid race
+-	 * with proc_create_data() */
+-	proc_remove(pkt_dev->entry);
+-
+-	/* And update the thread if_list */
++	 * with proc_create_data()
++	 */
+ 	_rem_dev_from_if_list(t, pkt_dev);
+ 
+ #ifdef CONFIG_XFRM
+diff --git a/net/ipv4/bpf_tcp_ca.c b/net/ipv4/bpf_tcp_ca.c
+index 39dcccf0f174b9..af29b75fc4860e 100644
+--- a/net/ipv4/bpf_tcp_ca.c
++++ b/net/ipv4/bpf_tcp_ca.c
+@@ -128,7 +128,7 @@ static int bpf_tcp_ca_btf_struct_access(struct bpf_verifier_log *log,
+ BPF_CALL_2(bpf_tcp_send_ack, struct tcp_sock *, tp, u32, rcv_nxt)
+ {
+ 	/* bpf_tcp_ca prog cannot have NULL tp */
+-	__tcp_send_ack((struct sock *)tp, rcv_nxt);
++	__tcp_send_ack((struct sock *)tp, rcv_nxt, 0);
+ 	return 0;
+ }
+ 
+diff --git a/net/ipv4/tcp_dctcp.h b/net/ipv4/tcp_dctcp.h
+index d69a77cbd0c75f..4b0259111d8166 100644
+--- a/net/ipv4/tcp_dctcp.h
++++ b/net/ipv4/tcp_dctcp.h
+@@ -28,7 +28,7 @@ static inline void dctcp_ece_ack_update(struct sock *sk, enum tcp_ca_event evt,
+ 		 */
+ 		if (inet_csk(sk)->icsk_ack.pending & ICSK_ACK_TIMER) {
+ 			dctcp_ece_ack_cwr(sk, *ce_state);
+-			__tcp_send_ack(sk, *prior_rcv_nxt);
++			__tcp_send_ack(sk, *prior_rcv_nxt, 0);
+ 		}
+ 		inet_csk(sk)->icsk_ack.pending |= ICSK_ACK_NOW;
+ 	}
+diff --git a/net/ipv4/tcp_input.c b/net/ipv4/tcp_input.c
+index 9efb84658a82dc..1a0dd36d507099 100644
+--- a/net/ipv4/tcp_input.c
++++ b/net/ipv4/tcp_input.c
+@@ -3739,24 +3739,17 @@ bool tcp_oow_rate_limited(struct net *net, const struct sk_buff *skb,
+ 	return __tcp_oow_rate_limited(net, mib_idx, last_oow_ack_time);
+ }
+ 
+-/* RFC 5961 7 [ACK Throttling] */
+-static void tcp_send_challenge_ack(struct sock *sk)
++/* Consume one slot from the per-netns RFC 5961 challenge ACK quota.
++ * Returns true if a challenge ACK may be sent.
++ */
++static bool tcp_challenge_ack_allowed(struct net *net)
+ {
+-	struct tcp_sock *tp = tcp_sk(sk);
+-	struct net *net = sock_net(sk);
+ 	u32 count, now, ack_limit;
+ 
+-	/* First check our per-socket dupack rate limit. */
+-	if (__tcp_oow_rate_limited(net,
+-				   LINUX_MIB_TCPACKSKIPPEDCHALLENGE,
+-				   &tp->last_oow_ack_time))
+-		return;
+-
+ 	ack_limit = READ_ONCE(net->ipv4.sysctl_tcp_challenge_ack_limit);
+ 	if (ack_limit == INT_MAX)
+-		goto send_ack;
++		return true;
+ 
+-	/* Then check host-wide RFC 5961 rate limit. */
+ 	now = jiffies / HZ;
+ 	if (now != READ_ONCE(net->ipv4.tcp_challenge_timestamp)) {
+ 		u32 half = (ack_limit + 1) >> 1;
+@@ -3768,12 +3761,49 @@ static void tcp_send_challenge_ack(struct sock *sk)
+ 	count = READ_ONCE(net->ipv4.tcp_challenge_count);
+ 	if (count > 0) {
+ 		WRITE_ONCE(net->ipv4.tcp_challenge_count, count - 1);
+-send_ack:
++		return true;
++	}
++	return false;
++}
++
++/* RFC 5961 7 [ACK Throttling] */
++static void tcp_send_challenge_ack(struct sock *sk)
++{
++	struct tcp_sock *tp = tcp_sk(sk);
++	struct net *net = sock_net(sk);
++
++	/* First check our per-socket dupack rate limit. */
++	if (__tcp_oow_rate_limited(net,
++				   LINUX_MIB_TCPACKSKIPPEDCHALLENGE,
++				   &tp->last_oow_ack_time))
++		return;
++
++	/* Then check the per-netns RFC 5961 rate limit. */
++	if (tcp_challenge_ack_allowed(net)) {
+ 		NET_INC_STATS(net, LINUX_MIB_TCPCHALLENGEACK);
+ 		tcp_send_ack(sk);
+ 	}
+ }
+ 
++/* Send a challenge ACK from a SYN-RECEIVED request socket. Uses
++ * __tcp_oow_rate_limited() directly so that an RST carrying payload
++ * cannot bypass the per-request rate limit.
++ */
++void tcp_reqsk_send_challenge_ack(struct sock *sk, struct sk_buff *skb,
++				  struct request_sock *req)
++{
++	struct net *net = sock_net(sk);
++
++	if (__tcp_oow_rate_limited(net, LINUX_MIB_TCPACKSKIPPEDCHALLENGE,
++				   &tcp_rsk(req)->last_oow_ack_time))
++		return;
++
++	if (tcp_challenge_ack_allowed(net)) {
++		NET_INC_STATS(net, LINUX_MIB_TCPCHALLENGEACK);
++		req->rsk_ops->send_ack(sk, skb, req);
++	}
++}
++
+ static void tcp_store_ts_recent(struct tcp_sock *tp)
+ {
+ 	tp->rx_opt.ts_recent = tp->rx_opt.rcv_tsval;
+diff --git a/net/ipv4/tcp_minisocks.c b/net/ipv4/tcp_minisocks.c
+index c3f5e4fc7b210e..86f0feb2497f1a 100644
+--- a/net/ipv4/tcp_minisocks.c
++++ b/net/ipv4/tcp_minisocks.c
+@@ -736,7 +736,7 @@ struct sock *tcp_check_req(struct sock *sk, struct sk_buff *skb,
+ 	 * elsewhere and is checked directly against the child socket rather
+ 	 * than req because user data may have been sent out.
+ 	 */
+-	if ((flg & TCP_FLAG_ACK) && !fastopen &&
++	if ((flg & TCP_FLAG_ACK) && !(flg & TCP_FLAG_RST) && !fastopen &&
+ 	    (TCP_SKB_CB(skb)->ack_seq !=
+ 	     tcp_rsk(req)->snt_isn + 1))
+ 		return sk;
+@@ -769,6 +769,16 @@ struct sock *tcp_check_req(struct sock *sk, struct sk_buff *skb,
+ 		flg &= ~TCP_FLAG_SYN;
+ 	}
+ 
++	/* RFC 5961 section 3.2, as clarified by RFC 9293 section
++	 * 3.10.7.4, requires a challenge ACK for a non-exact
++	 * in-window RST in SYN-RECEIVED.
++	 */
++	if ((flg & TCP_FLAG_RST) &&
++	    TCP_SKB_CB(skb)->seq != tcp_rsk(req)->rcv_nxt) {
++		tcp_reqsk_send_challenge_ack(sk, skb, req);
++		return NULL;
++	}
++
+ 	/* RFC793: "second check the RST bit" and
+ 	 *	   "fourth, check the SYN bit"
+ 	 */
+diff --git a/net/ipv4/tcp_output.c b/net/ipv4/tcp_output.c
+index c66fede62fa8dc..5abad93d3c743e 100644
+--- a/net/ipv4/tcp_output.c
++++ b/net/ipv4/tcp_output.c
+@@ -4098,7 +4098,7 @@ void tcp_send_delayed_ack(struct sock *sk)
+ }
+ 
+ /* This routine sends an ack and also updates the window. */
+-void __tcp_send_ack(struct sock *sk, u32 rcv_nxt)
++void __tcp_send_ack(struct sock *sk, u32 rcv_nxt, u16 flags)
+ {
+ 	struct sk_buff *buff;
+ 
+@@ -4127,7 +4127,7 @@ void __tcp_send_ack(struct sock *sk, u32 rcv_nxt)
+ 
+ 	/* Reserve space for headers and prepare control bits. */
+ 	skb_reserve(buff, MAX_TCP_HEADER);
+-	tcp_init_nondata_skb(buff, tcp_acceptable_seq(sk), TCPHDR_ACK);
++	tcp_init_nondata_skb(buff, tcp_acceptable_seq(sk), TCPHDR_ACK | flags);
+ 
+ 	/* We do not want pure acks influencing TCP Small Queues or fq/pacing
+ 	 * too much.
+@@ -4142,7 +4142,7 @@ EXPORT_SYMBOL_GPL(__tcp_send_ack);
+ 
+ void tcp_send_ack(struct sock *sk)
+ {
+-	__tcp_send_ack(sk, tcp_sk(sk)->rcv_nxt);
++	__tcp_send_ack(sk, tcp_sk(sk)->rcv_nxt, 0);
+ }
+ 
+ /* This routine sends a packet with an out of date sequence
+diff --git a/net/ipv4/udp_offload.c b/net/ipv4/udp_offload.c
+index b9b21e5af1a7fd..dec65fb8a0e42d 100644
+--- a/net/ipv4/udp_offload.c
++++ b/net/ipv4/udp_offload.c
+@@ -527,35 +527,6 @@ out:
+ 	return segs;
+ }
+ 
+-static int skb_gro_receive_list(struct sk_buff *p, struct sk_buff *skb)
+-{
+-	if (unlikely(p->len + skb->len >= 65536))
+-		return -E2BIG;
+-
+-	if (NAPI_GRO_CB(p)->last == p)
+-		skb_shinfo(p)->frag_list = skb;
+-	else
+-		NAPI_GRO_CB(p)->last->next = skb;
+-
+-	skb_pull(skb, skb_gro_offset(skb));
+-
+-	NAPI_GRO_CB(p)->last = skb;
+-	NAPI_GRO_CB(p)->count++;
+-	p->data_len += skb->len;
+-
+-	/* sk ownership - if any - completely transferred to the aggregated packet */
+-	skb->destructor = NULL;
+-	skb->sk = NULL;
+-	p->truesize += skb->truesize;
+-	p->len += skb->len;
+-
+-	skb_shinfo(p)->flags |= skb_shinfo(skb)->flags & SKBFL_SHARED_FRAG;
+-
+-	NAPI_GRO_CB(skb)->same_flow = 1;
+-
+-	return 0;
+-}
+-
+ 
+ #define UDP_GRO_CNT_MAX 64
+ static struct sk_buff *udp_gro_receive_segment(struct list_head *head,
+diff --git a/net/mptcp/fastopen.c b/net/mptcp/fastopen.c
+index d4dbdd3d5679de..35b93adf1b7355 100644
+--- a/net/mptcp/fastopen.c
++++ b/net/mptcp/fastopen.c
+@@ -24,12 +24,13 @@ void mptcp_fastopen_subflow_synack_set_params(struct mptcp_subflow_context *subf
+ 	sk = subflow->conn;
+ 	tp = tcp_sk(ssk);
+ 
+-	subflow->is_mptfo = 1;
+-
++	/* A valid TFO cookie does not guarantee SYN data. */
+ 	skb = skb_peek(&ssk->sk_receive_queue);
+-	if (WARN_ON_ONCE(!skb))
++	if (!skb)
+ 		return;
+ 
++	subflow->is_mptfo = 1;
++
+ 	/* dequeue the skb from sk receive queue */
+ 	__skb_unlink(skb, &ssk->sk_receive_queue);
+ 	skb_ext_reset(skb);
+diff --git a/net/mptcp/options.c b/net/mptcp/options.c
+index 2d45d8dd592687..b76f73704cac1d 100644
+--- a/net/mptcp/options.c
++++ b/net/mptcp/options.c
+@@ -50,6 +50,14 @@ static void mptcp_parse_option(const struct sk_buff *skb,
+ 			}
+ 		}
+ 
++		/* Only the MPC + ACK can be used with a RM_ADDR */
++		if (subopt == OPTION_MPTCP_MPC_ACK) {
++			if ((mp_opt->suboptions & ~OPTION_MPTCP_RM_ADDR) != 0)
++				break;
++		} else if (mp_opt->suboptions != 0) {
++			break;
++		}
++
+ 		/* Cfr RFC 8684 Section 3.3.0:
+ 		 * If a checksum is present but its use had
+ 		 * not been negotiated in the MP_CAPABLE handshake, the receiver MUST
+@@ -122,6 +130,11 @@ static void mptcp_parse_option(const struct sk_buff *skb,
+ 		break;
+ 
+ 	case MPTCPOPT_MP_JOIN:
++		/* Can be used with a restricted number of other options */
++		if ((mp_opt->suboptions & ~(OPTION_MPTCP_RM_ADDR |
++					    OPTION_MPTCP_PRIO)) != 0)
++			break;
++
+ 		if (opsize == TCPOLEN_MPTCP_MPJ_SYN) {
+ 			mp_opt->suboptions |= OPTION_MPTCP_MPJ_SYN;
+ 			mp_opt->backup = *ptr++ & MPTCPOPT_BACKUP;
+@@ -153,6 +166,14 @@ static void mptcp_parse_option(const struct sk_buff *skb,
+ 		break;
+ 
+ 	case MPTCPOPT_DSS:
++		/* Can be used with a restricted number of other options */
++		if ((mp_opt->suboptions & ~(OPTION_MPTCP_ADD_ADDR |
++					    OPTION_MPTCP_RM_ADDR |
++					    OPTION_MPTCP_PRIO |
++					    OPTION_MPTCP_FASTCLOSE |
++					    OPTION_MPTCP_FAIL)) != 0)
++			break;
++
+ 		pr_debug("DSS\n");
+ 		ptr++;
+ 
+@@ -188,8 +209,14 @@ static void mptcp_parse_option(const struct sk_buff *skb,
+ 		 * RFC 8684 Section 3.3.0 checks later in subflow_data_ready
+ 		 */
+ 		if (opsize != expected_opsize &&
+-		    opsize != expected_opsize + TCPOLEN_MPTCP_DSS_CHECKSUM)
++		    opsize != expected_opsize + TCPOLEN_MPTCP_DSS_CHECKSUM) {
++			mp_opt->dsn64 = 0;
++			mp_opt->use_map = 0;
++			mp_opt->ack64 = 0;
++			mp_opt->use_ack = 0;
++			mp_opt->data_fin = 0;
+ 			break;
++		}
+ 
+ 		mp_opt->suboptions |= OPTION_MPTCP_DSS;
+ 		if (mp_opt->use_ack) {
+@@ -234,6 +261,12 @@ static void mptcp_parse_option(const struct sk_buff *skb,
+ 		break;
+ 
+ 	case MPTCPOPT_ADD_ADDR:
++		/* Can be used with a restricted number of other options */
++		if ((mp_opt->suboptions & ~(OPTIONS_MPTCP_DSS |
++					    OPTION_MPTCP_RM_ADDR |
++					    OPTION_MPTCP_PRIO)) != 0)
++			break;
++
+ 		mp_opt->echo = (*ptr++) & MPTCP_ADDR_ECHO;
+ 		if (!mp_opt->echo) {
+ 			if (opsize == TCPOLEN_MPTCP_ADD_ADDR ||
+@@ -293,6 +326,14 @@ static void mptcp_parse_option(const struct sk_buff *skb,
+ 		break;
+ 
+ 	case MPTCPOPT_RM_ADDR:
++		/* Can be used with a restricted number of other options */
++		if ((mp_opt->suboptions & ~(OPTION_MPTCP_MPC_ACK |
++					    OPTIONS_MPTCP_MPJ |
++					    OPTIONS_MPTCP_DSS |
++					    OPTION_MPTCP_ADD_ADDR |
++					    OPTION_MPTCP_PRIO)) != 0)
++			break;
++
+ 		if (opsize < TCPOLEN_MPTCP_RM_ADDR_BASE + 1 ||
+ 		    opsize > TCPOLEN_MPTCP_RM_ADDR_BASE + MPTCP_RM_IDS_MAX)
+ 			break;
+@@ -307,6 +348,13 @@ static void mptcp_parse_option(const struct sk_buff *skb,
+ 		break;
+ 
+ 	case MPTCPOPT_MP_PRIO:
++		/* Can be used with a restricted number of other options */
++		if ((mp_opt->suboptions & ~(OPTIONS_MPTCP_MPJ |
++					    OPTIONS_MPTCP_DSS |
++					    OPTION_MPTCP_ADD_ADDR |
++					    OPTION_MPTCP_RM_ADDR)) != 0)
++			break;
++
+ 		if (opsize != TCPOLEN_MPTCP_PRIO)
+ 			break;
+ 
+@@ -316,6 +364,11 @@ static void mptcp_parse_option(const struct sk_buff *skb,
+ 		break;
+ 
+ 	case MPTCPOPT_MP_FASTCLOSE:
++		/* Can be used with a restricted number of other options */
++		if ((mp_opt->suboptions & ~(OPTIONS_MPTCP_DSS |
++					    OPTION_MPTCP_RST)) != 0)
++			break;
++
+ 		if (opsize != TCPOLEN_MPTCP_FASTCLOSE)
+ 			break;
+ 
+@@ -327,6 +380,11 @@ static void mptcp_parse_option(const struct sk_buff *skb,
+ 		break;
+ 
+ 	case MPTCPOPT_RST:
++		/* Can be used with a restricted number of other options */
++		if ((mp_opt->suboptions & ~(OPTION_MPTCP_FAIL |
++					    OPTION_MPTCP_FASTCLOSE)) != 0)
++			break;
++
+ 		if (opsize != TCPOLEN_MPTCP_RST)
+ 			break;
+ 
+@@ -342,6 +400,11 @@ static void mptcp_parse_option(const struct sk_buff *skb,
+ 		break;
+ 
+ 	case MPTCPOPT_MP_FAIL:
++		/* Can be used with a restricted number of other options */
++		if ((mp_opt->suboptions & ~(OPTIONS_MPTCP_DSS |
++					    OPTION_MPTCP_RST)) != 0)
++			break;
++
+ 		if (opsize != TCPOLEN_MPTCP_FAIL)
+ 			break;
+ 
+@@ -1415,7 +1478,7 @@ void mptcp_write_options(struct tcphdr *th, __be32 *ptr, struct tcp_sock *tp,
+ 	 *  RM   |  C   |  C   |  C   |  P   |------|------|------|------|
+ 	 *  PRIO |  X   |  C   |  C   |  C   |  C   |------|------|------|
+ 	 *  FAIL |  X   |  X   |  C   |  X   |  X   |  X   |------|------|
+-	 *  FC   |  X   |  X   |  X   |  X   |  X   |  X   |  X   |------|
++	 *  FC   |  X   |  X   |  P   |  X   |  X   |  X   |  X   |------|
+ 	 *  RST  |  X   |  X   |  X   |  X   |  X   |  X   |  O   |  O   |
+ 	 * ------|------|------|------|------|------|------|------|------|
+ 	 *
+diff --git a/net/mptcp/protocol.h b/net/mptcp/protocol.h
+index 251a1ad71ebbf6..aae8ca0bfabfa4 100644
+--- a/net/mptcp/protocol.h
++++ b/net/mptcp/protocol.h
+@@ -36,6 +36,7 @@
+ 				 OPTION_MPTCP_MPC_ACK)
+ #define OPTIONS_MPTCP_MPJ	(OPTION_MPTCP_MPJ_SYN | OPTION_MPTCP_MPJ_SYNACK | \
+ 				 OPTION_MPTCP_MPJ_ACK)
++#define OPTIONS_MPTCP_DSS	(OPTION_MPTCP_DSS | OPTION_MPTCP_CSUMREQD)
+ 
+ /* MPTCP option subtypes */
+ #define MPTCPOPT_MP_CAPABLE	0
+diff --git a/net/netfilter/ipset/ip_set_bitmap_gen.h b/net/netfilter/ipset/ip_set_bitmap_gen.h
+index 40f0383883f9db..605d54d2bd7e6d 100644
+--- a/net/netfilter/ipset/ip_set_bitmap_gen.h
++++ b/net/netfilter/ipset/ip_set_bitmap_gen.h
+@@ -75,7 +75,7 @@ mtype_flush(struct ip_set *set)
+ 		mtype_ext_cleanup(set);
+ 	bitmap_zero(map->members, map->elements);
+ 	set->elements = 0;
+-	atomic64_set(&set->ext_size, 0);
++	DEBUG_NET_WARN_ON_ONCE(atomic64_read(&set->ext_size) > 0);
+ }
+ 
+ /* Calculate the actual memory size of the set data */
+diff --git a/net/netfilter/ipset/ip_set_core.c b/net/netfilter/ipset/ip_set_core.c
+index 29bf5ee74fe360..e7c85b0af729bf 100644
+--- a/net/netfilter/ipset/ip_set_core.c
++++ b/net/netfilter/ipset/ip_set_core.c
+@@ -679,11 +679,18 @@ __ip_set_get(struct ip_set *set)
+ }
+ 
+ static void
+-__ip_set_put(struct ip_set *set)
++__ip_set_put_locked(struct ip_set *set)
+ {
+-	write_lock_bh(&ip_set_ref_lock);
++	lockdep_assert_held(&ip_set_ref_lock);
+ 	BUG_ON(set->ref == 0);
+ 	set->ref--;
++}
++
++static void
++__ip_set_put(struct ip_set *set)
++{
++	write_lock_bh(&ip_set_ref_lock);
++	__ip_set_put_locked(set);
+ 	write_unlock_bh(&ip_set_ref_lock);
+ }
+ 
+@@ -854,11 +861,11 @@ __ip_set_put_byindex(struct ip_set_net *inst, ip_set_id_t index)
+ {
+ 	struct ip_set *set;
+ 
+-	rcu_read_lock();
+-	set = rcu_dereference(inst->ip_set_list)[index];
++	write_lock_bh(&ip_set_ref_lock);
++	set = ip_set(inst, index);
+ 	if (set)
+-		__ip_set_put(set);
+-	rcu_read_unlock();
++		__ip_set_put_locked(set);
++	write_unlock_bh(&ip_set_ref_lock);
+ }
+ 
+ void
+diff --git a/net/netfilter/ipset/ip_set_list_set.c b/net/netfilter/ipset/ip_set_list_set.c
+index 9d6ab69ca1a376..720f05340b477d 100644
+--- a/net/netfilter/ipset/ip_set_list_set.c
++++ b/net/netfilter/ipset/ip_set_list_set.c
+@@ -301,9 +301,12 @@ list_set_uadd(struct ip_set *set, void *value, const struct ip_set_ext *ext,
+ 	e->set = set;
+ 	INIT_LIST_HEAD(&e->list);
+ 	list_set_init_extensions(set, ext, e);
+-	if (n)
++	if (n) {
+ 		list_set_replace(set, e, n);
+-	else if (next)
++		return 0;
++	}
++
++	if (next)
+ 		list_add_tail_rcu(&e->list, &next->list);
+ 	else if (prev)
+ 		list_add_rcu(&e->list, &prev->list);
+@@ -420,8 +423,7 @@ list_set_flush(struct ip_set *set)
+ 
+ 	list_for_each_entry_safe(e, n, &map->members, list)
+ 		list_set_del(set, e);
+-	set->elements = 0;
+-	atomic64_set(&set->ext_size, 0);
++	DEBUG_NET_WARN_ON_ONCE(set->elements > 0);
+ }
+ 
+ static void
+diff --git a/net/netfilter/ipvs/ip_vs_conn.c b/net/netfilter/ipvs/ip_vs_conn.c
+index b2b74ce6749096..f0a00e902450b5 100644
+--- a/net/netfilter/ipvs/ip_vs_conn.c
++++ b/net/netfilter/ipvs/ip_vs_conn.c
+@@ -758,7 +758,7 @@ int ip_vs_check_template(struct ip_vs_conn *ct, struct ip_vs_dest *cdest)
+ 	 * Checking the dest server status.
+ 	 */
+ 	if ((dest == NULL) ||
+-	    !(dest->flags & IP_VS_DEST_F_AVAILABLE) ||
++	    !(dest->cflags & IP_VS_DEST_CF_AVAILABLE) ||
+ 	    expire_quiescent_template(ipvs, dest) ||
+ 	    (cdest && (dest != cdest))) {
+ 		IP_VS_DBG_BUF(9, "check_template: dest not available for "
+@@ -1401,7 +1401,7 @@ void ip_vs_expire_nodest_conn_flush(struct netns_ipvs *ipvs)
+ 				continue;
+ 
+ 			dest = cp->dest;
+-			if (!dest || (dest->flags & IP_VS_DEST_F_AVAILABLE))
++			if (!dest || (dest->cflags & IP_VS_DEST_CF_AVAILABLE))
+ 				continue;
+ 
+ 			if (atomic_read(&cp->n_control))
+diff --git a/net/netfilter/ipvs/ip_vs_core.c b/net/netfilter/ipvs/ip_vs_core.c
+index a722bacce4613f..d15661e5a7f16f 100644
+--- a/net/netfilter/ipvs/ip_vs_core.c
++++ b/net/netfilter/ipvs/ip_vs_core.c
+@@ -124,7 +124,7 @@ ip_vs_in_stats(struct ip_vs_conn *cp, struct sk_buff *skb)
+ 	struct ip_vs_dest *dest = cp->dest;
+ 	struct netns_ipvs *ipvs = cp->ipvs;
+ 
+-	if (dest && (dest->flags & IP_VS_DEST_F_AVAILABLE)) {
++	if (dest && (dest->cflags & IP_VS_DEST_CF_AVAILABLE)) {
+ 		struct ip_vs_cpu_stats *s;
+ 		struct ip_vs_service *svc;
+ 
+@@ -160,7 +160,7 @@ ip_vs_out_stats(struct ip_vs_conn *cp, struct sk_buff *skb)
+ 	struct ip_vs_dest *dest = cp->dest;
+ 	struct netns_ipvs *ipvs = cp->ipvs;
+ 
+-	if (dest && (dest->flags & IP_VS_DEST_F_AVAILABLE)) {
++	if (dest && (dest->cflags & IP_VS_DEST_CF_AVAILABLE)) {
+ 		struct ip_vs_cpu_stats *s;
+ 		struct ip_vs_service *svc;
+ 
+@@ -2026,7 +2026,7 @@ ip_vs_in_hook(void *priv, struct sk_buff *skb, const struct nf_hook_state *state
+ 	}
+ 
+ 	/* Check the server status */
+-	if (cp && cp->dest && !(cp->dest->flags & IP_VS_DEST_F_AVAILABLE)) {
++	if (cp && cp->dest && !(cp->dest->cflags & IP_VS_DEST_CF_AVAILABLE)) {
+ 		/* the destination server is not available */
+ 		if (sysctl_expire_nodest_conn(ipvs)) {
+ 			bool old_ct = ip_vs_conn_uses_old_conntrack(cp, skb);
+diff --git a/net/netfilter/ipvs/ip_vs_ctl.c b/net/netfilter/ipvs/ip_vs_ctl.c
+index c98bdcea8b2f5b..97a7de8498d54e 100644
+--- a/net/netfilter/ipvs/ip_vs_ctl.c
++++ b/net/netfilter/ipvs/ip_vs_ctl.c
+@@ -1058,7 +1058,7 @@ __ip_vs_update_dest(struct ip_vs_service *svc, struct ip_vs_dest *dest,
+ 	}
+ 
+ 	/* set the dest status flags */
+-	dest->flags |= IP_VS_DEST_F_AVAILABLE;
++	dest->cflags |= IP_VS_DEST_CF_AVAILABLE;
+ 
+ 	if (READ_ONCE(dest->u_threshold) != udest->u_threshold ||
+ 	    READ_ONCE(dest->l_threshold) != udest->l_threshold) {
+@@ -1325,7 +1325,7 @@ static void __ip_vs_unlink_dest(struct ip_vs_service *svc,
+ 				struct ip_vs_dest *dest,
+ 				int svcupd)
+ {
+-	dest->flags &= ~IP_VS_DEST_F_AVAILABLE;
++	dest->cflags &= ~IP_VS_DEST_CF_AVAILABLE;
+ 
+ 	/*
+ 	 *  Remove it from the d-linked destination list.
+diff --git a/net/netfilter/ipvs/ip_vs_dh.c b/net/netfilter/ipvs/ip_vs_dh.c
+index 5e6ec32aff2b14..6d88bb4bf4ae8e 100644
+--- a/net/netfilter/ipvs/ip_vs_dh.c
++++ b/net/netfilter/ipvs/ip_vs_dh.c
+@@ -220,8 +220,8 @@ ip_vs_dh_schedule(struct ip_vs_service *svc, const struct sk_buff *skb,
+ 
+ 	s = (struct ip_vs_dh_state *) svc->sched_data;
+ 	dest = ip_vs_dh_get(svc->af, s, &iph->daddr);
+-	if (!dest
+-	    || !(dest->flags & IP_VS_DEST_F_AVAILABLE)
++	if (!dest ||
++	    !(dest->cflags & IP_VS_DEST_CF_AVAILABLE)
+ 	    || atomic_read(&dest->weight) <= 0
+ 	    || is_overloaded(dest)) {
+ 		ip_vs_scheduler_err(svc, "no destination available");
+diff --git a/net/netfilter/ipvs/ip_vs_lblc.c b/net/netfilter/ipvs/ip_vs_lblc.c
+index cf78ba4ce5ffd2..70014c89955d68 100644
+--- a/net/netfilter/ipvs/ip_vs_lblc.c
++++ b/net/netfilter/ipvs/ip_vs_lblc.c
+@@ -503,7 +503,7 @@ ip_vs_lblc_schedule(struct ip_vs_service *svc, const struct sk_buff *skb,
+ 		 */
+ 
+ 		dest = en->dest;
+-		if ((dest->flags & IP_VS_DEST_F_AVAILABLE) &&
++		if ((dest->cflags & IP_VS_DEST_CF_AVAILABLE) &&
+ 		    atomic_read(&dest->weight) > 0 && !is_overloaded(dest, svc))
+ 			goto out;
+ 	}
+diff --git a/net/netfilter/ipvs/ip_vs_lblcr.c b/net/netfilter/ipvs/ip_vs_lblcr.c
+index 9eddf118b40ec0..6b582be087785b 100644
+--- a/net/netfilter/ipvs/ip_vs_lblcr.c
++++ b/net/netfilter/ipvs/ip_vs_lblcr.c
+@@ -170,8 +170,8 @@ static inline struct ip_vs_dest *ip_vs_dest_set_min(struct ip_vs_dest_set *set)
+ 		if (least->flags & IP_VS_DEST_F_OVERLOAD)
+ 			continue;
+ 
+-		if ((atomic_read(&least->weight) > 0)
+-		    && (least->flags & IP_VS_DEST_F_AVAILABLE)) {
++		if ((atomic_read(&least->weight) > 0) &&
++		    (least->cflags & IP_VS_DEST_CF_AVAILABLE)) {
+ 			loh = ip_vs_dest_conn_overhead(least);
+ 			goto nextstage;
+ 		}
+@@ -187,8 +187,8 @@ static inline struct ip_vs_dest *ip_vs_dest_set_min(struct ip_vs_dest_set *set)
+ 
+ 		doh = ip_vs_dest_conn_overhead(dest);
+ 		if (((__s64)loh * atomic_read(&dest->weight) >
+-		     (__s64)doh * atomic_read(&least->weight))
+-		    && (dest->flags & IP_VS_DEST_F_AVAILABLE)) {
++		     (__s64)doh * atomic_read(&least->weight)) &&
++		    (dest->cflags & IP_VS_DEST_CF_AVAILABLE)) {
+ 			least = dest;
+ 			loh = doh;
+ 		}
+diff --git a/net/netfilter/nf_flow_table_core.c b/net/netfilter/nf_flow_table_core.c
+index 5c1ff07eaee0bd..acfbaf9db58bc3 100644
+--- a/net/netfilter/nf_flow_table_core.c
++++ b/net/netfilter/nf_flow_table_core.c
+@@ -279,17 +279,18 @@ int flow_offload_add(struct nf_flowtable *flow_table, struct flow_offload *flow)
+ 	flow->timeout = nf_flowtable_time_stamp + flow_offload_get_timeout(flow);
+ 
+ 	err = rhashtable_insert_fast(&flow_table->rhashtable,
+-				     &flow->tuplehash[0].node,
++				     &flow->tuplehash[FLOW_OFFLOAD_DIR_REPLY].node,
+ 				     nf_flow_offload_rhash_params);
+ 	if (err < 0)
+ 		return err;
+ 
++	/* GC only iterates original-direction entries; publish original last. */
+ 	err = rhashtable_insert_fast(&flow_table->rhashtable,
+-				     &flow->tuplehash[1].node,
++				     &flow->tuplehash[FLOW_OFFLOAD_DIR_ORIGINAL].node,
+ 				     nf_flow_offload_rhash_params);
+ 	if (err < 0) {
+ 		rhashtable_remove_fast(&flow_table->rhashtable,
+-				       &flow->tuplehash[0].node,
++				       &flow->tuplehash[FLOW_OFFLOAD_DIR_REPLY].node,
+ 				       nf_flow_offload_rhash_params);
+ 		return err;
+ 	}
+diff --git a/net/netfilter/nf_tables_offload.c b/net/netfilter/nf_tables_offload.c
+index 12ab78fa5d8420..27530bad6619d8 100644
+--- a/net/netfilter/nf_tables_offload.c
++++ b/net/netfilter/nf_tables_offload.c
+@@ -551,7 +551,7 @@ static void nft_flow_rule_offload_abort(struct net *net,
+ 			break;
+ 		}
+ 
+-		if (WARN_ON_ONCE(err))
++		if (WARN_ON_ONCE(err && err != -ENOMEM))
+ 			break;
+ 	}
+ }
+diff --git a/net/packet/af_packet.c b/net/packet/af_packet.c
+index 493a167a7c85b0..116578fbd9a1c7 100644
+--- a/net/packet/af_packet.c
++++ b/net/packet/af_packet.c
+@@ -1995,13 +1995,13 @@ static void packet_parse_headers(struct sk_buff *skb, struct socket *sock)
+ 	    sock->type == SOCK_RAW)
+ 		skb->protocol = dev_parse_header_protocol(skb);
+ 
++	skb_probe_transport_header(skb);
++
+ 	/* Move network header to the right position for VLAN tagged packets */
+ 	if (likely(skb->dev->type == ARPHRD_ETHER) &&
+ 	    eth_type_vlan(skb->protocol) &&
+ 	    vlan_get_protocol_and_depth(skb, skb->protocol, &depth) != 0)
+ 		skb_set_network_header(skb, depth);
+-
+-	skb_probe_transport_header(skb);
+ }
+ 
+ /*
+@@ -2186,13 +2186,13 @@ static int packet_rcv_vnet(struct msghdr *msg, const struct sk_buff *skb,
+ static int packet_rcv(struct sk_buff *skb, struct net_device *dev,
+ 		      struct packet_type *pt, struct net_device *orig_dev)
+ {
++	enum skb_drop_reason drop_reason = SKB_CONSUMED;
+ 	struct sock *sk;
+ 	struct sockaddr_ll *sll;
+ 	struct packet_sock *po;
+ 	u8 *skb_head = skb->data;
+ 	int skb_len = skb->len;
+ 	unsigned int snaplen, res;
+-	bool is_drop_n_account = false;
+ 
+ 	if (skb->pkt_type == PACKET_LOOPBACK)
+ 		goto drop;
+@@ -2282,9 +2282,9 @@ static int packet_rcv(struct sk_buff *skb, struct net_device *dev,
+ 	return 0;
+ 
+ drop_n_acct:
+-	is_drop_n_account = true;
+ 	atomic_inc(&po->tp_drops);
+ 	atomic_inc(&sk->sk_drops);
++	drop_reason = SKB_DROP_REASON_PACKET_SOCK_ERROR;
+ 
+ drop_n_restore:
+ 	if (skb_head != skb->data && skb_shared(skb)) {
+@@ -2292,16 +2292,14 @@ drop_n_restore:
+ 		skb->len = skb_len;
+ 	}
+ drop:
+-	if (!is_drop_n_account)
+-		consume_skb(skb);
+-	else
+-		kfree_skb(skb);
++	kfree_skb_reason(skb, drop_reason);
+ 	return 0;
+ }
+ 
+ static int tpacket_rcv(struct sk_buff *skb, struct net_device *dev,
+ 		       struct packet_type *pt, struct net_device *orig_dev)
+ {
++	enum skb_drop_reason drop_reason = SKB_CONSUMED;
+ 	struct sock *sk;
+ 	struct packet_sock *po;
+ 	struct sockaddr_ll *sll;
+@@ -2315,7 +2313,6 @@ static int tpacket_rcv(struct sk_buff *skb, struct net_device *dev,
+ 	struct sk_buff *copy_skb = NULL;
+ 	struct timespec64 ts;
+ 	__u32 ts_status;
+-	bool is_drop_n_account = false;
+ 	unsigned int slot_id = 0;
+ 	int vnet_hdr_sz = 0;
+ 
+@@ -2568,19 +2565,16 @@ drop_n_restore:
+ 		skb->len = skb_len;
+ 	}
+ drop:
+-	if (!is_drop_n_account)
+-		consume_skb(skb);
+-	else
+-		kfree_skb(skb);
++	kfree_skb_reason(skb, drop_reason);
+ 	return 0;
+ 
+ drop_n_account:
+ 	spin_unlock(&sk->sk_receive_queue.lock);
+ 	atomic_inc(&po->tp_drops);
+-	is_drop_n_account = true;
++	drop_reason = SKB_DROP_REASON_PACKET_SOCK_ERROR;
+ 
+ 	sk->sk_data_ready(sk);
+-	kfree_skb(copy_skb);
++	kfree_skb_reason(copy_skb, drop_reason);
+ 	goto drop_n_restore;
+ }
+ 
+@@ -2719,6 +2713,9 @@ static int tpacket_fill_skb(struct packet_sock *po, struct sk_buff *skb,
+ 		len = ((to_write > len_max) ? len_max : to_write);
+ 	}
+ 
++	if (unlikely(!skb->len))
++		return -EINVAL;
++
+ 	packet_parse_headers(skb, sock);
+ 
+ 	return tp_len;
+diff --git a/net/sched/act_api.c b/net/sched/act_api.c
+index 3b7e5fcdd4ff29..8514888378168d 100644
+--- a/net/sched/act_api.c
++++ b/net/sched/act_api.c
+@@ -41,11 +41,9 @@ int tcf_dev_queue_xmit(struct sk_buff *skb, int (*xmit)(struct sk_buff *skb))
+ }
+ EXPORT_SYMBOL_GPL(tcf_dev_queue_xmit);
+ 
+-static void tcf_action_goto_chain_exec(const struct tc_action *a,
++static void tcf_action_goto_chain_exec(const struct tcf_chain *chain,
+ 				       struct tcf_result *res)
+ {
+-	const struct tcf_chain *chain = rcu_dereference_bh(a->goto_chain);
+-
+ 	res->goto_tp = rcu_dereference_bh(chain->filter_chain);
+ }
+ 
+@@ -1117,11 +1115,14 @@ repeat:
+ 					return TC_ACT_OK;
+ 			}
+ 		} else if (TC_ACT_EXT_CMP(ret, TC_ACT_GOTO_CHAIN)) {
+-			if (unlikely(!rcu_access_pointer(a->goto_chain))) {
+-				net_warn_ratelimited("can't go to NULL chain!\n");
++			struct tcf_chain *chain = rcu_dereference_bh(a->goto_chain);
++
++			if (unlikely(!chain)) {
++				tcf_set_drop_reason(skb,
++						    SKB_DROP_REASON_TC_CHAIN_NOTFOUND);
+ 				return TC_ACT_SHOT;
+ 			}
+-			tcf_action_goto_chain_exec(a, res);
++			tcf_action_goto_chain_exec(chain, res);
+ 		}
+ 
+ 		if (ret != TC_ACT_PIPE)
+diff --git a/net/sched/cls_api.c b/net/sched/cls_api.c
+index ff6af03cb855d7..7f47e937e1b857 100644
+--- a/net/sched/cls_api.c
++++ b/net/sched/cls_api.c
+@@ -1731,12 +1731,18 @@ reclassify:
+ 			 * time we got here with a cookie from hardware.
+ 			 */
+ 			if (unlikely(n->tp != tp || n->tp->chain != n->chain ||
+-				     !tp->ops->get_exts))
++				     !tp->ops->get_exts)) {
++				tcf_set_drop_reason(skb,
++						    SKB_DROP_REASON_TC_COOKIE_ERROR);
+ 				return TC_ACT_SHOT;
++			}
+ 
+ 			exts = tp->ops->get_exts(tp, n->handle);
+-			if (unlikely(!exts || n->exts != exts))
++			if (unlikely(!exts || n->exts != exts)) {
++				tcf_set_drop_reason(skb,
++						    SKB_DROP_REASON_TC_COOKIE_ERROR);
+ 				return TC_ACT_SHOT;
++			}
+ 
+ 			n = NULL;
+ 			err = tcf_exts_exec_ex(skb, exts, act_index, res);
+@@ -1762,8 +1768,11 @@ reclassify:
+ 			return err;
+ 	}
+ 
+-	if (unlikely(n))
++	if (unlikely(n)) {
++		tcf_set_drop_reason(skb,
++				    SKB_DROP_REASON_TC_COOKIE_ERROR);
+ 		return TC_ACT_SHOT;
++	}
+ 
+ 	return TC_ACT_UNSPEC; /* signal: continue lookup */
+ #ifdef CONFIG_NET_CLS_ACT
+@@ -1773,6 +1782,8 @@ reset:
+ 				       tp->chain->block->index,
+ 				       tp->prio & 0xffff,
+ 				       ntohs(tp->protocol));
++		tcf_set_drop_reason(skb,
++				    SKB_DROP_REASON_TC_RECLASSIFY_LOOP);
+ 		return TC_ACT_SHOT;
+ 	}
+ 
+@@ -1809,8 +1820,11 @@ int tcf_classify(struct sk_buff *skb,
+ 			if (ext->act_miss) {
+ 				n = tcf_exts_miss_cookie_lookup(ext->act_miss_cookie,
+ 								&act_index);
+-				if (!n)
++				if (!n) {
++					tcf_set_drop_reason(skb,
++							    SKB_DROP_REASON_TC_COOKIE_ERROR);
+ 					return TC_ACT_SHOT;
++				}
+ 
+ 				chain = n->chain_index;
+ 			} else {
+@@ -1818,8 +1832,12 @@ int tcf_classify(struct sk_buff *skb,
+ 			}
+ 
+ 			fchain = tcf_chain_lookup_rcu(block, chain);
+-			if (!fchain)
++			if (!fchain) {
++				tcf_set_drop_reason(skb,
++						    SKB_DROP_REASON_TC_CHAIN_NOTFOUND);
++
+ 				return TC_ACT_SHOT;
++			}
+ 
+ 			/* Consume, so cloned/redirect skbs won't inherit ext */
+ 			skb_ext_del(skb, TC_SKB_EXT);
+@@ -1838,8 +1856,10 @@ int tcf_classify(struct sk_buff *skb,
+ 			struct tc_skb_cb *cb = tc_skb_cb(skb);
+ 
+ 			ext = tc_skb_ext_alloc(skb);
+-			if (WARN_ON_ONCE(!ext))
++			if (WARN_ON_ONCE(!ext)) {
++				tcf_set_drop_reason(skb, SKB_DROP_REASON_NOMEM);
+ 				return TC_ACT_SHOT;
++			}
+ 			ext->chain = last_executed_chain;
+ 			ext->mru = cb->mru;
+ 			ext->post_ct = cb->post_ct;
+diff --git a/net/sched/cls_bpf.c b/net/sched/cls_bpf.c
+index cede21257d27ca..8ca716bf9e42b7 100644
+--- a/net/sched/cls_bpf.c
++++ b/net/sched/cls_bpf.c
+@@ -374,7 +374,8 @@ static int cls_bpf_prog_from_ops(struct nlattr **tb, struct cls_bpf_prog *prog)
+ }
+ 
+ static int cls_bpf_prog_from_efd(struct nlattr **tb, struct cls_bpf_prog *prog,
+-				 u32 gen_flags, const struct tcf_proto *tp)
++				 u32 gen_flags, const struct tcf_proto *tp,
++				 struct netlink_ext_ack *extack)
+ {
+ 	struct bpf_prog *fp;
+ 	char *name = NULL;
+@@ -388,6 +389,19 @@ static int cls_bpf_prog_from_efd(struct nlattr **tb, struct cls_bpf_prog *prog,
+ 	if (IS_ERR(fp))
+ 		return PTR_ERR(fp);
+ 
++	if (bpf_prog_is_dev_bound(fp->aux)) {
++		struct tcf_block *block = tp->chain->block;
++		struct net_device *dev;
++
++		dev = block->q ? qdisc_dev(block->q) : NULL;
++		if (!dev || !bpf_offload_dev_match(fp, dev)) {
++			NL_SET_ERR_MSG(extack,
++				       "Program is bound to a different device");
++			bpf_prog_put(fp);
++			return -EINVAL;
++		}
++	}
++
+ 	if (tb[TCA_BPF_NAME]) {
+ 		name = nla_memdup(tb[TCA_BPF_NAME], GFP_KERNEL);
+ 		if (!name) {
+@@ -492,7 +506,7 @@ static int cls_bpf_change(struct net *net, struct sk_buff *in_skb,
+ 	prog->gen_flags = gen_flags;
+ 
+ 	ret = is_bpf ? cls_bpf_prog_from_ops(tb, prog) :
+-		cls_bpf_prog_from_efd(tb, prog, gen_flags, tp);
++		cls_bpf_prog_from_efd(tb, prog, gen_flags, tp, extack);
+ 	if (ret < 0)
+ 		goto errout_idr;
+ 
+diff --git a/net/sched/cls_u32.c b/net/sched/cls_u32.c
+index 9829df127d054f..e0805fa99e647d 100644
+--- a/net/sched/cls_u32.c
++++ b/net/sched/cls_u32.c
+@@ -1336,6 +1336,9 @@ static void u32_bind_class(void *fh, u32 classid, unsigned long cl, void *q,
+ {
+ 	struct tc_u_knode *n = fh;
+ 
++	if (TC_U32_KEY(n->handle) == 0)
++		return;
++
+ 	tc_cls_bind_class(classid, cl, q, &n->res, base);
+ }
+ 
+diff --git a/net/sched/sch_api.c b/net/sched/sch_api.c
+index 2047b9c1ae3f7a..22210e628ab34b 100644
+--- a/net/sched/sch_api.c
++++ b/net/sched/sch_api.c
+@@ -413,12 +413,13 @@ static __u8 __detect_linklayer(struct tc_ratespec *r, __u32 *rtab)
+ }
+ 
+ static struct qdisc_rate_table *qdisc_rtab_list;
++static DEFINE_SPINLOCK(qdisc_rtab_lock);
+ 
+ struct qdisc_rate_table *qdisc_get_rtab(struct tc_ratespec *r,
+ 					struct nlattr *tab,
+ 					struct netlink_ext_ack *extack)
+ {
+-	struct qdisc_rate_table *rtab;
++	struct qdisc_rate_table *rtab, *new_rtab;
+ 
+ 	if (tab == NULL || r->rate == 0 ||
+ 	    r->cell_log == 0 || r->cell_log >= 32 ||
+@@ -427,15 +428,20 @@ struct qdisc_rate_table *qdisc_get_rtab(struct tc_ratespec *r,
+ 		return NULL;
+ 	}
+ 
++	new_rtab = kmalloc(sizeof(*new_rtab), GFP_KERNEL);
++
++	spin_lock(&qdisc_rtab_lock);
+ 	for (rtab = qdisc_rtab_list; rtab; rtab = rtab->next) {
+ 		if (!memcmp(&rtab->rate, r, sizeof(struct tc_ratespec)) &&
+ 		    !memcmp(&rtab->data, nla_data(tab), 1024)) {
+ 			rtab->refcnt++;
++			spin_unlock(&qdisc_rtab_lock);
++			kfree(new_rtab);
+ 			return rtab;
+ 		}
+ 	}
+ 
+-	rtab = kmalloc(sizeof(*rtab), GFP_KERNEL);
++	rtab = new_rtab;
+ 	if (rtab) {
+ 		rtab->rate = *r;
+ 		rtab->refcnt = 1;
+@@ -447,6 +453,7 @@ struct qdisc_rate_table *qdisc_get_rtab(struct tc_ratespec *r,
+ 	} else {
+ 		NL_SET_ERR_MSG(extack, "Failed to allocate new qdisc rate table");
+ 	}
++	spin_unlock(&qdisc_rtab_lock);
+ 	return rtab;
+ }
+ EXPORT_SYMBOL(qdisc_get_rtab);
+@@ -455,18 +462,25 @@ void qdisc_put_rtab(struct qdisc_rate_table *tab)
+ {
+ 	struct qdisc_rate_table *rtab, **rtabp;
+ 
+-	if (!tab || --tab->refcnt)
++	if (!tab)
+ 		return;
+ 
++	spin_lock(&qdisc_rtab_lock);
++	if (--tab->refcnt) {
++		spin_unlock(&qdisc_rtab_lock);
++		return;
++	}
++
+ 	for (rtabp = &qdisc_rtab_list;
+ 	     (rtab = *rtabp) != NULL;
+ 	     rtabp = &rtab->next) {
+ 		if (rtab == tab) {
+ 			*rtabp = rtab->next;
+-			kfree(rtab);
+-			return;
++			break;
+ 		}
+ 	}
++	spin_unlock(&qdisc_rtab_lock);
++	kfree(tab);
+ }
+ EXPORT_SYMBOL(qdisc_put_rtab);
+ 
+diff --git a/net/tls/tls_sw.c b/net/tls/tls_sw.c
+index ac168ccd1fcb3a..99fb2688c8248c 100644
+--- a/net/tls/tls_sw.c
++++ b/net/tls/tls_sw.c
+@@ -2285,6 +2285,11 @@ ssize_t tls_sw_splice_read(struct socket *sock,  loff_t *ppos,
+ 	if (err < 0)
+ 		return err;
+ 
++	/* If crypto failed the connection is broken */
++	err = ctx->async_wait.err;
++	if (err)
++		goto splice_read_end;
++
+ 	if (!skb_queue_empty(&ctx->rx_list)) {
+ 		skb = __skb_dequeue(&ctx->rx_list);
+ 	} else {
+diff --git a/net/x25/af_x25.c b/net/x25/af_x25.c
+index 31f18f45b34597..7a9e8bfb464a30 100644
+--- a/net/x25/af_x25.c
++++ b/net/x25/af_x25.c
+@@ -362,6 +362,7 @@ static void x25_destroy_timer(struct timer_list *t)
+ 	struct sock *sk = from_timer(sk, t, sk_timer);
+ 
+ 	x25_destroy_socket_from_timer(sk);
++	sock_put(sk);
+ }
+ 
+ /*
+@@ -397,9 +398,8 @@ static void __x25_destroy_socket(struct sock *sk)
+ 
+ 	if (sk_has_allocations(sk)) {
+ 		/* Defer: outstanding buffers */
+-		sk->sk_timer.expires  = jiffies + 10 * HZ;
+ 		sk->sk_timer.function = x25_destroy_timer;
+-		add_timer(&sk->sk_timer);
++		sk_reset_timer(sk, &sk->sk_timer, jiffies + 10 * HZ);
+ 	} else {
+ 		/* drop last reference so sock_put will free */
+ 		__sock_put(sk);
+diff --git a/net/x25/x25_timer.c b/net/x25/x25_timer.c
+index 9376365cdcc9b7..2afa8ecaf509a7 100644
+--- a/net/x25/x25_timer.c
++++ b/net/x25/x25_timer.c
+@@ -36,45 +36,45 @@ void x25_init_timers(struct sock *sk)
+ 
+ void x25_start_heartbeat(struct sock *sk)
+ {
+-	mod_timer(&sk->sk_timer, jiffies + 5 * HZ);
++	sk_reset_timer(sk, &sk->sk_timer, jiffies + 5 * HZ);
+ }
+ 
+ void x25_stop_heartbeat(struct sock *sk)
+ {
+-	del_timer(&sk->sk_timer);
++	sk_stop_timer(sk, &sk->sk_timer);
+ }
+ 
+ void x25_start_t2timer(struct sock *sk)
+ {
+ 	struct x25_sock *x25 = x25_sk(sk);
+ 
+-	mod_timer(&x25->timer, jiffies + x25->t2);
++	sk_reset_timer(sk, &x25->timer, jiffies + x25->t2);
+ }
+ 
+ void x25_start_t21timer(struct sock *sk)
+ {
+ 	struct x25_sock *x25 = x25_sk(sk);
+ 
+-	mod_timer(&x25->timer, jiffies + x25->t21);
++	sk_reset_timer(sk, &x25->timer, jiffies + x25->t21);
+ }
+ 
+ void x25_start_t22timer(struct sock *sk)
+ {
+ 	struct x25_sock *x25 = x25_sk(sk);
+ 
+-	mod_timer(&x25->timer, jiffies + x25->t22);
++	sk_reset_timer(sk, &x25->timer, jiffies + x25->t22);
+ }
+ 
+ void x25_start_t23timer(struct sock *sk)
+ {
+ 	struct x25_sock *x25 = x25_sk(sk);
+ 
+-	mod_timer(&x25->timer, jiffies + x25->t23);
++	sk_reset_timer(sk, &x25->timer, jiffies + x25->t23);
+ }
+ 
+ void x25_stop_timer(struct sock *sk)
+ {
+-	del_timer(&x25_sk(sk)->timer);
++	sk_stop_timer(sk, &x25_sk(sk)->timer);
+ }
+ 
+ unsigned long x25_display_timer(struct sock *sk)
+@@ -108,7 +108,7 @@ static void x25_heartbeat_expiry(struct timer_list *t)
+ 			     sock_flag(sk, SOCK_DEAD))) {
+ 				bh_unlock_sock(sk);
+ 				x25_destroy_socket_from_timer(sk);
+-				return;
++				goto out;
+ 			}
+ 			break;
+ 
+@@ -120,8 +120,14 @@ static void x25_heartbeat_expiry(struct timer_list *t)
+ 			break;
+ 	}
+ restart_heartbeat:
+-	x25_start_heartbeat(sk);
++	/* Do not rearm once __x25_destroy_socket() has unlinked the socket:
++	 * it is past its cancel point and owns the teardown from there on.
++	 */
++	if (sk_hashed(sk))
++		x25_start_heartbeat(sk);
+ 	bh_unlock_sock(sk);
++out:
++	sock_put(sk);
+ }
+ 
+ /*
+@@ -166,4 +172,5 @@ static void x25_timer_expiry(struct timer_list *t)
+ 	} else
+ 		x25_do_timer_expiry(sk);
+ 	bh_unlock_sock(sk);
++	sock_put(sk);
+ }
+diff --git a/security/selinux/ss/policydb.c b/security/selinux/ss/policydb.c
+index 2d528f699a2297..81e910aaf22a37 100644
+--- a/security/selinux/ss/policydb.c
++++ b/security/selinux/ss/policydb.c
+@@ -715,6 +715,7 @@ static inline void symtab_hash_eval(struct symtab *s)
+ static int policydb_index(struct policydb *p)
+ {
+ 	int i, rc;
++	u32 v;
+ 
+ 	if (p->mls_enabled)
+ 		pr_debug("SELinux:  %d users, %d roles, %d types, %d bools, %d sens, %d cats\n",
+@@ -770,6 +771,24 @@ static int policydb_index(struct policydb *p)
+ 		if (rc)
+ 			goto out;
+ 	}
++
++	/*
++	 * A sparse class value is absorbed by policydb_class_isvalid() and
++	 * its siblings, but no such predicate exists for booleans: every
++	 * user of bool_val_to_struct[] walks it by index and dereferences
++	 * each entry -- cond_evaluate_expr(), the two getters and
++	 * security_set_bools() -- so an unclaimed one has no consumer that
++	 * can tolerate it.
++	 */
++	for (v = 0; v < p->p_bools.nprim; v++) {
++		if (!p->bool_val_to_struct[v]) {
++			pr_err("SELinux:  boolean %u is declared but not defined\n",
++			       v + 1);
++			rc = -EINVAL;
++			goto out;
++		}
++	}
++
+ 	rc = 0;
+ out:
+ 	return rc;
+@@ -1332,6 +1351,18 @@ static int class_read(struct policydb *p, struct symtab *s, void *fp)
+ 			       cladatum->comkey);
+ 			goto bad;
+ 		}
++
++		/*
++		 * security_get_permissions() maps the common's permissions
++		 * into an array sized by this class's nprim, so a class must
++		 * declare at least as many as the common it inherits.
++		 */
++		if (cladatum->permissions.nprim <
++		    cladatum->comdatum->permissions.nprim) {
++			pr_err("SELinux:  class %s has fewer permissions than common %s\n",
++			       key, cladatum->comkey);
++			goto bad;
++		}
+ 	}
+ 	for (i = 0; i < nel; i++) {
+ 		rc = perm_read(p, &cladatum->permissions, fp);
+diff --git a/security/selinux/ss/services.c b/security/selinux/ss/services.c
+index f5eead8af2e210..3d29f2a9b43a32 100644
+--- a/security/selinux/ss/services.c
++++ b/security/selinux/ss/services.c
+@@ -2157,7 +2157,9 @@ void selinux_policy_cancel(struct selinux_load_state *load_state)
+ 	oldpolicy = rcu_dereference_protected(state->policy,
+ 					lockdep_is_held(&state->policy_mutex));
+ 
+-	sidtab_cancel_convert(oldpolicy->sidtab);
++	/* a first load has no outgoing policy and converted nothing */
++	if (oldpolicy)
++		sidtab_cancel_convert(oldpolicy->sidtab);
+ 	selinux_policy_free(load_state->policy);
+ 	kfree(load_state->convert_data);
+ }
+@@ -3347,6 +3349,7 @@ int security_get_classes(struct selinux_policy *policy,
+ 			 char ***classes, u32 *nclasses)
+ {
+ 	struct policydb *policydb;
++	u32 i;
+ 	int rc;
+ 
+ 	policydb = &policy->policydb;
+@@ -3359,16 +3362,29 @@ int security_get_classes(struct selinux_policy *policy,
+ 
+ 	rc = hashtab_map(&policydb->p_classes.table, get_classes_callback,
+ 			 *classes);
+-	if (rc) {
+-		u32 i;
++	if (rc)
++		goto err;
+ 
+-		for (i = 0; i < *nclasses; i++)
+-			kfree((*classes)[i]);
+-		kfree(*classes);
++	/*
++	 * The class symtab may be sparse, which policydb_class_isvalid() exists
++	 * to absorb; the callback fills this array by value, so an unclaimed
++	 * one leaves a NULL that sel_make_classes() hands to sel_make_dir().
++	 */
++	for (i = 0; i < *nclasses; i++) {
++		if (!(*classes)[i]) {
++			rc = -EINVAL;
++			goto err;
++		}
+ 	}
+ 
+ out:
+ 	return rc;
++
++err:
++	for (i = 0; i < *nclasses; i++)
++		kfree((*classes)[i]);
++	kfree(*classes);
++	return rc;
+ }
+ 
+ static int get_permissions_callback(void *k, void *d, void *args)
+diff --git a/sound/soc/codecs/cs35l41-lib.c b/sound/soc/codecs/cs35l41-lib.c
+index 2ec5fdc875b13f..a76ff7bd502534 100644
+--- a/sound/soc/codecs/cs35l41-lib.c
++++ b/sound/soc/codecs/cs35l41-lib.c
+@@ -23,9 +23,9 @@ static const struct reg_default cs35l41_reg[] = {
+ 	{ CS35L41_GPIO_PAD_CONTROL,		0x00000000 },
+ 	{ CS35L41_GLOBAL_CLK_CTRL,		0x00000003 },
+ 	{ CS35L41_TST_FS_MON0,			0x00020016 },
++	{ CS35L41_BSTCVRT_PEAK_CUR,		0x0000004A },
+ 	{ CS35L41_BSTCVRT_COEFF,		0x00002424 },
+ 	{ CS35L41_BSTCVRT_SLOPE_LBST,		0x00007500 },
+-	{ CS35L41_BSTCVRT_PEAK_CUR,		0x0000004A },
+ 	{ CS35L41_SP_ENABLES,			0x00000000 },
+ 	{ CS35L41_SP_RATE_CTRL,			0x00000028 },
+ 	{ CS35L41_SP_FORMAT,			0x18180200 },
+diff --git a/sound/soc/codecs/cs35l45-tables.c b/sound/soc/codecs/cs35l45-tables.c
+index 621af1785979b1..e073685748a484 100644
+--- a/sound/soc/codecs/cs35l45-tables.c
++++ b/sound/soc/codecs/cs35l45-tables.c
+@@ -66,22 +66,6 @@ static const struct reg_default cs35l45_defaults[] = {
+ 	{ CS35L45_ASPTX3_INPUT,			0x00000020 },
+ 	{ CS35L45_ASPTX4_INPUT,			0x00000028 },
+ 	{ CS35L45_ASPTX5_INPUT,			0x00000048 },
+-	{ CS35L45_DSP1_RX1_RATE,		0x00000001 },
+-	{ CS35L45_DSP1_RX2_RATE,		0x00000001 },
+-	{ CS35L45_DSP1_RX3_RATE,		0x00000001 },
+-	{ CS35L45_DSP1_RX4_RATE,		0x00000001 },
+-	{ CS35L45_DSP1_RX5_RATE,		0x00000001 },
+-	{ CS35L45_DSP1_RX6_RATE,		0x00000001 },
+-	{ CS35L45_DSP1_RX7_RATE,		0x00000001 },
+-	{ CS35L45_DSP1_RX8_RATE,		0x00000001 },
+-	{ CS35L45_DSP1_TX1_RATE,		0x00000001 },
+-	{ CS35L45_DSP1_TX2_RATE,		0x00000001 },
+-	{ CS35L45_DSP1_TX3_RATE,		0x00000001 },
+-	{ CS35L45_DSP1_TX4_RATE,		0x00000001 },
+-	{ CS35L45_DSP1_TX5_RATE,		0x00000001 },
+-	{ CS35L45_DSP1_TX6_RATE,		0x00000001 },
+-	{ CS35L45_DSP1_TX7_RATE,		0x00000001 },
+-	{ CS35L45_DSP1_TX8_RATE,		0x00000001 },
+ 	{ CS35L45_DSP1RX1_INPUT,		0x00000008 },
+ 	{ CS35L45_DSP1RX2_INPUT,		0x00000009 },
+ 	{ CS35L45_DSP1RX3_INPUT,		0x00000018 },
+@@ -113,6 +97,22 @@ static const struct reg_default cs35l45_defaults[] = {
+ 	{ CS35L45_GPIO1_CTRL1,			0x81000001 },
+ 	{ CS35L45_GPIO2_CTRL1,			0x81000001 },
+ 	{ CS35L45_GPIO3_CTRL1,			0x81000001 },
++	{ CS35L45_DSP1_RX1_RATE,		0x00000001 },
++	{ CS35L45_DSP1_RX2_RATE,		0x00000001 },
++	{ CS35L45_DSP1_RX3_RATE,		0x00000001 },
++	{ CS35L45_DSP1_RX4_RATE,		0x00000001 },
++	{ CS35L45_DSP1_RX5_RATE,		0x00000001 },
++	{ CS35L45_DSP1_RX6_RATE,		0x00000001 },
++	{ CS35L45_DSP1_RX7_RATE,		0x00000001 },
++	{ CS35L45_DSP1_RX8_RATE,		0x00000001 },
++	{ CS35L45_DSP1_TX1_RATE,		0x00000001 },
++	{ CS35L45_DSP1_TX2_RATE,		0x00000001 },
++	{ CS35L45_DSP1_TX3_RATE,		0x00000001 },
++	{ CS35L45_DSP1_TX4_RATE,		0x00000001 },
++	{ CS35L45_DSP1_TX5_RATE,		0x00000001 },
++	{ CS35L45_DSP1_TX6_RATE,		0x00000001 },
++	{ CS35L45_DSP1_TX7_RATE,		0x00000001 },
++	{ CS35L45_DSP1_TX8_RATE,		0x00000001 },
+ };
+ 
+ static bool cs35l45_readable_reg(struct device *dev, unsigned int reg)
+diff --git a/sound/soc/codecs/cs4265.c b/sound/soc/codecs/cs4265.c
+index 1ed1e60d8e5368..a51ea5759745bc 100644
+--- a/sound/soc/codecs/cs4265.c
++++ b/sound/soc/codecs/cs4265.c
+@@ -46,11 +46,11 @@ static const struct reg_default cs4265_reg_defaults[] = {
+ 	{ CS4265_DAC_CHA_VOL, 0x00 },
+ 	{ CS4265_DAC_CHB_VOL, 0x00 },
+ 	{ CS4265_DAC_CTL2, 0xC0 },
+-	{ CS4265_SPDIF_CTL1, 0x00 },
+-	{ CS4265_SPDIF_CTL2, 0x00 },
+ 	{ CS4265_INT_MASK, 0x00 },
+ 	{ CS4265_STATUS_MODE_MSB, 0x00 },
+ 	{ CS4265_STATUS_MODE_LSB, 0x00 },
++	{ CS4265_SPDIF_CTL1, 0x00 },
++	{ CS4265_SPDIF_CTL2, 0x00 },
+ };
+ 
+ static bool cs4265_readable_register(struct device *dev, unsigned int reg)
+diff --git a/sound/soc/codecs/lpass-wsa-macro.c b/sound/soc/codecs/lpass-wsa-macro.c
+index e29815535929d5..431a6d9b5b5c48 100644
+--- a/sound/soc/codecs/lpass-wsa-macro.c
++++ b/sound/soc/codecs/lpass-wsa-macro.c
+@@ -1859,7 +1859,7 @@ static int wsa_macro_ear_spkr_pa_gain_get(struct snd_kcontrol *kcontrol,
+ 	struct snd_soc_component *component = snd_soc_kcontrol_component(kcontrol);
+ 	struct wsa_macro *wsa = snd_soc_component_get_drvdata(component);
+ 
+-	ucontrol->value.integer.value[0] = wsa->ear_spkr_gain;
++	ucontrol->value.enumerated.item[0] = wsa->ear_spkr_gain;
+ 
+ 	return 0;
+ }
+@@ -1870,7 +1870,7 @@ static int wsa_macro_ear_spkr_pa_gain_put(struct snd_kcontrol *kcontrol,
+ 	struct snd_soc_component *component = snd_soc_kcontrol_component(kcontrol);
+ 	struct wsa_macro *wsa = snd_soc_component_get_drvdata(component);
+ 
+-	wsa->ear_spkr_gain =  ucontrol->value.integer.value[0];
++	wsa->ear_spkr_gain =  ucontrol->value.enumerated.item[0];
+ 
+ 	return 0;
+ }
+@@ -1884,7 +1884,7 @@ static int wsa_macro_rx_mux_get(struct snd_kcontrol *kcontrol,
+ 				snd_soc_dapm_to_component(widget->dapm);
+ 	struct wsa_macro *wsa = snd_soc_component_get_drvdata(component);
+ 
+-	ucontrol->value.integer.value[0] =
++	ucontrol->value.enumerated.item[0] =
+ 			wsa->rx_port_value[widget->shift];
+ 	return 0;
+ }
+@@ -1898,7 +1898,7 @@ static int wsa_macro_rx_mux_put(struct snd_kcontrol *kcontrol,
+ 				snd_soc_dapm_to_component(widget->dapm);
+ 	struct soc_enum *e = (struct soc_enum *)kcontrol->private_value;
+ 	struct snd_soc_dapm_update *update = NULL;
+-	u32 rx_port_value = ucontrol->value.integer.value[0];
++	u32 rx_port_value = ucontrol->value.enumerated.item[0];
+ 	u32 bit_input;
+ 	u32 aif_rst;
+ 	struct wsa_macro *wsa = snd_soc_component_get_drvdata(component);
+diff --git a/sound/soc/codecs/tas2562.c b/sound/soc/codecs/tas2562.c
+index a1cb2d723ea575..ae351bb3c66f88 100644
+--- a/sound/soc/codecs/tas2562.c
++++ b/sound/soc/codecs/tas2562.c
+@@ -473,10 +473,15 @@ static int tas2562_volume_control_put(struct snd_kcontrol *kcontrol,
+ {
+ 	struct snd_soc_component *component = snd_soc_kcontrol_component(kcontrol);
+ 	struct tas2562_data *tas2562 = snd_soc_component_get_drvdata(component);
+-	int ret;
++	int ret, index;
+ 	u32 reg_val;
+ 
+-	reg_val = float_vol_db_lookup[ucontrol->value.integer.value[0]/2];
++	index = ucontrol->value.integer.value[0] / 2;
++	if (index < 0 || index >= ARRAY_SIZE(float_vol_db_lookup))
++		return -EINVAL;
++
++	reg_val = float_vol_db_lookup[index];
++
+ 	/*
+ 	 * The device applies the 32-bit coefficient to the playback path on
+ 	 * the write to DVC_CFG4 (the LSB, book 0 page 2 reg 0x0F), so the
+diff --git a/sound/soc/fsl/fsl_sai.c b/sound/soc/fsl/fsl_sai.c
+index 5a43658111b60f..61cc57b8467fea 100644
+--- a/sound/soc/fsl/fsl_sai.c
++++ b/sound/soc/fsl/fsl_sai.c
+@@ -716,6 +716,8 @@ static int fsl_sai_hw_free(struct snd_pcm_substream *substream,
+ 	struct fsl_sai *sai = snd_soc_dai_get_drvdata(cpu_dai);
+ 	bool tx = substream->stream == SNDRV_PCM_STREAM_PLAYBACK;
+ 	unsigned int ofs = sai->soc_data->reg_offset;
++	int adir = tx ? RX : TX;
++	int dir  = tx ? TX : RX;
+ 
+ 	/* Clear xMR to avoid channel swap with mclk_with_tere enabled case */
+ 	regmap_write(sai->regmap, FSL_SAI_xMR(tx), 0);
+@@ -723,10 +725,29 @@ static int fsl_sai_hw_free(struct snd_pcm_substream *substream,
+ 	regmap_update_bits(sai->regmap, FSL_SAI_xCR3(tx, ofs),
+ 			   FSL_SAI_CR3_TRCE_MASK, 0);
+ 
+-	if (!sai->is_consumer_mode &&
+-			sai->mclk_streams & BIT(substream->stream)) {
+-		clk_disable_unprepare(sai->mclk_clk[sai->mclk_id[tx]]);
+-		sai->mclk_streams &= ~BIT(substream->stream);
++	if (!sai->is_consumer_mode) {
++		bool adir_active = !!(sai->mclk_streams & BIT(!substream->stream));
++		/*
++		 * If opposite stream provides clocks for synchronous mode and
++		 * it is inactive, Clear BYP and BCI
++		 */
++		if (fsl_sai_dir_is_synced(sai, adir) && !adir_active)
++			regmap_update_bits(sai->regmap, FSL_SAI_xCR2(!tx, ofs),
++					   FSL_SAI_CR2_BCI | FSL_SAI_CR2_BYP, 0);
++		/*
++		 * Clear BYP and BCI of current stream if either of:
++		 * 1. current stream doesn't provide clocks for synchronous mode
++		 * 2. current stream provides clocks for synchronous mode but no
++		 *    more stream is active.
++		 */
++		if (!fsl_sai_dir_is_synced(sai, dir) || !adir_active)
++			regmap_update_bits(sai->regmap, FSL_SAI_xCR2(tx, ofs),
++					   FSL_SAI_CR2_BCI | FSL_SAI_CR2_BYP, 0);
++
++		if (sai->mclk_streams & BIT(substream->stream)) {
++			clk_disable_unprepare(sai->mclk_clk[sai->mclk_id[tx]]);
++			sai->mclk_streams &= ~BIT(substream->stream);
++		}
+ 	}
+ 
+ 	return 0;
+diff --git a/sound/soc/sof/sof-audio.c b/sound/soc/sof/sof-audio.c
+index 51626258347257..22a5df6aed2a94 100644
+--- a/sound/soc/sof/sof-audio.c
++++ b/sound/soc/sof/sof-audio.c
+@@ -139,7 +139,6 @@ static int sof_widget_setup_unlocked(struct snd_sof_dev *sdev,
+ {
+ 	const struct sof_ipc_tplg_ops *tplg_ops = sof_ipc_get_ops(sdev, tplg);
+ 	struct snd_sof_pipeline *spipe = swidget->spipe;
+-	bool use_count_decremented = false;
+ 	int ret;
+ 	int i;
+ 
+@@ -218,9 +217,10 @@ static int sof_widget_setup_unlocked(struct snd_sof_dev *sdev,
+ 	return 0;
+ 
+ widget_free:
+-	/* widget use_count will be decremented by sof_widget_free() */
++	/* widget use_count and core_put handled by sof_widget_free() */
+ 	sof_widget_free_unlocked(sdev, swidget);
+-	use_count_decremented = true;
++	return ret;
++
+ pipe_widget_free:
+ 	if (swidget->id != snd_soc_dapm_scheduler) {
+ 		sof_widget_free_unlocked(sdev, swidget->spipe->pipe_widget);
+@@ -235,8 +235,7 @@ pipe_widget_free:
+ 		}
+ 	}
+ use_count_dec:
+-	if (!use_count_decremented)
+-		swidget->use_count--;
++	swidget->use_count--;
+ 
+ 	return ret;
+ }
+diff --git a/sound/soc/xilinx/xlnx_formatter_pcm.c b/sound/soc/xilinx/xlnx_formatter_pcm.c
+index 299cfb5e202240..56a815caf23f0c 100644
+--- a/sound/soc/xilinx/xlnx_formatter_pcm.c
++++ b/sound/soc/xilinx/xlnx_formatter_pcm.c
+@@ -281,8 +281,7 @@ static irqreturn_t xlnx_mm2s_irq_handler(int irq, void *arg)
+ {
+ 	u32 val;
+ 	void __iomem *reg;
+-	struct device *dev = arg;
+-	struct xlnx_pcm_drv_data *adata = dev_get_drvdata(dev);
++	struct xlnx_pcm_drv_data *adata = arg;
+ 
+ 	reg = adata->mmio + XLNX_MM2S_OFFSET + XLNX_AUD_STS;
+ 	val = readl(reg);
+@@ -300,8 +299,7 @@ static irqreturn_t xlnx_s2mm_irq_handler(int irq, void *arg)
+ {
+ 	u32 val;
+ 	void __iomem *reg;
+-	struct device *dev = arg;
+-	struct xlnx_pcm_drv_data *adata = dev_get_drvdata(dev);
++	struct xlnx_pcm_drv_data *adata = arg;
+ 
+ 	reg = adata->mmio + XLNX_S2MM_OFFSET + XLNX_AUD_STS;
+ 	val = readl(reg);
+@@ -637,7 +635,7 @@ static int xlnx_formatter_pcm_probe(struct platform_device *pdev)
+ 		}
+ 		ret = devm_request_irq(dev, aud_drv_data->mm2s_irq,
+ 				       xlnx_mm2s_irq_handler, 0,
+-				       "xlnx_formatter_pcm_mm2s_irq", dev);
++				       "xlnx_formatter_pcm_mm2s_irq", aud_drv_data);
+ 		if (ret) {
+ 			dev_err(dev, "xlnx audio mm2s irq request failed\n");
+ 			goto clk_err;
+@@ -664,7 +662,7 @@ static int xlnx_formatter_pcm_probe(struct platform_device *pdev)
+ 		ret = devm_request_irq(dev, aud_drv_data->s2mm_irq,
+ 				       xlnx_s2mm_irq_handler, 0,
+ 				       "xlnx_formatter_pcm_s2mm_irq",
+-				       dev);
++				       aud_drv_data);
+ 		if (ret) {
+ 			dev_err(dev, "xlnx audio s2mm irq request failed\n");
+ 			goto clk_err;
+diff --git a/tools/testing/selftests/net/mptcp/mptcp_join.sh b/tools/testing/selftests/net/mptcp/mptcp_join.sh
+index 58b16ee798d5c2..b692310b8b707a 100755
+--- a/tools/testing/selftests/net/mptcp/mptcp_join.sh
++++ b/tools/testing/selftests/net/mptcp/mptcp_join.sh
+@@ -573,7 +573,7 @@ check_transfer()
+ 		mv "$tmpfile" "$out"
+ 		tmpfile=""
+ 	fi
+-	cmp -l "$in" "$out" | while read -r i a b; do
++	while read -r i a b; do
+ 		local sum=$((0${a} + 0${b}))
+ 		if [ $check_invert -eq 0 ] || [ $sum -ne $((0xff)) ]; then
+ 			fail_test "$what does not match (in, out):"
+@@ -584,7 +584,7 @@ check_transfer()
+ 		else
+ 			print_info "$what has inverted byte at ${i}"
+ 		fi
+-	done
++	done < <(cmp -l "$in" "$out")
+ 
+ 	return 0
+ }

--- a/patch/kernel/archive/odroidxu4-6.6/patch-6.6.153-154.patch
+++ b/patch/kernel/archive/odroidxu4-6.6/patch-6.6.153-154.patch
@@ -1,0 +1,5549 @@
+diff --git a/Makefile b/Makefile
+index 0633c724af10c2..f196561476c3b4 100644
+--- a/Makefile
++++ b/Makefile
+@@ -1,7 +1,7 @@
+ # SPDX-License-Identifier: GPL-2.0
+ VERSION = 6
+ PATCHLEVEL = 6
+-SUBLEVEL = 153
++SUBLEVEL = 154
+ EXTRAVERSION =
+ NAME = Pinguïn Aangedreven
+ 
+diff --git a/drivers/block/null_blk/zoned.c b/drivers/block/null_blk/zoned.c
+index d057f7099e7f7e..6ed46db23cb2d4 100644
+--- a/drivers/block/null_blk/zoned.c
++++ b/drivers/block/null_blk/zoned.c
+@@ -16,6 +16,8 @@ static inline sector_t mb_to_sects(unsigned long mb)
+ 
+ static inline unsigned int null_zone_no(struct nullb_device *dev, sector_t sect)
+ {
++	if (WARN_ON_ONCE(!dev->zone_size_sects))
++		return 0;
+ 	return sect >> ilog2(dev->zone_size_sects);
+ }
+ 
+@@ -65,8 +67,8 @@ int null_init_zoned_dev(struct nullb_device *dev, struct request_queue *q)
+ 	sector_t sector = 0;
+ 	unsigned int i;
+ 
+-	if (!is_power_of_2(dev->zone_size)) {
+-		pr_err("zone_size must be power-of-two\n");
++	if (!dev->zone_size || !is_power_of_2(dev->zone_size)) {
++		pr_err("zone_size must be non-zero power-of-two\n");
+ 		return -EINVAL;
+ 	}
+ 	if (dev->zone_size > dev->size) {
+@@ -97,6 +99,10 @@ int null_init_zoned_dev(struct nullb_device *dev, struct request_queue *q)
+ 	zone_capacity_sects = mb_to_sects(dev->zone_capacity);
+ 	dev_capacity_sects = mb_to_sects(dev->size);
+ 	dev->zone_size_sects = mb_to_sects(dev->zone_size);
++	if (!dev->zone_size_sects) {
++		pr_err("zone_size too large or too small, leads to zero sectors\n");
++		return -EINVAL;
++	}
+ 	dev->nr_zones = round_up(dev_capacity_sects, dev->zone_size_sects)
+ 		>> ilog2(dev->zone_size_sects);
+ 
+diff --git a/drivers/gpio/gpio-ml-ioh.c b/drivers/gpio/gpio-ml-ioh.c
+index 48e3768a830e7d..47099428284495 100644
+--- a/drivers/gpio/gpio-ml-ioh.c
++++ b/drivers/gpio/gpio-ml-ioh.c
+@@ -84,7 +84,7 @@ struct ioh_gpio {
+ 	u32 gpio_use_sel;
+ 	int ch;
+ 	int irq_base;
+-	spinlock_t spinlock;
++	raw_spinlock_t spinlock;
+ };
+ 
+ static const int num_ports[] = {6, 12, 16, 16, 15, 16, 16, 12};
+@@ -95,7 +95,7 @@ static void ioh_gpio_set(struct gpio_chip *gpio, unsigned nr, int val)
+ 	struct ioh_gpio *chip =	gpiochip_get_data(gpio);
+ 	unsigned long flags;
+ 
+-	spin_lock_irqsave(&chip->spinlock, flags);
++	raw_spin_lock_irqsave(&chip->spinlock, flags);
+ 	reg_val = ioread32(&chip->reg->regs[chip->ch].po);
+ 	if (val)
+ 		reg_val |= BIT(nr);
+@@ -103,7 +103,7 @@ static void ioh_gpio_set(struct gpio_chip *gpio, unsigned nr, int val)
+ 		reg_val &= ~BIT(nr);
+ 
+ 	iowrite32(reg_val, &chip->reg->regs[chip->ch].po);
+-	spin_unlock_irqrestore(&chip->spinlock, flags);
++	raw_spin_unlock_irqrestore(&chip->spinlock, flags);
+ }
+ 
+ static int ioh_gpio_get(struct gpio_chip *gpio, unsigned nr)
+@@ -121,7 +121,7 @@ static int ioh_gpio_direction_output(struct gpio_chip *gpio, unsigned nr,
+ 	u32 reg_val;
+ 	unsigned long flags;
+ 
+-	spin_lock_irqsave(&chip->spinlock, flags);
++	raw_spin_lock_irqsave(&chip->spinlock, flags);
+ 	pm = ioread32(&chip->reg->regs[chip->ch].pm);
+ 	pm &= BIT(num_ports[chip->ch]) - 1;
+ 	pm |= BIT(nr);
+@@ -134,7 +134,7 @@ static int ioh_gpio_direction_output(struct gpio_chip *gpio, unsigned nr,
+ 		reg_val &= ~BIT(nr);
+ 	iowrite32(reg_val, &chip->reg->regs[chip->ch].po);
+ 
+-	spin_unlock_irqrestore(&chip->spinlock, flags);
++	raw_spin_unlock_irqrestore(&chip->spinlock, flags);
+ 
+ 	return 0;
+ }
+@@ -145,12 +145,12 @@ static int ioh_gpio_direction_input(struct gpio_chip *gpio, unsigned nr)
+ 	u32 pm;
+ 	unsigned long flags;
+ 
+-	spin_lock_irqsave(&chip->spinlock, flags);
++	raw_spin_lock_irqsave(&chip->spinlock, flags);
+ 	pm = ioread32(&chip->reg->regs[chip->ch].pm);
+ 	pm &= BIT(num_ports[chip->ch]) - 1;
+ 	pm &= ~BIT(nr);
+ 	iowrite32(pm, &chip->reg->regs[chip->ch].pm);
+-	spin_unlock_irqrestore(&chip->spinlock, flags);
++	raw_spin_unlock_irqrestore(&chip->spinlock, flags);
+ 
+ 	return 0;
+ }
+@@ -254,7 +254,7 @@ static int ioh_irq_type(struct irq_data *d, unsigned int type)
+ 	dev_dbg(chip->dev, "%s:irq=%d type=%d ch=%d pos=%d type=%d\n",
+ 		__func__, irq, type, ch, im_pos, type);
+ 
+-	spin_lock_irqsave(&chip->spinlock, flags);
++	raw_spin_lock_irqsave(&chip->spinlock, flags);
+ 
+ 	switch (type) {
+ 	case IRQ_TYPE_EDGE_RISING:
+@@ -294,7 +294,7 @@ static int ioh_irq_type(struct irq_data *d, unsigned int type)
+ 	ien = ioread32(&chip->reg->regs[chip->ch].ien);
+ 	iowrite32(ien | BIT(ch), &chip->reg->regs[chip->ch].ien);
+ end:
+-	spin_unlock_irqrestore(&chip->spinlock, flags);
++	raw_spin_unlock_irqrestore(&chip->spinlock, flags);
+ 
+ 	return 0;
+ }
+@@ -324,11 +324,11 @@ static void ioh_irq_disable(struct irq_data *d)
+ 	unsigned long flags;
+ 	u32 ien;
+ 
+-	spin_lock_irqsave(&chip->spinlock, flags);
++	raw_spin_lock_irqsave(&chip->spinlock, flags);
+ 	ien = ioread32(&chip->reg->regs[chip->ch].ien);
+ 	ien &= ~BIT(d->irq - chip->irq_base);
+ 	iowrite32(ien, &chip->reg->regs[chip->ch].ien);
+-	spin_unlock_irqrestore(&chip->spinlock, flags);
++	raw_spin_unlock_irqrestore(&chip->spinlock, flags);
+ }
+ 
+ static void ioh_irq_enable(struct irq_data *d)
+@@ -338,11 +338,11 @@ static void ioh_irq_enable(struct irq_data *d)
+ 	unsigned long flags;
+ 	u32 ien;
+ 
+-	spin_lock_irqsave(&chip->spinlock, flags);
++	raw_spin_lock_irqsave(&chip->spinlock, flags);
+ 	ien = ioread32(&chip->reg->regs[chip->ch].ien);
+ 	ien |= BIT(d->irq - chip->irq_base);
+ 	iowrite32(ien, &chip->reg->regs[chip->ch].ien);
+-	spin_unlock_irqrestore(&chip->spinlock, flags);
++	raw_spin_unlock_irqrestore(&chip->spinlock, flags);
+ }
+ 
+ static irqreturn_t ioh_gpio_handler(int irq, void *dev_id)
+@@ -438,7 +438,7 @@ static int ioh_gpio_probe(struct pci_dev *pdev,
+ 		chip->base = base;
+ 		chip->reg = chip->base;
+ 		chip->ch = i;
+-		spin_lock_init(&chip->spinlock);
++		raw_spin_lock_init(&chip->spinlock);
+ 		ioh_gpio_setup(chip, num_ports[i]);
+ 		ret = devm_gpiochip_add_data(dev, &chip->gpio, chip);
+ 		if (ret) {
+@@ -482,9 +482,9 @@ static int __maybe_unused ioh_gpio_suspend(struct device *dev)
+ 	struct ioh_gpio *chip = dev_get_drvdata(dev);
+ 	unsigned long flags;
+ 
+-	spin_lock_irqsave(&chip->spinlock, flags);
++	raw_spin_lock_irqsave(&chip->spinlock, flags);
+ 	ioh_gpio_save_reg_conf(chip);
+-	spin_unlock_irqrestore(&chip->spinlock, flags);
++	raw_spin_unlock_irqrestore(&chip->spinlock, flags);
+ 
+ 	return 0;
+ }
+@@ -494,11 +494,11 @@ static int __maybe_unused ioh_gpio_resume(struct device *dev)
+ 	struct ioh_gpio *chip = dev_get_drvdata(dev);
+ 	unsigned long flags;
+ 
+-	spin_lock_irqsave(&chip->spinlock, flags);
++	raw_spin_lock_irqsave(&chip->spinlock, flags);
+ 	iowrite32(0x01, &chip->reg->srst);
+ 	iowrite32(0x00, &chip->reg->srst);
+ 	ioh_gpio_restore_reg_conf(chip);
+-	spin_unlock_irqrestore(&chip->spinlock, flags);
++	raw_spin_unlock_irqrestore(&chip->spinlock, flags);
+ 
+ 	return 0;
+ }
+diff --git a/drivers/gpu/drm/amd/amdgpu/amdgpu.h b/drivers/gpu/drm/amd/amdgpu/amdgpu.h
+index 78426f8c5420db..0d2f7be98dd447 100644
+--- a/drivers/gpu/drm/amd/amdgpu/amdgpu.h
++++ b/drivers/gpu/drm/amd/amdgpu/amdgpu.h
+@@ -1300,7 +1300,7 @@ int amdgpu_device_pci_reset(struct amdgpu_device *adev);
+ bool amdgpu_device_need_post(struct amdgpu_device *adev);
+ bool amdgpu_device_pcie_dynamic_switching_supported(void);
+ bool amdgpu_device_should_use_aspm(struct amdgpu_device *adev);
+-bool amdgpu_device_aspm_support_quirk(void);
++bool amdgpu_device_nv_aspm_support_quirk(void);
+ 
+ void amdgpu_cs_report_moved_bytes(struct amdgpu_device *adev, u64 num_bytes,
+ 				  u64 num_vis_bytes);
+diff --git a/drivers/gpu/drm/amd/amdgpu/amdgpu_device.c b/drivers/gpu/drm/amd/amdgpu/amdgpu_device.c
+index 8672838fb67cad..892a40c439637e 100644
+--- a/drivers/gpu/drm/amd/amdgpu/amdgpu_device.c
++++ b/drivers/gpu/drm/amd/amdgpu/amdgpu_device.c
+@@ -84,6 +84,7 @@
+ 
+ #if IS_ENABLED(CONFIG_X86)
+ #include <asm/intel-family.h>
++#include <asm/cpu_device_id.h>
+ #endif
+ 
+ MODULE_FIRMWARE("amdgpu/vega10_gpu_info.bin");
+@@ -1283,6 +1284,71 @@ bool amdgpu_device_pcie_dynamic_switching_supported(void)
+ 	return true;
+ }
+ 
++bool amdgpu_device_nv_aspm_support_quirk(void)
++{
++#if IS_ENABLED(CONFIG_X86)
++	struct cpuinfo_x86 *c = &cpu_data(0);
++
++	return !(c->x86 == 6 && c->x86_model == INTEL_FAM6_ALDERLAKE);
++#else
++	return true;
++#endif
++}
++
++static bool amdgpu_device_aspm_support_quirk(struct amdgpu_device *adev)
++{
++#if IS_ENABLED(CONFIG_X86)
++	struct cpuinfo_x86 *c = &cpu_data(0);
++
++	if (!(adev->ip_versions[GC_HWIP][0] == IP_VERSION(12, 0, 0) ||
++		  adev->ip_versions[GC_HWIP][0] == IP_VERSION(12, 0, 1)))
++		return false;
++
++	if (c->x86 == 6 &&
++		adev->pm.pcie_gen_mask & CAIL_PCIE_LINK_SPEED_SUPPORT_GEN5) {
++		switch (c->x86_model) {
++		case VFM_MODEL(INTEL_ALDERLAKE):
++		case VFM_MODEL(INTEL_ALDERLAKE_L):
++		case VFM_MODEL(INTEL_RAPTORLAKE):
++		case VFM_MODEL(INTEL_RAPTORLAKE_P):
++		case VFM_MODEL(INTEL_RAPTORLAKE_S):
++			return true;
++		default:
++			return false;
++		}
++	} else {
++		return false;
++	}
++#else
++	return false;
++#endif
++}
++
++/*
++ * Some dGPUs expose their display endpoint below an internal PCIe switch.
++ * Use the switch upstream port to query the host-facing link.
++ */
++static struct pci_dev *amdgpu_device_get_aspm_pdev(struct amdgpu_device *adev)
++{
++	struct pci_dev *swds, *swus;
++
++	swds = pci_upstream_bridge(adev->pdev);
++	if (!swds ||
++	    (swds->vendor != PCI_VENDOR_ID_ATI &&
++	     swds->vendor != PCI_VENDOR_ID_AMD) ||
++	    pci_pcie_type(swds) != PCI_EXP_TYPE_DOWNSTREAM)
++		return adev->pdev;
++
++	swus = pci_upstream_bridge(swds);
++	if (!swus ||
++	    (swus->vendor != PCI_VENDOR_ID_ATI &&
++	     swus->vendor != PCI_VENDOR_ID_AMD) ||
++	    pci_pcie_type(swus) != PCI_EXP_TYPE_UPSTREAM)
++		return adev->pdev;
++
++	return swus;
++}
++
+ /**
+  * amdgpu_device_should_use_aspm - check if the device should program ASPM
+  *
+@@ -1295,6 +1361,9 @@ bool amdgpu_device_pcie_dynamic_switching_supported(void)
+  */
+ bool amdgpu_device_should_use_aspm(struct amdgpu_device *adev)
+ {
++	struct pci_dev *aspm_pdev, *parent;
++	bool enabled;
++
+ 	switch (amdgpu_aspm) {
+ 	case -1:
+ 		break;
+@@ -1305,18 +1374,29 @@ bool amdgpu_device_should_use_aspm(struct amdgpu_device *adev)
+ 	default:
+ 		return false;
+ 	}
+-	return pcie_aspm_enabled(adev->pdev);
+-}
++	if (amdgpu_device_aspm_support_quirk(adev))
++		return false;
+ 
+-bool amdgpu_device_aspm_support_quirk(void)
+-{
+-#if IS_ENABLED(CONFIG_X86)
+-	struct cpuinfo_x86 *c = &cpu_data(0);
++	/*
++	 * pcie_aspm_enabled() checks the link between its argument and
++	 * the immediate upstream bridge. Use SWUS for dGPUs with an
++	 * internal switch so that this is the host-facing link.
++	 */
++	aspm_pdev = amdgpu_device_get_aspm_pdev(adev);
++	parent = pci_upstream_bridge(aspm_pdev);
++	if (!parent) {
++		dev_dbg(adev->dev, "ASPM: no upstream PCIe link for %s\n",
++			pci_name(aspm_pdev));
++		return false;
++	}
+ 
+-	return !(c->x86 == 6 && c->x86_model == INTEL_FAM6_ALDERLAKE);
+-#else
+-	return true;
+-#endif
++	enabled = pcie_aspm_enabled(aspm_pdev);
++	/* Report the exact link used for the automatic ASPM decision. */
++	dev_dbg(adev->dev, "ASPM: link %s <-> %s is %s\n",
++		pci_name(parent), pci_name(aspm_pdev),
++		enabled ? "enabled" : "disabled");
++
++	return enabled;
+ }
+ 
+ /* if we get transitioned to only one device, take VGA back */
+diff --git a/drivers/gpu/drm/amd/amdgpu/nv.c b/drivers/gpu/drm/amd/amdgpu/nv.c
+index 82709e692f4cc0..56e5a9eaf0c616 100644
+--- a/drivers/gpu/drm/amd/amdgpu/nv.c
++++ b/drivers/gpu/drm/amd/amdgpu/nv.c
+@@ -513,7 +513,7 @@ static int nv_set_vce_clocks(struct amdgpu_device *adev, u32 evclk, u32 ecclk)
+ 
+ static void nv_program_aspm(struct amdgpu_device *adev)
+ {
+-	if (!amdgpu_device_should_use_aspm(adev) || !amdgpu_device_aspm_support_quirk())
++	if (!amdgpu_device_should_use_aspm(adev) || !amdgpu_device_nv_aspm_support_quirk())
+ 		return;
+ 
+ 	if (!(adev->flags & AMD_IS_APU) &&
+diff --git a/drivers/gpu/drm/amd/display/amdgpu_dm/amdgpu_dm.c b/drivers/gpu/drm/amd/display/amdgpu_dm/amdgpu_dm.c
+index 7ae94daa969a2c..7c72caac7b4d71 100644
+--- a/drivers/gpu/drm/amd/display/amdgpu_dm/amdgpu_dm.c
++++ b/drivers/gpu/drm/amd/display/amdgpu_dm/amdgpu_dm.c
+@@ -4937,9 +4937,9 @@ fill_plane_color_attributes(const struct drm_plane_state *plane_state,
+ 
+ 	case DRM_COLOR_YCBCR_BT2020:
+ 		if (full_range)
+-			*color_space = COLOR_SPACE_2020_YCBCR;
++			*color_space = COLOR_SPACE_2020_YCBCR_FULL;
+ 		else
+-			return -EINVAL;
++			*color_space = COLOR_SPACE_2020_YCBCR_LIMITED;
+ 		break;
+ 
+ 	default:
+@@ -5430,7 +5430,7 @@ get_output_color_space(const struct dc_crtc_timing *dc_crtc_timing,
+ 		if (dc_crtc_timing->pixel_encoding == PIXEL_ENCODING_RGB)
+ 			color_space = COLOR_SPACE_2020_RGB_FULLRANGE;
+ 		else
+-			color_space = COLOR_SPACE_2020_YCBCR;
++			color_space = COLOR_SPACE_2020_YCBCR_LIMITED;
+ 		break;
+ 	case DRM_MODE_COLORIMETRY_DEFAULT: // ITU601
+ 	default:
+diff --git a/drivers/gpu/drm/amd/display/amdgpu_dm/amdgpu_dm_debugfs.c b/drivers/gpu/drm/amd/display/amdgpu_dm/amdgpu_dm_debugfs.c
+index 4b8101bf62e9d2..2e779f5cd43e78 100644
+--- a/drivers/gpu/drm/amd/display/amdgpu_dm/amdgpu_dm_debugfs.c
++++ b/drivers/gpu/drm/amd/display/amdgpu_dm/amdgpu_dm_debugfs.c
+@@ -1091,7 +1091,7 @@ static int amdgpu_current_colorspace_show(struct seq_file *m, void *data)
+ 	case COLOR_SPACE_2020_RGB_FULLRANGE:
+ 		seq_puts(m, "BT2020_RGB");
+ 		break;
+-	case COLOR_SPACE_2020_YCBCR:
++	case COLOR_SPACE_2020_YCBCR_LIMITED:
+ 		seq_puts(m, "BT2020_YCC");
+ 		break;
+ 	default:
+diff --git a/drivers/gpu/drm/amd/display/dc/basics/dc_common.c b/drivers/gpu/drm/amd/display/dc/basics/dc_common.c
+index b2fc4f8e648250..a51c2701da247f 100644
+--- a/drivers/gpu/drm/amd/display/dc/basics/dc_common.c
++++ b/drivers/gpu/drm/amd/display/dc/basics/dc_common.c
+@@ -40,7 +40,8 @@ bool is_rgb_cspace(enum dc_color_space output_color_space)
+ 	case COLOR_SPACE_YCBCR709:
+ 	case COLOR_SPACE_YCBCR601_LIMITED:
+ 	case COLOR_SPACE_YCBCR709_LIMITED:
+-	case COLOR_SPACE_2020_YCBCR:
++	case COLOR_SPACE_2020_YCBCR_LIMITED:
++	case COLOR_SPACE_2020_YCBCR_FULL:
+ 		return false;
+ 	default:
+ 		/* Add a case to switch */
+diff --git a/drivers/gpu/drm/amd/display/dc/core/dc_hw_sequencer.c b/drivers/gpu/drm/amd/display/dc/core/dc_hw_sequencer.c
+index 2eae1fd95fd06b..37b156d32dd917 100644
+--- a/drivers/gpu/drm/amd/display/dc/core/dc_hw_sequencer.c
++++ b/drivers/gpu/drm/amd/display/dc/core/dc_hw_sequencer.c
+@@ -47,7 +47,8 @@ enum dc_color_space_type {
+ 	COLOR_SPACE_RGB_LIMITED_TYPE,
+ 	COLOR_SPACE_YCBCR601_TYPE,
+ 	COLOR_SPACE_YCBCR709_TYPE,
+-	COLOR_SPACE_YCBCR2020_TYPE,
++	COLOR_SPACE_YCBCR2020_LIMITED_TYPE,
++	COLOR_SPACE_YCBCR2020_FULL_TYPE,
+ 	COLOR_SPACE_YCBCR601_LIMITED_TYPE,
+ 	COLOR_SPACE_YCBCR709_LIMITED_TYPE,
+ 	COLOR_SPACE_YCBCR709_BLACK_TYPE,
+@@ -99,9 +100,15 @@ static const struct out_csc_color_matrix_type output_csc_matrix[] = {
+ 		{ 0xE00, 0xF349, 0xFEB7, 0x1000,
+ 		  0x6CE, 0x16E3, 0x24F,  0x200,
+ 		  0xFCCB, 0xF535, 0xE00, 0x1000} },
+-	{ COLOR_SPACE_YCBCR2020_TYPE,
++	/* Corrected. Not included in the TODO above. */
++	{ COLOR_SPACE_YCBCR2020_LIMITED_TYPE,
++		{ 0x0E04, 0xF31D, 0xFEDF, 0x1004,
++		  0x0733, 0x1294, 0x01A0, 0x0201,
++		  0xFC16, 0xF5E6, 0x0E04, 0x1004} },
++	/* Corrected. Not included in the TODO above. */
++	{ COLOR_SPACE_YCBCR2020_FULL_TYPE,
+ 		{ 0x1000, 0xF149, 0xFEB7, 0x1004,
+-		  0x0868, 0x15B2, 0x01E6, 0x201,
++		  0x0868, 0x15B2, 0x01E6, 0,
+ 		  0xFB88, 0xF478, 0x1000, 0x1004} },
+ 	{ COLOR_SPACE_YCBCR709_BLACK_TYPE,
+ 		{ 0x0000, 0x0000, 0x0000, 0x1000,
+@@ -168,14 +175,14 @@ static bool is_ycbcr709_type(
+ 	return ret;
+ }
+ 
+-static bool is_ycbcr2020_type(
+-	enum dc_color_space color_space)
++static bool is_ycbcr2020_limited_type(enum dc_color_space color_space)
+ {
+-	bool ret = false;
++	return color_space == COLOR_SPACE_2020_YCBCR_LIMITED;
++}
+ 
+-	if (color_space == COLOR_SPACE_2020_YCBCR)
+-		ret = true;
+-	return ret;
++static bool is_ycbcr2020_full_type(enum dc_color_space color_space)
++{
++	return color_space == COLOR_SPACE_2020_YCBCR_FULL;
+ }
+ 
+ static bool is_ycbcr709_limited_type(
+@@ -204,8 +211,10 @@ static enum dc_color_space_type get_color_space_type(enum dc_color_space color_s
+ 		type = COLOR_SPACE_YCBCR601_LIMITED_TYPE;
+ 	else if (is_ycbcr709_limited_type(color_space))
+ 		type = COLOR_SPACE_YCBCR709_LIMITED_TYPE;
+-	else if (is_ycbcr2020_type(color_space))
+-		type = COLOR_SPACE_YCBCR2020_TYPE;
++	else if (is_ycbcr2020_limited_type(color_space))
++		type = COLOR_SPACE_YCBCR2020_LIMITED_TYPE;
++	else if (is_ycbcr2020_full_type(color_space))
++		type = COLOR_SPACE_YCBCR2020_FULL_TYPE;
+ 	else if (color_space == COLOR_SPACE_YCBCR709)
+ 		type = COLOR_SPACE_YCBCR709_BLACK_TYPE;
+ 	else if (color_space == COLOR_SPACE_YCBCR709_BLACK)
+@@ -244,7 +253,8 @@ void color_space_to_black_color(
+ 	case COLOR_SPACE_YCBCR709_BLACK:
+ 	case COLOR_SPACE_YCBCR601_LIMITED:
+ 	case COLOR_SPACE_YCBCR709_LIMITED:
+-	case COLOR_SPACE_2020_YCBCR:
++	case COLOR_SPACE_2020_YCBCR_LIMITED:
++	case COLOR_SPACE_2020_YCBCR_FULL:
+ 		*black_color = black_color_format[BLACK_COLOR_FORMAT_YUV_CV];
+ 		break;
+ 
+diff --git a/drivers/gpu/drm/amd/display/dc/core/dc_resource.c b/drivers/gpu/drm/amd/display/dc/core/dc_resource.c
+index 802c0e19d03b3c..84474d5122284a 100644
+--- a/drivers/gpu/drm/amd/display/dc/core/dc_resource.c
++++ b/drivers/gpu/drm/amd/display/dc/core/dc_resource.c
+@@ -3296,7 +3296,7 @@ static void set_avi_info_frame(
+ 		break;
+ 	case COLOR_SPACE_2020_RGB_FULLRANGE:
+ 	case COLOR_SPACE_2020_RGB_LIMITEDRANGE:
+-	case COLOR_SPACE_2020_YCBCR:
++	case COLOR_SPACE_2020_YCBCR_LIMITED:
+ 		hdmi_info.bits.EC0_EC2 = COLORIMETRYEX_BT2020RGBYCBCR;
+ 		hdmi_info.bits.C0_C1   = COLORIMETRY_EXTENDED;
+ 		break;
+@@ -3310,7 +3310,7 @@ static void set_avi_info_frame(
+ 		break;
+ 	}
+ 
+-	if (pixel_encoding && color_space == COLOR_SPACE_2020_YCBCR &&
++	if (pixel_encoding && color_space == COLOR_SPACE_2020_YCBCR_LIMITED &&
+ 			stream->out_transfer_func->tf == TRANSFER_FUNCTION_GAMMA22) {
+ 		hdmi_info.bits.EC0_EC2 = 0;
+ 		hdmi_info.bits.C0_C1 = COLORIMETRY_ITU709;
+diff --git a/drivers/gpu/drm/amd/display/dc/dc_hw_types.h b/drivers/gpu/drm/amd/display/dc/dc_hw_types.h
+index 00de342e5290b7..3050807c8da023 100644
+--- a/drivers/gpu/drm/amd/display/dc/dc_hw_types.h
++++ b/drivers/gpu/drm/amd/display/dc/dc_hw_types.h
+@@ -616,7 +616,8 @@ enum dc_color_space {
+ 	COLOR_SPACE_YCBCR709_LIMITED,
+ 	COLOR_SPACE_2020_RGB_FULLRANGE,
+ 	COLOR_SPACE_2020_RGB_LIMITEDRANGE,
+-	COLOR_SPACE_2020_YCBCR,
++	COLOR_SPACE_2020_YCBCR_LIMITED,
++	COLOR_SPACE_2020_YCBCR_FULL,
+ 	COLOR_SPACE_ADOBERGB,
+ 	COLOR_SPACE_DCIP3,
+ 	COLOR_SPACE_DISPLAYNATIVE,
+@@ -624,6 +625,7 @@ enum dc_color_space {
+ 	COLOR_SPACE_APPCTRL,
+ 	COLOR_SPACE_CUSTOMPOINTS,
+ 	COLOR_SPACE_YCBCR709_BLACK,
++	COLOR_SPACE_2020_YCBCR = COLOR_SPACE_2020_YCBCR_LIMITED,
+ };
+ 
+ enum dc_dither_option {
+diff --git a/drivers/gpu/drm/amd/display/dc/dce/dce_stream_encoder.c b/drivers/gpu/drm/amd/display/dc/dce/dce_stream_encoder.c
+index f810825322ba9f..57de41f3c0332b 100644
+--- a/drivers/gpu/drm/amd/display/dc/dce/dce_stream_encoder.c
++++ b/drivers/gpu/drm/amd/display/dc/dce/dce_stream_encoder.c
+@@ -420,7 +420,7 @@ static void dce110_stream_encoder_dp_set_stream_attribute(
+ 			dynamic_range_rgb = 1; /*limited range*/
+ 			break;
+ 		case COLOR_SPACE_2020_RGB_FULLRANGE:
+-		case COLOR_SPACE_2020_YCBCR:
++		case COLOR_SPACE_2020_YCBCR_LIMITED:
+ 		case COLOR_SPACE_XR_RGB:
+ 		case COLOR_SPACE_MSREF_SCRGB:
+ 		case COLOR_SPACE_ADOBERGB:
+@@ -432,6 +432,7 @@ static void dce110_stream_encoder_dp_set_stream_attribute(
+ 		case COLOR_SPACE_APPCTRL:
+ 		case COLOR_SPACE_CUSTOMPOINTS:
+ 		case COLOR_SPACE_UNKNOWN:
++		default:
+ 			/* do nothing */
+ 			break;
+ 		}
+diff --git a/drivers/gpu/drm/amd/display/dc/dcn10/dcn10_stream_encoder.c b/drivers/gpu/drm/amd/display/dc/dcn10/dcn10_stream_encoder.c
+index f496e952ceecb8..f8f1e98f646e6b 100644
+--- a/drivers/gpu/drm/amd/display/dc/dcn10/dcn10_stream_encoder.c
++++ b/drivers/gpu/drm/amd/display/dc/dcn10/dcn10_stream_encoder.c
+@@ -393,7 +393,7 @@ void enc1_stream_encoder_dp_set_stream_attribute(
+ 		break;
+ 	case COLOR_SPACE_2020_RGB_LIMITEDRANGE:
+ 	case COLOR_SPACE_2020_RGB_FULLRANGE:
+-	case COLOR_SPACE_2020_YCBCR:
++	case COLOR_SPACE_2020_YCBCR_LIMITED:
+ 	case COLOR_SPACE_XR_RGB:
+ 	case COLOR_SPACE_MSREF_SCRGB:
+ 	case COLOR_SPACE_ADOBERGB:
+@@ -406,6 +406,7 @@ void enc1_stream_encoder_dp_set_stream_attribute(
+ 	case COLOR_SPACE_CUSTOMPOINTS:
+ 	case COLOR_SPACE_UNKNOWN:
+ 	case COLOR_SPACE_YCBCR709_BLACK:
++	default:
+ 		/* do nothing */
+ 		break;
+ 	}
+diff --git a/drivers/gpu/drm/amd/display/dc/dcn31/dcn31_hpo_dp_stream_encoder.c b/drivers/gpu/drm/amd/display/dc/dcn31/dcn31_hpo_dp_stream_encoder.c
+index 45143459eeddcf..1e756c0858d04c 100644
+--- a/drivers/gpu/drm/amd/display/dc/dcn31/dcn31_hpo_dp_stream_encoder.c
++++ b/drivers/gpu/drm/amd/display/dc/dcn31/dcn31_hpo_dp_stream_encoder.c
+@@ -323,7 +323,7 @@ static void dcn31_hpo_dp_stream_enc_set_stream_attribute(
+ 		break;
+ 	case COLOR_SPACE_2020_RGB_LIMITEDRANGE:
+ 	case COLOR_SPACE_2020_RGB_FULLRANGE:
+-	case COLOR_SPACE_2020_YCBCR:
++	case COLOR_SPACE_2020_YCBCR_LIMITED:
+ 	case COLOR_SPACE_XR_RGB:
+ 	case COLOR_SPACE_MSREF_SCRGB:
+ 	case COLOR_SPACE_ADOBERGB:
+@@ -336,6 +336,7 @@ static void dcn31_hpo_dp_stream_enc_set_stream_attribute(
+ 	case COLOR_SPACE_CUSTOMPOINTS:
+ 	case COLOR_SPACE_UNKNOWN:
+ 	case COLOR_SPACE_YCBCR709_BLACK:
++	default:
+ 		/* do nothing */
+ 		break;
+ 	}
+diff --git a/drivers/gpu/drm/amd/display/dc/inc/hw/dpp.h b/drivers/gpu/drm/amd/display/dc/inc/hw/dpp.h
+index f4aa76e0251854..119fb97d0532ad 100644
+--- a/drivers/gpu/drm/amd/display/dc/inc/hw/dpp.h
++++ b/drivers/gpu/drm/amd/display/dc/inc/hw/dpp.h
+@@ -94,10 +94,14 @@ static const struct dpp_input_csc_matrix __maybe_unused dpp_input_csc_matrix[] =
+ 		{ 0x39a6, 0x2568, 0,      0xe0d6,
+ 		  0xeedd, 0x2568, 0xf925, 0x9a8,
+ 		  0,      0x2568, 0x43ee, 0xdbb2 } },
+-	{ COLOR_SPACE_2020_YCBCR,
++	{ COLOR_SPACE_2020_YCBCR_FULL,
+ 		{ 0x2F30, 0x2000, 0,      0xE869,
+ 		  0xEDB7, 0x2000, 0xFABC, 0xBC6,
+ 		  0,      0x2000, 0x3C34, 0xE1E6 } },
++	{ COLOR_SPACE_2020_YCBCR_LIMITED,
++		{ 0x35B9, 0x2543, 0,      0xE2B2,
++		  0xEB2F, 0x2543, 0xFA01, 0x0B1F,
++		  0,      0x2543, 0x4489, 0xDB42 } },
+ 	{ COLOR_SPACE_2020_RGB_LIMITEDRANGE,
+ 		{ 0x35E0, 0x255F, 0,      0xE2B3,
+ 		  0xEB20, 0x255F, 0xF9FD, 0xB1E,
+diff --git a/drivers/gpu/drm/amd/display/modules/info_packet/info_packet.c b/drivers/gpu/drm/amd/display/modules/info_packet/info_packet.c
+index 84f9b412a4f117..09b14aeb3c840e 100644
+--- a/drivers/gpu/drm/amd/display/modules/info_packet/info_packet.c
++++ b/drivers/gpu/drm/amd/display/modules/info_packet/info_packet.c
+@@ -383,10 +383,10 @@ void mod_build_vsc_infopacket(const struct dc_stream_state *stream,
+ 				colorimetryFormat = ColorimetryYCC_DP_ITU709;
+ 			else if (cs == COLOR_SPACE_ADOBERGB)
+ 				colorimetryFormat = ColorimetryYCC_DP_AdobeYCC;
+-			else if (cs == COLOR_SPACE_2020_YCBCR)
++			else if (cs == COLOR_SPACE_2020_YCBCR_LIMITED)
+ 				colorimetryFormat = ColorimetryYCC_DP_ITU2020YCbCr;
+ 
+-			if (cs == COLOR_SPACE_2020_YCBCR && tf == TRANSFER_FUNC_GAMMA_22)
++			if (cs == COLOR_SPACE_2020_YCBCR_LIMITED && tf == TRANSFER_FUNC_GAMMA_22)
+ 				colorimetryFormat = ColorimetryYCC_DP_ITU709;
+ 			break;
+ 
+diff --git a/drivers/hid/hid-core.c b/drivers/hid/hid-core.c
+index b3bcc0fdede7ff..b924980b5783e7 100644
+--- a/drivers/hid/hid-core.c
++++ b/drivers/hid/hid-core.c
+@@ -344,6 +344,9 @@ static int hid_add_field(struct hid_parser *parser, unsigned report_type, unsign
+ 
+ static u32 item_udata(struct hid_item *item)
+ {
++	if (item->format != HID_ITEM_FORMAT_SHORT)
++		return 0;
++
+ 	switch (item->size) {
+ 	case 1: return item->data.u8;
+ 	case 2: return item->data.u16;
+@@ -354,6 +357,9 @@ static u32 item_udata(struct hid_item *item)
+ 
+ static s32 item_sdata(struct hid_item *item)
+ {
++	if (item->format != HID_ITEM_FORMAT_SHORT)
++		return 0;
++
+ 	switch (item->size) {
+ 	case 1: return item->data.s8;
+ 	case 2: return item->data.s16;
+@@ -1907,13 +1913,14 @@ int hid_set_field(struct hid_field *field, unsigned offset, __s32 value)
+ 
+ 	size = field->report_size;
+ 
+-	hid_dump_input(field->report->device, field->usage + offset, value);
+-
+ 	if (offset >= field->report_count) {
+ 		hid_err(field->report->device, "offset (%d) exceeds report_count (%d)\n",
+ 				offset, field->report_count);
+ 		return -1;
+ 	}
++
++	hid_dump_input(field->report->device, field->usage + offset, value);
++
+ 	if (field->logical_minimum < 0) {
+ 		if (value != snto32(s32ton(value, size), size)) {
+ 			hid_err(field->report->device, "value %d is out of range\n", value);
+diff --git a/drivers/hid/hid-hyperv.c b/drivers/hid/hid-hyperv.c
+index 9eafff0b6ea4c3..d044bed96accbd 100644
+--- a/drivers/hid/hid-hyperv.c
++++ b/drivers/hid/hid-hyperv.c
+@@ -171,18 +171,32 @@ static void mousevsc_free_device(struct mousevsc_dev *device)
+ }
+ 
+ static void mousevsc_on_receive_device_info(struct mousevsc_dev *input_device,
+-				struct synthhid_device_info *device_info)
++					    struct synthhid_device_info *device_info,
++					    u32 device_info_size)
+ {
+ 	int ret = 0;
+ 	struct hid_descriptor *desc;
+ 	struct mousevsc_prt_msg ack;
++	size_t desc_offset;
++	size_t desc_size;
+ 
+ 	input_device->dev_info_status = -ENOMEM;
+ 
++	if (device_info_size < sizeof(*device_info)) {
++		input_device->dev_info_status = -EINVAL;
++		goto cleanup;
++	}
++
+ 	input_device->hid_dev_info = device_info->hid_dev_info;
+ 	desc = &device_info->hid_descriptor;
++	desc_offset = offsetof(struct synthhid_device_info, hid_descriptor);
++	desc_size = device_info_size - desc_offset;
+ 	if (desc->bLength == 0)
+ 		goto cleanup;
++	if (desc->bLength < sizeof(*desc) || desc->bLength > desc_size) {
++		input_device->dev_info_status = -EINVAL;
++		goto cleanup;
++	}
+ 
+ 	/* The pointer is not NULL when we resume from hibernation */
+ 	kfree(input_device->hid_desc);
+@@ -197,6 +211,10 @@ static void mousevsc_on_receive_device_info(struct mousevsc_dev *input_device,
+ 		input_device->dev_info_status = -EINVAL;
+ 		goto cleanup;
+ 	}
++	if (input_device->report_desc_size > desc_size - desc->bLength) {
++		input_device->dev_info_status = -EINVAL;
++		goto cleanup;
++	}
+ 
+ 	/* The pointer is not NULL when we resume from hibernation */
+ 	kfree(input_device->report_desc);
+@@ -273,14 +291,17 @@ static void mousevsc_on_receive(struct hv_device *device,
+ 		break;
+ 
+ 	case SYNTH_HID_INITIAL_DEVICE_INFO:
+-		WARN_ON(pipe_msg->size < sizeof(struct hv_input_dev_info));
++		if (WARN_ON_ONCE(pipe_msg->size <
++				 sizeof(struct synthhid_device_info)))
++			break;
+ 
+ 		/*
+ 		 * Parse out the device info into device attr,
+ 		 * hid desc and report desc
+ 		 */
+ 		mousevsc_on_receive_device_info(input_dev,
+-			(struct synthhid_device_info *)pipe_msg->data);
++						(struct synthhid_device_info *)pipe_msg->data,
++						pipe_msg->size);
+ 		break;
+ 	case SYNTH_HID_INPUT_REPORT:
+ 		input_report =
+diff --git a/drivers/hid/hid-input.c b/drivers/hid/hid-input.c
+index c1708caa6b6cce..8f5e5cb88d37d9 100644
+--- a/drivers/hid/hid-input.c
++++ b/drivers/hid/hid-input.c
+@@ -361,6 +361,9 @@ static const struct hid_device_id hid_battery_quirks[] = {
+ 	{ HID_BLUETOOTH_DEVICE(USB_VENDOR_ID_APPLE,
+ 		USB_DEVICE_ID_APPLE_MAGICTRACKPAD),
+ 	  HID_BATTERY_QUIRK_IGNORE },
++	{ HID_BLUETOOTH_DEVICE(BT_VENDOR_ID_APPLE,
++		USB_DEVICE_ID_APPLE_MAGICTRACKPAD2_USBC),
++	  HID_BATTERY_QUIRK_AVOID_QUERY },
+ 	{ HID_BLUETOOTH_DEVICE(USB_VENDOR_ID_ELECOM,
+ 		USB_DEVICE_ID_ELECOM_BM084),
+ 	  HID_BATTERY_QUIRK_IGNORE },
+diff --git a/drivers/hid/hid-magicmouse.c b/drivers/hid/hid-magicmouse.c
+index d5df2745f3da44..aa6c5479de2a19 100644
+--- a/drivers/hid/hid-magicmouse.c
++++ b/drivers/hid/hid-magicmouse.c
+@@ -384,6 +384,10 @@ static int magicmouse_raw_event(struct hid_device *hdev,
+ 	struct input_dev *input = msc->input;
+ 	int x = 0, y = 0, ii, clicks = 0, npoints;
+ 
++	/* Protect against zero sized recursive calls from DOUBLE_REPORT_ID */
++	if (size < 1)
++		return 0;
++
+ 	switch (data[0]) {
+ 	case TRACKPAD_REPORT_ID:
+ 	case TRACKPAD2_BT_REPORT_ID:
+@@ -484,6 +488,18 @@ static int magicmouse_raw_event(struct hid_device *hdev,
+ 		/* Sometimes the trackpad sends two touch reports in one
+ 		 * packet.
+ 		 */
++
++		/* Ensure that we have at least 2 elements (report type and size) */
++		if (size < 2)
++			return 0;
++
++		if (size < data[1] + 2) {
++			hid_warn(hdev,
++				 "received report length (%d) was smaller than specified (%d)",
++				 size, data[1] + 2);
++			return 0;
++		}
++
+ 		magicmouse_raw_event(hdev, report, data + 2, data[1]);
+ 		magicmouse_raw_event(hdev, report, data + 2 + data[1],
+ 			size - 2 - data[1]);
+@@ -792,6 +808,12 @@ static bool is_usb_magictrackpad2(__u32 vendor, __u32 product)
+ 	       product == USB_DEVICE_ID_APPLE_MAGICTRACKPAD2_USBC;
+ }
+ 
++static bool is_bt_magictrackpad2(__u32 vendor, __u32 product)
++{
++	return vendor == BT_VENDOR_ID_APPLE &&
++	       product == USB_DEVICE_ID_APPLE_MAGICTRACKPAD2_USBC;
++}
++
+ static int magicmouse_fetch_battery(struct hid_device *hdev)
+ {
+ #ifdef CONFIG_HID_BATTERY_STRENGTH
+@@ -800,7 +822,8 @@ static int magicmouse_fetch_battery(struct hid_device *hdev)
+ 
+ 	if (!hdev->battery ||
+ 	    (!is_usb_magicmouse2(hdev->vendor, hdev->product) &&
+-	     !is_usb_magictrackpad2(hdev->vendor, hdev->product)))
++	     !is_usb_magictrackpad2(hdev->vendor, hdev->product) &&
++	     !is_bt_magictrackpad2(hdev->vendor, hdev->product)))
+ 		return -1;
+ 
+ 	report_enum = &hdev->report_enum[hdev->battery_report_type];
+@@ -862,6 +885,16 @@ static int magicmouse_probe(struct hid_device *hdev,
+ 		return ret;
+ 	}
+ 
++	/*
++	 * When hidinput_connect() fails it frees every input device it
++	 * created, but that does not fail hid_hw_start(): the core simply
++	 * does not claim an input. msc->input, cached in ->input_mapping
++	 * while the report descriptor was parsed, would then be a dangling
++	 * pointer that passes every NULL check. Trust the core's claim.
++	 */
++	if (!(hdev->claimed & HID_CLAIMED_INPUT))
++		msc->input = NULL;
++
+ 	if (is_usb_magicmouse2(id->vendor, id->product) ||
+ 	    is_usb_magictrackpad2(id->vendor, id->product)) {
+ 		timer_setup(&msc->battery_timer, magicmouse_battery_timer_tick, 0);
+@@ -926,6 +959,16 @@ static int magicmouse_probe(struct hid_device *hdev,
+ 		schedule_delayed_work(&msc->work, msecs_to_jiffies(500));
+ 	}
+ 
++	/*
++	 * Query the Bluetooth Magic Trackpad USB-C battery as done for USB.
++	 * Start io first: probe holds driver_input_lock and the synchronous
++	 * GET_REPORT reply would otherwise be dropped.
++	 */
++	if (is_bt_magictrackpad2(id->vendor, id->product)) {
++		hid_device_io_start(hdev);
++		magicmouse_fetch_battery(hdev);
++	}
++
+ 	return 0;
+ err_stop_hw:
+ 	if (is_usb_magicmouse2(id->vendor, id->product) ||
+diff --git a/drivers/hid/hid-nintendo.c b/drivers/hid/hid-nintendo.c
+index 4850e915a57d4d..b85e9f1a49f0b4 100644
+--- a/drivers/hid/hid-nintendo.c
++++ b/drivers/hid/hid-nintendo.c
+@@ -2217,7 +2217,12 @@ static int joycon_ctlr_read_handler(struct joycon_ctlr *ctlr, u8 *data,
+ {
+ 	if (data[0] == JC_INPUT_SUBCMD_REPLY || data[0] == JC_INPUT_IMU_DATA ||
+ 	    data[0] == JC_INPUT_MCU_DATA) {
+-		if (size >= 12) /* make sure it contains the input report */
++		/*
++		 * The whole struct is cast and parsed below, including the
++		 * IMU/subcmd union, not just the 12-byte partial header this
++		 * used to check for.
++		 */
++		if (size >= sizeof(struct joycon_input_report))
+ 			joycon_parse_report(ctlr,
+ 					    (struct joycon_input_report *)data);
+ 	}
+diff --git a/drivers/hid/hid-sensor-custom.c b/drivers/hid/hid-sensor-custom.c
+index d85398721659ab..2147cb350acba4 100644
+--- a/drivers/hid/hid-sensor-custom.c
++++ b/drivers/hid/hid-sensor-custom.c
+@@ -1006,26 +1006,26 @@ static int hid_sensor_custom_probe(struct platform_device *pdev)
+ 		return ret;
+ 	}
+ 
+-	ret = sysfs_create_group(&sensor_inst->pdev->dev.kobj,
+-				 &enable_sensor_attr_group);
++	ret = hid_sensor_custom_add_attributes(sensor_inst);
+ 	if (ret)
+ 		goto err_remove_callback;
+ 
+-	ret = hid_sensor_custom_add_attributes(sensor_inst);
++	ret = sysfs_create_group(&sensor_inst->pdev->dev.kobj,
++				 &enable_sensor_attr_group);
+ 	if (ret)
+-		goto err_remove_group;
++		goto err_remove_attributes;
+ 
+ 	ret = hid_sensor_custom_dev_if_add(sensor_inst);
+ 	if (ret)
+-		goto err_remove_attributes;
++		goto err_remove_group;
+ 
+ 	return 0;
+ 
+-err_remove_attributes:
+-	hid_sensor_custom_remove_attributes(sensor_inst);
+ err_remove_group:
+ 	sysfs_remove_group(&sensor_inst->pdev->dev.kobj,
+ 			   &enable_sensor_attr_group);
++err_remove_attributes:
++	hid_sensor_custom_remove_attributes(sensor_inst);
+ err_remove_callback:
+ 	sensor_hub_remove_callback(hsdev, hsdev->usage);
+ 
+@@ -1043,9 +1043,10 @@ static int hid_sensor_custom_remove(struct platform_device *pdev)
+ 	}
+ 
+ 	hid_sensor_custom_dev_if_remove(sensor_inst);
+-	hid_sensor_custom_remove_attributes(sensor_inst);
++	/* Remove enable_sensor first as it uses fields via power_state/report_state. */
+ 	sysfs_remove_group(&sensor_inst->pdev->dev.kobj,
+ 			   &enable_sensor_attr_group);
++	hid_sensor_custom_remove_attributes(sensor_inst);
+ 	sensor_hub_remove_callback(hsdev, hsdev->usage);
+ 
+ 	return 0;
+diff --git a/drivers/input/keyboard/atkbd.c b/drivers/input/keyboard/atkbd.c
+index 66d73cad96eaa4..665c09fe8410c8 100644
+--- a/drivers/input/keyboard/atkbd.c
++++ b/drivers/input/keyboard/atkbd.c
+@@ -1945,17 +1945,32 @@ static const struct dmi_system_id atkbd_dmi_quirk_table[] __initconst = {
+ 		.callback = atkbd_deactivate_fixup,
+ 	},
+ 	{
+-		/* Lenovo Yoga Air 14 (83QK) */
+ 		.matches = {
+-			DMI_MATCH(DMI_SYS_VENDOR, "LENOVO"),
+-			DMI_MATCH(DMI_PRODUCT_NAME, "83QK"),
++			DMI_MATCH(DMI_SYS_VENDOR, "HONOR"),
++			DMI_MATCH(DMI_PRODUCT_NAME, "BCC-N"),
+ 		},
+ 		.callback = atkbd_deactivate_fixup,
+ 	},
+ 	{
+ 		.matches = {
+ 			DMI_MATCH(DMI_SYS_VENDOR, "HONOR"),
+-			DMI_MATCH(DMI_PRODUCT_NAME, "BCC-N"),
++			DMI_MATCH(DMI_PRODUCT_NAME, "FMB-P"),
++		},
++		.callback = atkbd_deactivate_fixup,
++	},
++	{
++		/* HONOR MagicBook Pro 14 2026 */
++		.matches = {
++			DMI_MATCH(DMI_SYS_VENDOR, "HONOR"),
++			DMI_MATCH(DMI_PRODUCT_NAME, "ZQC-P"),
++		},
++		.callback = atkbd_deactivate_fixup,
++	},
++	{
++		/* Lenovo Yoga Air 14 (83QK) */
++		.matches = {
++			DMI_MATCH(DMI_SYS_VENDOR, "LENOVO"),
++			DMI_MATCH(DMI_PRODUCT_NAME, "83QK"),
+ 		},
+ 		.callback = atkbd_deactivate_fixup,
+ 	},
+diff --git a/drivers/input/mouse/byd.c b/drivers/input/mouse/byd.c
+index 221a553f45cd88..cb49f388830205 100644
+--- a/drivers/input/mouse/byd.c
++++ b/drivers/input/mouse/byd.c
+@@ -426,7 +426,7 @@ static void byd_disconnect(struct psmouse *psmouse)
+ 	struct byd_data *priv = psmouse->private;
+ 
+ 	if (priv) {
+-		del_timer(&priv->timer);
++		timer_shutdown_sync(&priv->timer);
+ 		kfree(psmouse->private);
+ 		psmouse->private = NULL;
+ 	}
+diff --git a/drivers/net/ntb_netdev.c b/drivers/net/ntb_netdev.c
+index dade51cf599c62..554ec6e5444033 100644
+--- a/drivers/net/ntb_netdev.c
++++ b/drivers/net/ntb_netdev.c
+@@ -100,7 +100,7 @@ static void ntb_netdev_rx_handler(struct ntb_transport_qp *qp, void *qp_data,
+ 				  void *data, int len)
+ {
+ 	struct net_device *ndev = qp_data;
+-	struct sk_buff *skb;
++	struct sk_buff *skb, *new_skb;
+ 	int rc;
+ 
+ 	skb = data;
+@@ -115,6 +115,12 @@ static void ntb_netdev_rx_handler(struct ntb_transport_qp *qp, void *qp_data,
+ 		goto enqueue_again;
+ 	}
+ 
++	new_skb = netdev_alloc_skb(ndev, ndev->mtu + ETH_HLEN);
++	if (!new_skb) {
++		ndev->stats.rx_dropped++;
++		goto enqueue_again;
++	}
++
+ 	skb_put(skb, len);
+ 	skb->protocol = eth_type_trans(skb, ndev);
+ 	skb->ip_summed = CHECKSUM_NONE;
+@@ -127,12 +133,7 @@ static void ntb_netdev_rx_handler(struct ntb_transport_qp *qp, void *qp_data,
+ 		ndev->stats.rx_bytes += len;
+ 	}
+ 
+-	skb = netdev_alloc_skb(ndev, ndev->mtu + ETH_HLEN);
+-	if (!skb) {
+-		ndev->stats.rx_errors++;
+-		ndev->stats.rx_frame_errors++;
+-		return;
+-	}
++	skb = new_skb;
+ 
+ enqueue_again:
+ 	rc = ntb_transport_rx_enqueue(qp, skb, skb->data, ndev->mtu + ETH_HLEN);
+diff --git a/drivers/net/usb/rndis_host.c b/drivers/net/usb/rndis_host.c
+index 7b3739b29c8f72..1d7e9a1a3cf1d4 100644
+--- a/drivers/net/usb/rndis_host.c
++++ b/drivers/net/usb/rndis_host.c
+@@ -14,6 +14,7 @@
+ #include <linux/usb/cdc.h>
+ #include <linux/usb/usbnet.h>
+ #include <linux/usb/rndis_host.h>
++#include <linux/overflow.h>
+ 
+ 
+ /*
+@@ -506,6 +507,7 @@ int rndis_rx_fixup(struct usbnet *dev, struct sk_buff *skb)
+ 		struct rndis_data_hdr	*hdr = (void *)skb->data;
+ 		struct sk_buff		*skb2;
+ 		u32			msg_type, msg_len, data_offset, data_len;
++		u32			overflow_check;
+ 
+ 		msg_type = le32_to_cpu(hdr->msg_type);
+ 		msg_len = le32_to_cpu(hdr->msg_len);
+@@ -514,7 +516,9 @@ int rndis_rx_fixup(struct usbnet *dev, struct sk_buff *skb)
+ 
+ 		/* don't choke if we see oob, per-packet data, etc */
+ 		if (unlikely(msg_type != RNDIS_MSG_PACKET || skb->len < msg_len
+-				|| (data_offset + data_len + 8) > msg_len)) {
++				|| (data_offset + data_len + 8) > msg_len
++				|| check_add_overflow(data_offset, data_len, &overflow_check)
++				|| check_add_overflow(overflow_check, 8, &overflow_check))) {
+ 			dev->net->stats.rx_frame_errors++;
+ 			netdev_dbg(dev->net, "bad rndis message %d/%d/%d/%d, len %d\n",
+ 				   le32_to_cpu(hdr->msg_type),
+diff --git a/drivers/nfc/fdp/i2c.c b/drivers/nfc/fdp/i2c.c
+index c1896a1d978cdc..f292e7f374568c 100644
+--- a/drivers/nfc/fdp/i2c.c
++++ b/drivers/nfc/fdp/i2c.c
+@@ -166,9 +166,36 @@ static int fdp_nci_i2c_read(struct fdp_i2c_phy *phy, struct sk_buff **skb)
+ 		/* Packet that contains a length */
+ 		if (tmp[0] == 0 && tmp[1] == 0) {
+ 			phy->next_read_size = (tmp[2] << 8) + tmp[3] + 3;
++
++			/*
++			 * next_read_size is taken from the device and is used
++			 * as the i2c_master_recv() count for the next packet
++			 * and as the data skb size. A value above the receive
++			 * buffer overflows tmp[]; one below the minimum frame
++			 * size runs the header/LRC strip and the length-field
++			 * read past a short receive. Either way the packet is
++			 * corrupt: drop it and force resynchronization.
++			 */
++			if (phy->next_read_size < FDP_NCI_I2C_MIN_PAYLOAD ||
++			    phy->next_read_size > FDP_NCI_I2C_MAX_PAYLOAD) {
++				dev_dbg(&client->dev, "%s: corrupted packet\n",
++					__func__);
++				phy->next_read_size = FDP_NCI_I2C_MIN_PAYLOAD;
++				goto flush;
++			}
+ 		} else {
+ 			phy->next_read_size = FDP_NCI_I2C_MIN_PAYLOAD;
+ 
++			/*
++			 * Only one data packet is delivered per call; if the
++			 * device sends another, do not overwrite and leak the
++			 * skb allocated for the previous one.
++			 */
++			if (*skb) {
++				kfree_skb(*skb);
++				*skb = NULL;
++			}
++
+ 			*skb = alloc_skb(len, GFP_KERNEL);
+ 			if (*skb == NULL) {
+ 				r = -ENOMEM;
+diff --git a/drivers/nfc/microread/microread.c b/drivers/nfc/microread/microread.c
+index bb4d029bb88853..b0e483ee7eec43 100644
+--- a/drivers/nfc/microread/microread.c
++++ b/drivers/nfc/microread/microread.c
+@@ -483,13 +483,19 @@ static void microread_target_discovered(struct nfc_hci_dev *hdev, u8 gate,
+ 
+ 	switch (gate) {
+ 	case MICROREAD_GATE_ID_MREAD_ISO_A:
++		if (skb->len <= MICROREAD_EMCF_A_LEN) {
++			r = -EINVAL;
++			goto exit_free;
++		}
++
+ 		targets->supported_protocols =
+ 		      nfc_hci_sak_to_protocol(skb->data[MICROREAD_EMCF_A_SAK]);
+ 		targets->sens_res =
+ 			 be16_to_cpu(*(u16 *)&skb->data[MICROREAD_EMCF_A_ATQA]);
+ 		targets->sel_res = skb->data[MICROREAD_EMCF_A_SAK];
+ 		targets->nfcid1_len = skb->data[MICROREAD_EMCF_A_LEN];
+-		if (targets->nfcid1_len > sizeof(targets->nfcid1)) {
++		if (targets->nfcid1_len > sizeof(targets->nfcid1) ||
++		    targets->nfcid1_len > skb->len - MICROREAD_EMCF_A_UID) {
+ 			r = -EINVAL;
+ 			goto exit_free;
+ 		}
+@@ -497,13 +503,19 @@ static void microread_target_discovered(struct nfc_hci_dev *hdev, u8 gate,
+ 		       targets->nfcid1_len);
+ 		break;
+ 	case MICROREAD_GATE_ID_MREAD_ISO_A_3:
++		if (skb->len <= MICROREAD_EMCF_A3_LEN) {
++			r = -EINVAL;
++			goto exit_free;
++		}
++
+ 		targets->supported_protocols =
+ 		      nfc_hci_sak_to_protocol(skb->data[MICROREAD_EMCF_A3_SAK]);
+ 		targets->sens_res =
+ 			 be16_to_cpu(*(u16 *)&skb->data[MICROREAD_EMCF_A3_ATQA]);
+ 		targets->sel_res = skb->data[MICROREAD_EMCF_A3_SAK];
+ 		targets->nfcid1_len = skb->data[MICROREAD_EMCF_A3_LEN];
+-		if (targets->nfcid1_len > sizeof(targets->nfcid1)) {
++		if (targets->nfcid1_len > sizeof(targets->nfcid1) ||
++		    targets->nfcid1_len > skb->len - MICROREAD_EMCF_A3_UID) {
+ 			r = -EINVAL;
+ 			goto exit_free;
+ 		}
+@@ -511,11 +523,21 @@ static void microread_target_discovered(struct nfc_hci_dev *hdev, u8 gate,
+ 		       targets->nfcid1_len);
+ 		break;
+ 	case MICROREAD_GATE_ID_MREAD_ISO_B:
++		if (skb->len < MICROREAD_EMCF_B_UID + 4) {
++			r = -EINVAL;
++			goto exit_free;
++		}
++
+ 		targets->supported_protocols = NFC_PROTO_ISO14443_B_MASK;
+ 		memcpy(targets->nfcid1, &skb->data[MICROREAD_EMCF_B_UID], 4);
+ 		targets->nfcid1_len = 4;
+ 		break;
+ 	case MICROREAD_GATE_ID_MREAD_NFC_T1:
++		if (skb->len < MICROREAD_EMCF_T1_UID + 4) {
++			r = -EINVAL;
++			goto exit_free;
++		}
++
+ 		targets->supported_protocols = NFC_PROTO_JEWEL_MASK;
+ 		targets->sens_res =
+ 			le16_to_cpu(*(u16 *)&skb->data[MICROREAD_EMCF_T1_ATQA]);
+@@ -523,6 +545,11 @@ static void microread_target_discovered(struct nfc_hci_dev *hdev, u8 gate,
+ 		targets->nfcid1_len = 4;
+ 		break;
+ 	case MICROREAD_GATE_ID_MREAD_NFC_T3:
++		if (skb->len < MICROREAD_EMCF_T3_UID + 8) {
++			r = -EINVAL;
++			goto exit_free;
++		}
++
+ 		targets->supported_protocols = NFC_PROTO_FELICA_MASK;
+ 		memcpy(targets->nfcid1, &skb->data[MICROREAD_EMCF_T3_UID], 8);
+ 		targets->nfcid1_len = 8;
+diff --git a/drivers/nfc/pn533/pn533.c b/drivers/nfc/pn533/pn533.c
+index e2bc67300a915a..6abe7b38acfbc8 100644
+--- a/drivers/nfc/pn533/pn533.c
++++ b/drivers/nfc/pn533/pn533.c
+@@ -2803,6 +2803,7 @@ void pn53x_common_clean(struct pn533 *priv)
+ 	destroy_workqueue(priv->wq);
+ 
+ 	skb_queue_purge(&priv->resp_q);
++	skb_queue_purge(&priv->fragment_skb);
+ 
+ 	list_for_each_entry_safe(cmd, n, &priv->cmd_queue, queue) {
+ 		list_del(&cmd->queue);
+diff --git a/drivers/nfc/st21nfca/dep.c b/drivers/nfc/st21nfca/dep.c
+index 1ec651e31064b1..e56a0117858363 100644
+--- a/drivers/nfc/st21nfca/dep.c
++++ b/drivers/nfc/st21nfca/dep.c
+@@ -207,6 +207,9 @@ static int st21nfca_tm_recv_atr_req(struct nfc_hci_dev *hdev,
+ 	if (atr_req->length < sizeof(struct st21nfca_atr_req))
+ 		return -EPROTO;
+ 
++	if (atr_req->length > skb->len)
++		return -EPROTO;
++
+ 	r = st21nfca_tm_send_atr_res(hdev, atr_req);
+ 	if (r)
+ 		return r;
+diff --git a/drivers/nvme/target/fabrics-cmd-auth.c b/drivers/nvme/target/fabrics-cmd-auth.c
+index ccd5dd3dac85f9..91651ffde2c90a 100644
+--- a/drivers/nvme/target/fabrics-cmd-auth.c
++++ b/drivers/nvme/target/fabrics-cmd-auth.c
+@@ -475,7 +475,7 @@ void nvmet_execute_auth_receive(struct nvmet_req *req)
+ 		return;
+ 	}
+ 
+-	d = kmalloc(al, GFP_KERNEL);
++	d = kzalloc(al, GFP_KERNEL);
+ 	if (!d) {
+ 		status = NVME_SC_INTERNAL;
+ 		goto done;
+diff --git a/drivers/nvme/target/fc.c b/drivers/nvme/target/fc.c
+index 188b9f1bdaca14..c114f5db1d61a3 100644
+--- a/drivers/nvme/target/fc.c
++++ b/drivers/nvme/target/fc.c
+@@ -571,7 +571,7 @@ out_fail:
+ 		list_del(&iod->ls_rcv_list);
+ 	}
+ 
+-	kfree(iod);
++	kfree(tgtport->iod);
+ 
+ 	return -EFAULT;
+ }
+diff --git a/drivers/nvme/target/tcp.c b/drivers/nvme/target/tcp.c
+index 0b6c3241a25593..2b6079ca552e30 100644
+--- a/drivers/nvme/target/tcp.c
++++ b/drivers/nvme/target/tcp.c
+@@ -428,14 +428,15 @@ static int nvmet_tcp_map_data(struct nvmet_tcp_cmd *cmd)
+ 	}
+ 	cmd->req.transfer_len += len;
+ 
+-	cmd->req.sg = sgl_alloc(len, GFP_KERNEL, &cmd->req.sg_cnt);
++	cmd->req.sg = sgl_alloc(len, GFP_KERNEL | __GFP_NOWARN,
++				&cmd->req.sg_cnt);
+ 	if (!cmd->req.sg)
+ 		return NVME_SC_INTERNAL;
+ 	cmd->cur_sg = cmd->req.sg;
+ 
+ 	if (nvmet_tcp_has_data_in(cmd)) {
+ 		cmd->iov = kmalloc_array(cmd->req.sg_cnt,
+-				sizeof(*cmd->iov), GFP_KERNEL);
++				sizeof(*cmd->iov), GFP_KERNEL | __GFP_NOWARN);
+ 		if (!cmd->iov)
+ 			goto err;
+ 	}
+diff --git a/drivers/pci/controller/pci-host-generic.c b/drivers/pci/controller/pci-host-generic.c
+index 63865aeb636b88..70e9f4cab9be7c 100644
+--- a/drivers/pci/controller/pci-host-generic.c
++++ b/drivers/pci/controller/pci-host-generic.c
+@@ -14,15 +14,6 @@
+ #include <linux/pci-ecam.h>
+ #include <linux/platform_device.h>
+ 
+-static const struct pci_ecam_ops gen_pci_cfg_cam_bus_ops = {
+-	.bus_shift	= 16,
+-	.pci_ops	= {
+-		.map_bus	= pci_ecam_map_bus,
+-		.read		= pci_generic_config_read,
+-		.write		= pci_generic_config_write,
+-	}
+-};
+-
+ static bool pci_dw_valid_device(struct pci_bus *bus, unsigned int devfn)
+ {
+ 	struct pci_config_window *cfg = bus->sysdata;
+@@ -58,7 +49,7 @@ static const struct pci_ecam_ops pci_dw_ecam_bus_ops = {
+ 
+ static const struct of_device_id gen_pci_of_match[] = {
+ 	{ .compatible = "pci-host-cam-generic",
+-	  .data = &gen_pci_cfg_cam_bus_ops },
++	  .data = &pci_generic_cam_ops },
+ 
+ 	{ .compatible = "pci-host-ecam-generic",
+ 	  .data = &pci_generic_ecam_ops },
+diff --git a/drivers/pci/ecam.c b/drivers/pci/ecam.c
+index 1c40d2506aef34..97430664db3acc 100644
+--- a/drivers/pci/ecam.c
++++ b/drivers/pci/ecam.c
+@@ -208,6 +208,19 @@ const struct pci_ecam_ops pci_generic_ecam_ops = {
+ };
+ EXPORT_SYMBOL_GPL(pci_generic_ecam_ops);
+ 
++/* CAM ops */
++const struct pci_ecam_ops pci_generic_cam_ops = {
++	.bus_shift	= 16,
++	.pci_ops	= {
++		.add_bus	= pci_ecam_add_bus,
++		.remove_bus	= pci_ecam_remove_bus,
++		.map_bus	= pci_ecam_map_bus,
++		.read		= pci_generic_config_read,
++		.write		= pci_generic_config_write,
++	}
++};
++EXPORT_SYMBOL_GPL(pci_generic_cam_ops);
++
+ #if defined(CONFIG_ACPI) && defined(CONFIG_PCI_QUIRKS)
+ /* ECAM ops for 32-bit access only (non-compliant) */
+ const struct pci_ecam_ops pci_32b_ops = {
+diff --git a/drivers/s390/cio/vfio_ccw_chp.c b/drivers/s390/cio/vfio_ccw_chp.c
+index 3284b676334740..a518234d0753c6 100644
+--- a/drivers/s390/cio/vfio_ccw_chp.c
++++ b/drivers/s390/cio/vfio_ccw_chp.c
+@@ -93,18 +93,13 @@ static ssize_t vfio_ccw_crw_region_read(struct vfio_ccw_private *private,
+ 	loff_t pos = *ppos & VFIO_CCW_OFFSET_MASK;
+ 	struct ccw_crw_region *region;
+ 	struct vfio_ccw_crw *crw;
++	unsigned long flags;
+ 	int ret;
+ 
+ 	if (pos + count > sizeof(*region))
+ 		return -EINVAL;
+ 
+ 	mutex_lock(&private->io_mutex);
+-	crw = list_first_entry_or_null(&private->crw,
+-				       struct vfio_ccw_crw, next);
+-
+-	if (crw)
+-		list_del(&crw->next);
+-
+ 	if (i >= private->num_regions) {
+ 		ret = -EINVAL;
+ 		goto out;
+@@ -113,6 +108,16 @@ static ssize_t vfio_ccw_crw_region_read(struct vfio_ccw_private *private,
+ 	i = array_index_nospec(i, private->num_regions);
+ 	region = private->region[i].data;
+ 
++	spin_lock_irqsave(&private->crw_lock, flags);
++	crw = list_first_entry_or_null(&private->crw,
++				       struct vfio_ccw_crw, next);
++
++	if (crw)
++		list_del(&crw->next);
++
++	/* Drop CRW lock while copying to userspace */
++	spin_unlock_irqrestore(&private->crw_lock, flags);
++
+ 	if (crw)
+ 		memcpy(&region->crw, &crw->crw, sizeof(region->crw));
+ 
+@@ -122,15 +127,16 @@ static ssize_t vfio_ccw_crw_region_read(struct vfio_ccw_private *private,
+ 		ret = count;
+ 
+ 	region->crw = 0;
+-
+-out:
+-	mutex_unlock(&private->io_mutex);
+-
+ 	kfree(crw);
+ 
+ 	/* Notify the guest if more CRWs are on our queue */
++	spin_lock_irqsave(&private->crw_lock, flags);
+ 	if (!list_empty(&private->crw) && private->crw_trigger)
+ 		eventfd_signal(private->crw_trigger, 1);
++	spin_unlock_irqrestore(&private->crw_lock, flags);
++
++out:
++	mutex_unlock(&private->io_mutex);
+ 
+ 	return ret;
+ }
+diff --git a/drivers/s390/cio/vfio_ccw_cp.c b/drivers/s390/cio/vfio_ccw_cp.c
+index 933eb4a6cbdb5d..bbc57a60e27cac 100644
+--- a/drivers/s390/cio/vfio_ccw_cp.c
++++ b/drivers/s390/cio/vfio_ccw_cp.c
+@@ -233,6 +233,7 @@ static void convert_ccw0_to_ccw1(struct ccw1 *source, unsigned long len)
+ }
+ 
+ #define idal_is_2k(_cp) (!(_cp)->orb.cmd.c64 || (_cp)->orb.cmd.i2k)
++#define get_idaw_size(_cp) ((_cp)->orb.cmd.c64 ? sizeof(u64) : sizeof(u32))
+ 
+ /*
+  * Helpers to operate ccwchain.
+@@ -450,9 +451,6 @@ static int ccwchain_handle_ccw(u32 cda, struct channel_program *cp)
+ 	/* Loop for tics on this new chain. */
+ 	ret = ccwchain_loop_tic(chain, cp);
+ 
+-	if (ret)
+-		ccwchain_free(chain);
+-
+ 	return ret;
+ }
+ 
+@@ -481,6 +479,23 @@ static int ccwchain_loop_tic(struct ccwchain *chain, struct channel_program *cp)
+ 	return 0;
+ }
+ 
++static int ccwchain_build_ccws(u32 cda, struct channel_program *cp)
++{
++	struct ccwchain *chain, *temp;
++	int ret;
++
++	ret = ccwchain_handle_ccw(cda, cp);
++
++	if (ret) {
++		/* Cleanup if an error occurred */
++		list_for_each_entry_safe(chain, temp, &cp->ccwchain_list, next) {
++			ccwchain_free(chain);
++		}
++	}
++
++	return ret;
++}
++
+ static int ccwchain_fetch_tic(struct ccw1 *ccw,
+ 			      struct channel_program *cp)
+ {
+@@ -507,7 +522,8 @@ static unsigned long *get_guest_idal(struct ccw1 *ccw,
+ 		&container_of(cp, struct vfio_ccw_private, cp)->vdev;
+ 	unsigned long *idaws;
+ 	unsigned int *idaws_f1;
+-	int idal_len = idaw_nr * sizeof(*idaws);
++	u64 first_idaw;
++	int idal_len = idaw_nr * get_idaw_size(cp);
+ 	int idaw_size = idal_is_2k(cp) ? PAGE_SIZE / 2 : PAGE_SIZE;
+ 	int idaw_mask = ~(idaw_size - 1);
+ 	int i, ret;
+@@ -523,6 +539,18 @@ static unsigned long *get_guest_idal(struct ccw1 *ccw,
+ 			kfree(idaws);
+ 			return ERR_PTR(ret);
+ 		}
++
++		idaws_f1 = (unsigned int *)idaws;
++		if (cp->orb.cmd.c64)
++			first_idaw = idaws[0];
++		else
++			first_idaw = (unsigned long)(idaws_f1[0]);
++
++		/* Unexpected mismatch from earlier read */
++		if (first_idaw != cp->guest_iova) {
++			kfree(idaws);
++			return ERR_PTR(-EINVAL);
++		}
+ 	} else {
+ 		/* Fabricate an IDAL based off CCW data address */
+ 		if (cp->orb.cmd.c64) {
+@@ -560,7 +588,7 @@ static int ccw_count_idaws(struct ccw1 *ccw,
+ 	struct vfio_device *vdev =
+ 		&container_of(cp, struct vfio_ccw_private, cp)->vdev;
+ 	u64 iova;
+-	int size = cp->orb.cmd.c64 ? sizeof(u64) : sizeof(u32);
++	int size = get_idaw_size(cp);
+ 	int ret;
+ 	int bytes = 1;
+ 
+@@ -584,6 +612,9 @@ static int ccw_count_idaws(struct ccw1 *ccw,
+ 		iova = ccw->cda;
+ 	}
+ 
++	/* Save the read address for later */
++	cp->guest_iova = iova;
++
+ 	/* Format-1 IDAWs operate on 2K each */
+ 	if (!cp->orb.cmd.c64)
+ 		return idal_2k_nr_words((void *)iova, bytes);
+@@ -728,7 +759,7 @@ int cp_init(struct channel_program *cp, union orb *orb)
+ 	memcpy(&cp->orb, orb, sizeof(*orb));
+ 
+ 	/* Build a ccwchain for the first CCW segment */
+-	ret = ccwchain_handle_ccw(orb->cmd.cpa, cp);
++	ret = ccwchain_build_ccws(orb->cmd.cpa, cp);
+ 
+ 	if (!ret)
+ 		cp->initialized = true;
+diff --git a/drivers/s390/cio/vfio_ccw_cp.h b/drivers/s390/cio/vfio_ccw_cp.h
+index a9b1d8dbc6f655..9af98ff12d6716 100644
+--- a/drivers/s390/cio/vfio_ccw_cp.h
++++ b/drivers/s390/cio/vfio_ccw_cp.h
+@@ -35,6 +35,7 @@
+  * @initialized: whether this instance is actually initialized
+  * @guest_cp: copy of guest channel program
+  * @ccwchain_count: number of channel program segments (linked by TIC)
++ * @guest_iova: first data address of a guest channel program
+  *
+  * @ccwchain_list is the head of a ccwchain list, that contents the
+  * translated result of the guest channel program that pointed out by
+@@ -46,6 +47,7 @@ struct channel_program {
+ 	bool initialized;
+ 	struct ccw1 *guest_cp;
+ 	unsigned int ccwchain_count;
++	u64 guest_iova;
+ };
+ 
+ int cp_init(struct channel_program *cp, union orb *orb);
+diff --git a/drivers/s390/cio/vfio_ccw_drv.c b/drivers/s390/cio/vfio_ccw_drv.c
+index 884e2e5e410490..e3e91aa1068272 100644
+--- a/drivers/s390/cio/vfio_ccw_drv.c
++++ b/drivers/s390/cio/vfio_ccw_drv.c
+@@ -118,11 +118,14 @@ void vfio_ccw_sch_io_todo(struct work_struct *work)
+ void vfio_ccw_crw_todo(struct work_struct *work)
+ {
+ 	struct vfio_ccw_private *private;
++	unsigned long flags;
+ 
+ 	private = container_of(work, struct vfio_ccw_private, crw_work);
+ 
++	spin_lock_irqsave(&private->crw_lock, flags);
+ 	if (!list_empty(&private->crw) && private->crw_trigger)
+ 		eventfd_signal(private->crw_trigger, 1);
++	spin_unlock_irqrestore(&private->crw_lock, flags);
+ }
+ 
+ void vfio_ccw_notoper_todo(struct work_struct *work)
+@@ -286,6 +289,7 @@ static void vfio_ccw_queue_crw(struct vfio_ccw_private *private,
+ 			       unsigned int rsid)
+ {
+ 	struct vfio_ccw_crw *crw;
++	unsigned long flags;
+ 
+ 	/*
+ 	 * If unable to allocate a CRW, just drop the event and
+@@ -303,7 +307,9 @@ static void vfio_ccw_queue_crw(struct vfio_ccw_private *private,
+ 	crw->crw.erc = erc;
+ 	crw->crw.rsid = rsid;
+ 
++	spin_lock_irqsave(&private->crw_lock, flags);
+ 	list_add_tail(&crw->next, &private->crw);
++	spin_unlock_irqrestore(&private->crw_lock, flags);
+ 	queue_work(vfio_ccw_work_q, &private->crw_work);
+ }
+ 
+diff --git a/drivers/s390/cio/vfio_ccw_ops.c b/drivers/s390/cio/vfio_ccw_ops.c
+index 67acfa2533eef7..d1c17969cb98ec 100644
+--- a/drivers/s390/cio/vfio_ccw_ops.c
++++ b/drivers/s390/cio/vfio_ccw_ops.c
+@@ -55,6 +55,7 @@ static int vfio_ccw_mdev_init_dev(struct vfio_device *vdev)
+ 	INIT_WORK(&private->io_work, vfio_ccw_sch_io_todo);
+ 	INIT_WORK(&private->crw_work, vfio_ccw_crw_todo);
+ 	INIT_WORK(&private->notoper_work, vfio_ccw_notoper_todo);
++	spin_lock_init(&private->crw_lock);
+ 
+ 	private->cp.guest_cp = kcalloc(CCWCHAIN_LEN_MAX, sizeof(struct ccw1),
+ 				       GFP_KERNEL);
+@@ -132,6 +133,7 @@ static void vfio_ccw_mdev_release_dev(struct vfio_device *vdev)
+ 	struct vfio_ccw_private *private =
+ 		container_of(vdev, struct vfio_ccw_private, vdev);
+ 	struct vfio_ccw_crw *crw, *temp;
++	unsigned long flags;
+ 
+ 	/*
+ 	 * Ensure these work items are fully drained, so none can
+@@ -147,10 +149,12 @@ static void vfio_ccw_mdev_release_dev(struct vfio_device *vdev)
+ 	cancel_work_sync(&private->crw_work);
+ 	flush_work(&private->notoper_work);
+ 
++	spin_lock_irqsave(&private->crw_lock, flags);
+ 	list_for_each_entry_safe(crw, temp, &private->crw, next) {
+ 		list_del(&crw->next);
+ 		kfree(crw);
+ 	}
++	spin_unlock_irqrestore(&private->crw_lock, flags);
+ 
+ 	kmem_cache_free(vfio_ccw_crw_region, private->crw_region);
+ 	kmem_cache_free(vfio_ccw_schib_region, private->schib_region);
+diff --git a/drivers/s390/cio/vfio_ccw_private.h b/drivers/s390/cio/vfio_ccw_private.h
+index 0e30497da600f8..7c16cd570043cd 100644
+--- a/drivers/s390/cio/vfio_ccw_private.h
++++ b/drivers/s390/cio/vfio_ccw_private.h
+@@ -98,6 +98,8 @@ struct vfio_ccw_parent {
+  * @cp: channel program for the current I/O operation
+  * @irb: irb info received from interrupt
+  * @scsw: scsw info
++ * @crw_lock: serialization of CRW list information
++ * @crw: list of Channel Report Word elements
+  * @io_trigger: eventfd ctx for signaling userspace I/O results
+  * @crw_trigger: eventfd ctx for signaling userspace CRW information
+  * @req_trigger: eventfd ctx for signaling userspace to return device
+@@ -120,6 +122,8 @@ struct vfio_ccw_private {
+ 	struct channel_program	cp;
+ 	struct irb		irb;
+ 	union scsw		scsw;
++
++	spinlock_t		crw_lock;
+ 	struct list_head	crw;
+ 
+ 	struct eventfd_ctx	*io_trigger;
+diff --git a/drivers/tty/serial/amba-pl011.c b/drivers/tty/serial/amba-pl011.c
+index 8aa71a51cdabb4..4c107556ae315b 100644
+--- a/drivers/tty/serial/amba-pl011.c
++++ b/drivers/tty/serial/amba-pl011.c
+@@ -1193,7 +1193,7 @@ static void pl011_dma_shutdown(struct uart_amba_port *uap)
+ 
+ 	if (uap->using_tx_dma) {
+ 		/* In theory, this should already be done by pl011_dma_flush_buffer */
+-		dmaengine_terminate_all(uap->dmatx.chan);
++		dmaengine_terminate_sync(uap->dmatx.chan);
+ 		if (uap->dmatx.queued) {
+ 			dma_unmap_single(uap->dmatx.chan->device->dev,
+ 					 uap->dmatx.dma, uap->dmatx.len,
+@@ -1206,12 +1206,12 @@ static void pl011_dma_shutdown(struct uart_amba_port *uap)
+ 	}
+ 
+ 	if (uap->using_rx_dma) {
+-		dmaengine_terminate_all(uap->dmarx.chan);
++		if (uap->dmarx.poll_rate)
++			timer_delete_sync(&uap->dmarx.timer);
++		dmaengine_terminate_sync(uap->dmarx.chan);
+ 		/* Clean up the RX DMA */
+ 		pl011_dmabuf_free(uap->dmarx.chan, &uap->dmarx.dbuf_a, DMA_FROM_DEVICE);
+ 		pl011_dmabuf_free(uap->dmarx.chan, &uap->dmarx.dbuf_b, DMA_FROM_DEVICE);
+-		if (uap->dmarx.poll_rate)
+-			del_timer_sync(&uap->dmarx.timer);
+ 		uap->using_rx_dma = false;
+ 	}
+ }
+diff --git a/drivers/tty/serial/qcom_geni_serial.c b/drivers/tty/serial/qcom_geni_serial.c
+index ab5b4c6c29de08..91c502e833e16d 100644
+--- a/drivers/tty/serial/qcom_geni_serial.c
++++ b/drivers/tty/serial/qcom_geni_serial.c
+@@ -144,6 +144,7 @@ static const struct uart_ops qcom_geni_uart_pops;
+ static struct uart_driver qcom_geni_console_driver;
+ static struct uart_driver qcom_geni_uart_driver;
+ 
++static void qcom_geni_serial_stop_tx_dma(struct uart_port *uport);
+ static int qcom_geni_serial_port_setup(struct uart_port *uport);
+ 
+ static inline struct qcom_geni_serial_port *to_dev_port(struct uart_port *uport)
+@@ -597,35 +598,48 @@ static unsigned int qcom_geni_serial_tx_empty(struct uart_port *uport)
+ 	return !readl(uport->membase + SE_GENI_TX_FIFO_STATUS);
+ }
+ 
++static void qcom_geni_serial_flush_buffer_dma(struct uart_port *uport)
++{
++	struct qcom_geni_serial_port *port = to_dev_port(uport);
++
++	qcom_geni_serial_stop_tx_dma(uport);
++	port->tx_remaining = 0;
++}
++
+ static void qcom_geni_serial_stop_tx_dma(struct uart_port *uport)
+ {
+ 	struct qcom_geni_serial_port *port = to_dev_port(uport);
+ 	bool done;
+ 
+-	if (!qcom_geni_serial_main_active(uport))
+-		return;
++	if (qcom_geni_serial_main_active(uport)) {
++		geni_se_cancel_m_cmd(&port->se);
++
++		done = qcom_geni_serial_poll_bit(uport, SE_GENI_M_IRQ_STATUS,
++						 M_CMD_CANCEL_EN, true);
++		if (!done) {
++			geni_se_abort_m_cmd(&port->se);
++			done = qcom_geni_serial_poll_bit(uport, SE_GENI_M_IRQ_STATUS,
++							 M_CMD_ABORT_EN, true);
++			if (!done)
++				dev_err_ratelimited(uport->dev, "M_CMD_ABORT_EN not set");
++			writel(M_CMD_ABORT_EN, uport->membase + SE_GENI_M_IRQ_CLEAR);
++		}
++
++		writel(M_CMD_CANCEL_EN, uport->membase + SE_GENI_M_IRQ_CLEAR);
++	}
+ 
+ 	if (port->tx_dma_addr) {
++		writel(1, uport->membase + SE_DMA_TX_FSM_RST);
++		if (!qcom_geni_serial_poll_bit(uport, SE_DMA_TX_IRQ_STAT,
++					       TX_RESET_DONE, true))
++			dev_err_ratelimited(uport->dev, "TX DMA reset failed");
++		writel(TX_RESET_DONE | TX_DMA_DONE,
++		       uport->membase + SE_DMA_TX_IRQ_CLR);
++
+ 		geni_se_tx_dma_unprep(&port->se, port->tx_dma_addr,
+ 				      port->tx_remaining);
+ 		port->tx_dma_addr = 0;
+-		port->tx_remaining = 0;
+-	}
+-
+-	geni_se_cancel_m_cmd(&port->se);
+-
+-	done = qcom_geni_serial_poll_bit(uport, SE_GENI_M_IRQ_STATUS,
+-					 M_CMD_CANCEL_EN, true);
+-	if (!done) {
+-		geni_se_abort_m_cmd(&port->se);
+-		done = qcom_geni_serial_poll_bit(uport, SE_GENI_M_IRQ_STATUS,
+-						 M_CMD_ABORT_EN, true);
+-		if (!done)
+-			dev_err_ratelimited(uport->dev, "M_CMD_ABORT_EN not set");
+-		writel(M_CMD_ABORT_EN, uport->membase + SE_GENI_M_IRQ_CLEAR);
+ 	}
+-
+-	writel(M_CMD_CANCEL_EN, uport->membase + SE_GENI_M_IRQ_CLEAR);
+ }
+ 
+ static void qcom_geni_serial_start_tx_dma(struct uart_port *uport)
+@@ -1600,6 +1614,7 @@ static const struct uart_ops qcom_geni_uart_pops = {
+ 	.request_port = qcom_geni_serial_request_port,
+ 	.config_port = qcom_geni_serial_config_port,
+ 	.shutdown = qcom_geni_serial_shutdown,
++	.flush_buffer = qcom_geni_serial_flush_buffer_dma,
+ 	.type = qcom_geni_serial_get_type,
+ 	.set_mctrl = qcom_geni_serial_set_mctrl,
+ 	.get_mctrl = qcom_geni_serial_get_mctrl,
+diff --git a/drivers/tty/serial/sc16is7xx.c b/drivers/tty/serial/sc16is7xx.c
+index 6c9a96a72059ad..02b74a695c8e00 100644
+--- a/drivers/tty/serial/sc16is7xx.c
++++ b/drivers/tty/serial/sc16is7xx.c
+@@ -9,6 +9,8 @@
+ #define pr_fmt(fmt) KBUILD_MODNAME ": " fmt
+ 
+ #include <linux/bitops.h>
++#include <linux/bits.h>
++#include <linux/cleanup.h>
+ #include <linux/clk.h>
+ #include <linux/delay.h>
+ #include <linux/device.h>
+@@ -73,52 +75,52 @@
+ #define SC16IS7XX_XOFF2_REG		(0x07) /* Xoff2 word */
+ 
+ /* IER register bits */
+-#define SC16IS7XX_IER_RDI_BIT		(1 << 0) /* Enable RX data interrupt */
+-#define SC16IS7XX_IER_THRI_BIT		(1 << 1) /* Enable TX holding register
++#define SC16IS7XX_IER_RDI_BIT		BIT(0)   /* Enable RX data interrupt */
++#define SC16IS7XX_IER_THRI_BIT		BIT(1)   /* Enable TX holding register
+ 						  * interrupt */
+-#define SC16IS7XX_IER_RLSI_BIT		(1 << 2) /* Enable RX line status
++#define SC16IS7XX_IER_RLSI_BIT		BIT(2)   /* Enable RX line status
+ 						  * interrupt */
+-#define SC16IS7XX_IER_MSI_BIT		(1 << 3) /* Enable Modem status
++#define SC16IS7XX_IER_MSI_BIT		BIT(3)   /* Enable Modem status
+ 						  * interrupt */
+ 
+ /* IER register bits - write only if (EFR[4] == 1) */
+-#define SC16IS7XX_IER_SLEEP_BIT		(1 << 4) /* Enable Sleep mode */
+-#define SC16IS7XX_IER_XOFFI_BIT		(1 << 5) /* Enable Xoff interrupt */
+-#define SC16IS7XX_IER_RTSI_BIT		(1 << 6) /* Enable nRTS interrupt */
+-#define SC16IS7XX_IER_CTSI_BIT		(1 << 7) /* Enable nCTS interrupt */
++#define SC16IS7XX_IER_SLEEP_BIT		BIT(4)   /* Enable Sleep mode */
++#define SC16IS7XX_IER_XOFFI_BIT		BIT(5)   /* Enable Xoff interrupt */
++#define SC16IS7XX_IER_RTSI_BIT		BIT(6)   /* Enable nRTS interrupt */
++#define SC16IS7XX_IER_CTSI_BIT		BIT(7)   /* Enable nCTS interrupt */
+ 
+ /* FCR register bits */
+-#define SC16IS7XX_FCR_FIFO_BIT		(1 << 0) /* Enable FIFO */
+-#define SC16IS7XX_FCR_RXRESET_BIT	(1 << 1) /* Reset RX FIFO */
+-#define SC16IS7XX_FCR_TXRESET_BIT	(1 << 2) /* Reset TX FIFO */
+-#define SC16IS7XX_FCR_RXLVLL_BIT	(1 << 6) /* RX Trigger level LSB */
+-#define SC16IS7XX_FCR_RXLVLH_BIT	(1 << 7) /* RX Trigger level MSB */
++#define SC16IS7XX_FCR_FIFO_BIT		BIT(0)   /* Enable FIFO */
++#define SC16IS7XX_FCR_RXRESET_BIT	BIT(1)   /* Reset RX FIFO */
++#define SC16IS7XX_FCR_TXRESET_BIT	BIT(2)   /* Reset TX FIFO */
++#define SC16IS7XX_FCR_RXLVLL_BIT	BIT(6)   /* RX Trigger level LSB */
++#define SC16IS7XX_FCR_RXLVLH_BIT	BIT(7)   /* RX Trigger level MSB */
+ 
+ /* FCR register bits - write only if (EFR[4] == 1) */
+-#define SC16IS7XX_FCR_TXLVLL_BIT	(1 << 4) /* TX Trigger level LSB */
+-#define SC16IS7XX_FCR_TXLVLH_BIT	(1 << 5) /* TX Trigger level MSB */
++#define SC16IS7XX_FCR_TXLVLL_BIT	BIT(4)   /* TX Trigger level LSB */
++#define SC16IS7XX_FCR_TXLVLH_BIT	BIT(5)   /* TX Trigger level MSB */
+ 
+ /* IIR register bits */
+-#define SC16IS7XX_IIR_NO_INT_BIT	(1 << 0) /* No interrupts pending */
+-#define SC16IS7XX_IIR_ID_MASK		0x3e     /* Mask for the interrupt ID */
+-#define SC16IS7XX_IIR_THRI_SRC		0x02     /* TX holding register empty */
+-#define SC16IS7XX_IIR_RDI_SRC		0x04     /* RX data interrupt */
+-#define SC16IS7XX_IIR_RLSE_SRC		0x06     /* RX line status error */
+-#define SC16IS7XX_IIR_RTOI_SRC		0x0c     /* RX time-out interrupt */
+-#define SC16IS7XX_IIR_MSI_SRC		0x00     /* Modem status interrupt
+-						  * - only on 75x/76x
+-						  */
+-#define SC16IS7XX_IIR_INPIN_SRC		0x30     /* Input pin change of state
+-						  * - only on 75x/76x
+-						  */
+-#define SC16IS7XX_IIR_XOFFI_SRC		0x10     /* Received Xoff */
+-#define SC16IS7XX_IIR_CTSRTS_SRC	0x20     /* nCTS,nRTS change of state
+-						  * from active (LOW)
+-						  * to inactive (HIGH)
+-						  */
++#define SC16IS7XX_IIR_NO_INT_BIT	0x01		/* No interrupts pending */
++#define SC16IS7XX_IIR_ID_MASK		GENMASK(5, 1)	/* Mask for the interrupt ID */
++#define SC16IS7XX_IIR_THRI_SRC		0x02		/* TX holding register empty */
++#define SC16IS7XX_IIR_RDI_SRC		0x04		/* RX data interrupt */
++#define SC16IS7XX_IIR_RLSE_SRC		0x06		/* RX line status error */
++#define SC16IS7XX_IIR_RTOI_SRC		0x0c		/* RX time-out interrupt */
++#define SC16IS7XX_IIR_MSI_SRC		0x00		/* Modem status interrupt
++							 * - only on 75x/76x
++							 */
++#define SC16IS7XX_IIR_INPIN_SRC		0x30		/* Input pin change of state
++							 * - only on 75x/76x
++							 */
++#define SC16IS7XX_IIR_XOFFI_SRC		0x10		/* Received Xoff */
++#define SC16IS7XX_IIR_CTSRTS_SRC	0x20		/* nCTS,nRTS change of state
++							 * from active (LOW)
++							 * to inactive (HIGH)
++							 */
+ /* LCR register bits */
+-#define SC16IS7XX_LCR_LENGTH0_BIT	(1 << 0) /* Word length bit 0 */
+-#define SC16IS7XX_LCR_LENGTH1_BIT	(1 << 1) /* Word length bit 1
++#define SC16IS7XX_LCR_LENGTH0_BIT	BIT(0)   /* Word length bit 0 */
++#define SC16IS7XX_LCR_LENGTH1_BIT	BIT(1)   /* Word length bit 1
+ 						  *
+ 						  * Word length bits table:
+ 						  * 00 -> 5 bit words
+@@ -126,7 +128,7 @@
+ 						  * 10 -> 7 bit words
+ 						  * 11 -> 8 bit words
+ 						  */
+-#define SC16IS7XX_LCR_STOPLEN_BIT	(1 << 2) /* STOP length bit
++#define SC16IS7XX_LCR_STOPLEN_BIT	BIT(2)   /* STOP length bit
+ 						  *
+ 						  * STOP length bit table:
+ 						  * 0 -> 1 stop bit
+@@ -134,11 +136,11 @@
+ 						  *      word length is 5,
+ 						  *      2 stop bits otherwise
+ 						  */
+-#define SC16IS7XX_LCR_PARITY_BIT	(1 << 3) /* Parity bit enable */
+-#define SC16IS7XX_LCR_EVENPARITY_BIT	(1 << 4) /* Even parity bit enable */
+-#define SC16IS7XX_LCR_FORCEPARITY_BIT	(1 << 5) /* 9-bit multidrop parity */
+-#define SC16IS7XX_LCR_TXBREAK_BIT	(1 << 6) /* TX break enable */
+-#define SC16IS7XX_LCR_DLAB_BIT		(1 << 7) /* Divisor Latch enable */
++#define SC16IS7XX_LCR_PARITY_BIT	BIT(3)   /* Parity bit enable */
++#define SC16IS7XX_LCR_EVENPARITY_BIT	BIT(4)   /* Even parity bit enable */
++#define SC16IS7XX_LCR_FORCEPARITY_BIT	BIT(5)   /* 9-bit multidrop parity */
++#define SC16IS7XX_LCR_TXBREAK_BIT	BIT(6)   /* TX break enable */
++#define SC16IS7XX_LCR_DLAB_BIT		BIT(7)   /* Divisor Latch enable */
+ #define SC16IS7XX_LCR_WORD_LEN_5	(0x00)
+ #define SC16IS7XX_LCR_WORD_LEN_6	(0x01)
+ #define SC16IS7XX_LCR_WORD_LEN_7	(0x02)
+@@ -149,58 +151,63 @@
+ 								* reg set */
+ 
+ /* MCR register bits */
+-#define SC16IS7XX_MCR_DTR_BIT		(1 << 0) /* DTR complement
++#define SC16IS7XX_MCR_DTR_BIT		BIT(0)   /* DTR complement
+ 						  * - only on 75x/76x
+ 						  */
+-#define SC16IS7XX_MCR_RTS_BIT		(1 << 1) /* RTS complement */
+-#define SC16IS7XX_MCR_TCRTLR_BIT	(1 << 2) /* TCR/TLR register enable */
+-#define SC16IS7XX_MCR_LOOP_BIT		(1 << 4) /* Enable loopback test mode */
+-#define SC16IS7XX_MCR_XONANY_BIT	(1 << 5) /* Enable Xon Any
++#define SC16IS7XX_MCR_RTS_BIT		BIT(1)   /* RTS complement */
++#define SC16IS7XX_MCR_TCRTLR_BIT	BIT(2)   /* TCR/TLR register enable */
++#define SC16IS7XX_MCR_LOOP_BIT		BIT(4)   /* Enable loopback test mode */
++#define SC16IS7XX_MCR_XONANY_BIT	BIT(5)   /* Enable Xon Any
+ 						  * - write enabled
+ 						  * if (EFR[4] == 1)
+ 						  */
+-#define SC16IS7XX_MCR_IRDA_BIT		(1 << 6) /* Enable IrDA mode
++#define SC16IS7XX_MCR_IRDA_BIT		BIT(6)   /* Enable IrDA mode
+ 						  * - write enabled
+ 						  * if (EFR[4] == 1)
+ 						  */
+-#define SC16IS7XX_MCR_CLKSEL_BIT	(1 << 7) /* Divide clock by 4
++#define SC16IS7XX_MCR_CLKSEL_BIT	BIT(7)   /* Divide clock by 4
+ 						  * - write enabled
+ 						  * if (EFR[4] == 1)
+ 						  */
+ 
+ /* LSR register bits */
+-#define SC16IS7XX_LSR_DR_BIT		(1 << 0) /* Receiver data ready */
+-#define SC16IS7XX_LSR_OE_BIT		(1 << 1) /* Overrun Error */
+-#define SC16IS7XX_LSR_PE_BIT		(1 << 2) /* Parity Error */
+-#define SC16IS7XX_LSR_FE_BIT		(1 << 3) /* Frame Error */
+-#define SC16IS7XX_LSR_BI_BIT		(1 << 4) /* Break Interrupt */
+-#define SC16IS7XX_LSR_BRK_ERROR_MASK	0x1E     /* BI, FE, PE, OE bits */
+-#define SC16IS7XX_LSR_THRE_BIT		(1 << 5) /* TX holding register empty */
+-#define SC16IS7XX_LSR_TEMT_BIT		(1 << 6) /* Transmitter empty */
+-#define SC16IS7XX_LSR_FIFOE_BIT		(1 << 7) /* Fifo Error */
++#define SC16IS7XX_LSR_DR_BIT		BIT(0)   /* Receiver data ready */
++#define SC16IS7XX_LSR_OE_BIT		BIT(1)   /* Overrun Error */
++#define SC16IS7XX_LSR_PE_BIT		BIT(2)   /* Parity Error */
++#define SC16IS7XX_LSR_FE_BIT		BIT(3)   /* Frame Error */
++#define SC16IS7XX_LSR_BI_BIT		BIT(4)   /* Break Interrupt */
++#define SC16IS7XX_LSR_BRK_ERROR_MASK \
++	(SC16IS7XX_LSR_OE_BIT | \
++	 SC16IS7XX_LSR_PE_BIT | \
++	 SC16IS7XX_LSR_FE_BIT | \
++	 SC16IS7XX_LSR_BI_BIT)
++
++#define SC16IS7XX_LSR_THRE_BIT		BIT(5)   /* TX holding register empty */
++#define SC16IS7XX_LSR_TEMT_BIT		BIT(6)   /* Transmitter empty */
++#define SC16IS7XX_LSR_FIFOE_BIT		BIT(7)   /* Fifo Error */
+ 
+ /* MSR register bits */
+-#define SC16IS7XX_MSR_DCTS_BIT		(1 << 0) /* Delta CTS Clear To Send */
+-#define SC16IS7XX_MSR_DDSR_BIT		(1 << 1) /* Delta DSR Data Set Ready
++#define SC16IS7XX_MSR_DCTS_BIT		BIT(0)   /* Delta CTS Clear To Send */
++#define SC16IS7XX_MSR_DDSR_BIT		BIT(1)   /* Delta DSR Data Set Ready
+ 						  * or (IO4)
+ 						  * - only on 75x/76x
+ 						  */
+-#define SC16IS7XX_MSR_DRI_BIT		(1 << 2) /* Delta RI Ring Indicator
++#define SC16IS7XX_MSR_DRI_BIT		BIT(2)   /* Delta RI Ring Indicator
+ 						  * or (IO7)
+ 						  * - only on 75x/76x
+ 						  */
+-#define SC16IS7XX_MSR_DCD_BIT		(1 << 3) /* Delta CD Carrier Detect
++#define SC16IS7XX_MSR_DCD_BIT		BIT(3)   /* Delta CD Carrier Detect
+ 						  * or (IO6)
+ 						  * - only on 75x/76x
+ 						  */
+-#define SC16IS7XX_MSR_CTS_BIT		(1 << 4) /* CTS */
+-#define SC16IS7XX_MSR_DSR_BIT		(1 << 5) /* DSR (IO4)
++#define SC16IS7XX_MSR_CTS_BIT		BIT(4)   /* CTS */
++#define SC16IS7XX_MSR_DSR_BIT		BIT(5)   /* DSR (IO4)
+ 						  * - only on 75x/76x
+ 						  */
+-#define SC16IS7XX_MSR_RI_BIT		(1 << 6) /* RI (IO7)
++#define SC16IS7XX_MSR_RI_BIT		BIT(6)   /* RI (IO7)
+ 						  * - only on 75x/76x
+ 						  */
+-#define SC16IS7XX_MSR_CD_BIT		(1 << 7) /* CD (IO6)
++#define SC16IS7XX_MSR_CD_BIT		BIT(7)   /* CD (IO6)
+ 						  * - only on 75x/76x
+ 						  */
+ #define SC16IS7XX_MSR_DELTA_MASK	0x0F     /* Any of the delta bits! */
+@@ -236,19 +243,19 @@
+ #define SC16IS7XX_TLR_RX_TRIGGER(words)	((((words) / 4) & 0x0f) << 4)
+ 
+ /* IOControl register bits (Only 750/760) */
+-#define SC16IS7XX_IOCONTROL_LATCH_BIT	(1 << 0) /* Enable input latching */
+-#define SC16IS7XX_IOCONTROL_MODEM_A_BIT	(1 << 1) /* Enable GPIO[7:4] as modem A pins */
+-#define SC16IS7XX_IOCONTROL_MODEM_B_BIT	(1 << 2) /* Enable GPIO[3:0] as modem B pins */
+-#define SC16IS7XX_IOCONTROL_SRESET_BIT	(1 << 3) /* Software Reset */
++#define SC16IS7XX_IOCONTROL_LATCH_BIT	BIT(0)   /* Enable input latching */
++#define SC16IS7XX_IOCONTROL_MODEM_A_BIT	BIT(1)   /* Enable GPIO[7:4] as modem A pins */
++#define SC16IS7XX_IOCONTROL_MODEM_B_BIT	BIT(2)   /* Enable GPIO[3:0] as modem B pins */
++#define SC16IS7XX_IOCONTROL_SRESET_BIT	BIT(3)   /* Software Reset */
+ 
+ /* EFCR register bits */
+-#define SC16IS7XX_EFCR_9BIT_MODE_BIT	(1 << 0) /* Enable 9-bit or Multidrop
++#define SC16IS7XX_EFCR_9BIT_MODE_BIT	BIT(0)   /* Enable 9-bit or Multidrop
+ 						  * mode (RS485) */
+-#define SC16IS7XX_EFCR_RXDISABLE_BIT	(1 << 1) /* Disable receiver */
+-#define SC16IS7XX_EFCR_TXDISABLE_BIT	(1 << 2) /* Disable transmitter */
+-#define SC16IS7XX_EFCR_AUTO_RS485_BIT	(1 << 4) /* Auto RS485 RTS direction */
+-#define SC16IS7XX_EFCR_RTS_INVERT_BIT	(1 << 5) /* RTS output inversion */
+-#define SC16IS7XX_EFCR_IRDA_MODE_BIT	(1 << 7) /* IrDA mode
++#define SC16IS7XX_EFCR_RXDISABLE_BIT	BIT(1)   /* Disable receiver */
++#define SC16IS7XX_EFCR_TXDISABLE_BIT	BIT(2)   /* Disable transmitter */
++#define SC16IS7XX_EFCR_AUTO_RS485_BIT	BIT(4)   /* Auto RS485 RTS direction */
++#define SC16IS7XX_EFCR_RTS_INVERT_BIT	BIT(5)   /* RTS output inversion */
++#define SC16IS7XX_EFCR_IRDA_MODE_BIT	BIT(7)   /* IrDA mode
+ 						  * 0 = rate upto 115.2 kbit/s
+ 						  *   - Only 750/760
+ 						  * 1 = rate upto 1.152 Mbit/s
+@@ -256,16 +263,16 @@
+ 						  */
+ 
+ /* EFR register bits */
+-#define SC16IS7XX_EFR_AUTORTS_BIT	(1 << 6) /* Auto RTS flow ctrl enable */
+-#define SC16IS7XX_EFR_AUTOCTS_BIT	(1 << 7) /* Auto CTS flow ctrl enable */
+-#define SC16IS7XX_EFR_XOFF2_DETECT_BIT	(1 << 5) /* Enable Xoff2 detection */
+-#define SC16IS7XX_EFR_ENABLE_BIT	(1 << 4) /* Enable enhanced functions
++#define SC16IS7XX_EFR_AUTORTS_BIT	BIT(6)   /* Auto RTS flow ctrl enable */
++#define SC16IS7XX_EFR_AUTOCTS_BIT	BIT(7)   /* Auto CTS flow ctrl enable */
++#define SC16IS7XX_EFR_XOFF2_DETECT_BIT	BIT(5)   /* Enable Xoff2 detection */
++#define SC16IS7XX_EFR_ENABLE_BIT	BIT(4)   /* Enable enhanced functions
+ 						  * and writing to IER[7:4],
+ 						  * FCR[5:4], MCR[7:5]
+ 						  */
+-#define SC16IS7XX_EFR_SWFLOW3_BIT	(1 << 3) /* SWFLOW bit 3 */
+-#define SC16IS7XX_EFR_SWFLOW2_BIT	(1 << 2) /* SWFLOW bit 2
+-						  *
++#define SC16IS7XX_EFR_SWFLOW3_BIT	BIT(3)
++#define SC16IS7XX_EFR_SWFLOW2_BIT	BIT(2)
++						 /*
+ 						  * SWFLOW bits 3 & 2 table:
+ 						  * 00 -> no transmitter flow
+ 						  *       control
+@@ -277,10 +284,10 @@
+ 						  *       XON1, XON2, XOFF1 and
+ 						  *       XOFF2
+ 						  */
+-#define SC16IS7XX_EFR_SWFLOW1_BIT	(1 << 1) /* SWFLOW bit 2 */
+-#define SC16IS7XX_EFR_SWFLOW0_BIT	(1 << 0) /* SWFLOW bit 3
+-						  *
+-						  * SWFLOW bits 3 & 2 table:
++#define SC16IS7XX_EFR_SWFLOW1_BIT	BIT(1)
++#define SC16IS7XX_EFR_SWFLOW0_BIT	BIT(0)
++						 /*
++						  * SWFLOW bits 1 & 0 table:
+ 						  * 00 -> no received flow
+ 						  *       control
+ 						  * 01 -> receiver compares
+@@ -311,9 +318,9 @@ struct sc16is7xx_devtype {
+ 	int	nr_uart;
+ };
+ 
+-#define SC16IS7XX_RECONF_MD		(1 << 0)
+-#define SC16IS7XX_RECONF_IER		(1 << 1)
+-#define SC16IS7XX_RECONF_RS485		(1 << 2)
++#define SC16IS7XX_RECONF_MD		BIT(0)
++#define SC16IS7XX_RECONF_IER		BIT(1)
++#define SC16IS7XX_RECONF_RS485		BIT(2)
+ 
+ struct sc16is7xx_one_config {
+ 	unsigned int			flags;
+@@ -324,7 +331,7 @@ struct sc16is7xx_one_config {
+ struct sc16is7xx_one {
+ 	struct uart_port		port;
+ 	struct regmap			*regmap;
+-	struct mutex			efr_lock; /* EFR registers access */
++	struct mutex			lock; /* For registers sharing same address space. */
+ 	struct kthread_work		tx_work;
+ 	struct kthread_work		reg_work;
+ 	struct kthread_delayed_work	ms_work;
+@@ -431,7 +438,7 @@ static void sc16is7xx_efr_lock(struct uart_port *port)
+ {
+ 	struct sc16is7xx_one *one = to_sc16is7xx_one(port, port);
+ 
+-	mutex_lock(&one->efr_lock);
++	mutex_lock(&one->lock);
+ 
+ 	/* Backup content of LCR. */
+ 	one->old_lcr = sc16is7xx_port_read(port, SC16IS7XX_LCR_REG);
+@@ -453,7 +460,7 @@ static void sc16is7xx_efr_unlock(struct uart_port *port)
+ 	/* Restore original content of LCR */
+ 	sc16is7xx_port_write(port, SC16IS7XX_LCR_REG, one->old_lcr);
+ 
+-	mutex_unlock(&one->efr_lock);
++	mutex_unlock(&one->lock);
+ }
+ 
+ static void sc16is7xx_ier_clear(struct uart_port *port, u8 bit)
+@@ -587,7 +594,7 @@ static int sc16is7xx_set_baud(struct uart_port *port, int baud)
+ 			      SC16IS7XX_MCR_CLKSEL_BIT,
+ 			      prescaler == 1 ? 0 : SC16IS7XX_MCR_CLKSEL_BIT);
+ 
+-	mutex_lock(&one->efr_lock);
++	mutex_lock(&one->lock);
+ 
+ 	/* Backup LCR and access special register set (DLL/DLH) */
+ 	lcr = sc16is7xx_port_read(port, SC16IS7XX_LCR_REG);
+@@ -603,7 +610,7 @@ static int sc16is7xx_set_baud(struct uart_port *port, int baud)
+ 	/* Restore LCR and access to general register set */
+ 	sc16is7xx_port_write(port, SC16IS7XX_LCR_REG, lcr);
+ 
+-	mutex_unlock(&one->efr_lock);
++	mutex_unlock(&one->lock);
+ 
+ 	return DIV_ROUND_CLOSEST((clk / prescaler) / 16, div);
+ }
+@@ -759,7 +766,7 @@ static void sc16is7xx_update_mlines(struct sc16is7xx_one *one)
+ 	unsigned long flags;
+ 	unsigned int status, changed;
+ 
+-	lockdep_assert_held_once(&one->efr_lock);
++	lockdep_assert_held_once(&one->lock);
+ 
+ 	status = sc16is7xx_get_hwmctrl(port);
+ 	changed = status ^ one->old_mctrl;
+@@ -785,18 +792,15 @@ static void sc16is7xx_update_mlines(struct sc16is7xx_one *one)
+ 
+ static bool sc16is7xx_port_irq(struct sc16is7xx_port *s, int portno)
+ {
+-	bool rc = true;
+ 	unsigned int iir, rxlen;
+ 	struct uart_port *port = &s->p[portno].port;
+ 	struct sc16is7xx_one *one = to_sc16is7xx_one(port, port);
+ 
+-	mutex_lock(&one->efr_lock);
++	guard(mutex)(&one->lock);
+ 
+ 	iir = sc16is7xx_port_read(port, SC16IS7XX_IIR_REG);
+-	if (iir & SC16IS7XX_IIR_NO_INT_BIT) {
+-		rc = false;
+-		goto out_port_irq;
+-	}
++	if (iir & SC16IS7XX_IIR_NO_INT_BIT)
++		return false;
+ 
+ 	iir &= SC16IS7XX_IIR_ID_MASK;
+ 
+@@ -836,10 +840,7 @@ static bool sc16is7xx_port_irq(struct sc16is7xx_port *s, int portno)
+ 		break;
+ 	}
+ 
+-out_port_irq:
+-	mutex_unlock(&one->efr_lock);
+-
+-	return rc;
++	return true;
+ }
+ 
+ static irqreturn_t sc16is7xx_irq(int irq, void *dev_id)
+@@ -869,9 +870,11 @@ static void sc16is7xx_tx_proc(struct kthread_work *ws)
+ 	    (port->rs485.delay_rts_before_send > 0))
+ 		msleep(port->rs485.delay_rts_before_send);
+ 
+-	mutex_lock(&one->efr_lock);
++	guard(mutex)(&one->lock);
++	sc16is7xx_port_update(port, SC16IS7XX_IER_REG,
++			      SC16IS7XX_IER_THRI_BIT,
++			      SC16IS7XX_IER_THRI_BIT);
+ 	sc16is7xx_handle_tx(port);
+-	mutex_unlock(&one->efr_lock);
+ }
+ 
+ static void sc16is7xx_reconf_rs485(struct uart_port *port)
+@@ -938,9 +941,8 @@ static void sc16is7xx_ms_proc(struct kthread_work *ws)
+ 	struct sc16is7xx_port *s = dev_get_drvdata(one->port.dev);
+ 
+ 	if (one->port.state) {
+-		mutex_lock(&one->efr_lock);
+-		sc16is7xx_update_mlines(one);
+-		mutex_unlock(&one->efr_lock);
++		scoped_guard(mutex, &one->lock)
++			sc16is7xx_update_mlines(one);
+ 
+ 		kthread_queue_delayed_work(&s->kworker, &one->ms_work, HZ);
+ 	}
+@@ -1581,7 +1583,7 @@ static int sc16is7xx_probe(struct device *dev,
+ 		s->p[i].old_mctrl	= 0;
+ 		s->p[i].regmap		= regmaps[i];
+ 
+-		mutex_init(&s->p[i].efr_lock);
++		mutex_init(&s->p[i].lock);
+ 
+ 		ret = uart_get_rs485_mode(&s->p[i].port);
+ 		if (ret)
+diff --git a/fs/ext4/xattr.c b/fs/ext4/xattr.c
+index 5b5c3ce7719dc6..5d068b2905e41b 100644
+--- a/fs/ext4/xattr.c
++++ b/fs/ext4/xattr.c
+@@ -2070,12 +2070,13 @@ inserted:
+ 				 * stable so we can check the additional
+ 				 * reference fits.
+ 				 */
+-				ref = le32_to_cpu(BHDR(new_bh)->h_refcount) + 1;
+-				if (ref > EXT4_XATTR_REFCOUNT_MAX) {
++				ref = le32_to_cpu(BHDR(new_bh)->h_refcount);
++				if (ref >= EXT4_XATTR_REFCOUNT_MAX) {
+ 					/*
+ 					 * Undo everything and check mbcache
+ 					 * again.
+ 					 */
++					clear_bit(MBE_REUSABLE_B, &ce->e_flags);
+ 					unlock_buffer(new_bh);
+ 					dquot_free_block(inode,
+ 							 EXT4_C2B(EXT4_SB(sb),
+@@ -2086,6 +2087,7 @@ inserted:
+ 					new_bh = NULL;
+ 					goto inserted;
+ 				}
++				ref++;
+ 				BHDR(new_bh)->h_refcount = cpu_to_le32(ref);
+ 				if (ref == EXT4_XATTR_REFCOUNT_MAX)
+ 					clear_bit(MBE_REUSABLE_B, &ce->e_flags);
+@@ -2834,6 +2836,7 @@ retry:
+ 		    s_min_extra_isize) {
+ 			tried_min_extra_isize++;
+ 			new_extra_isize = s_min_extra_isize;
++			error = 0;
+ 			goto retry;
+ 		}
+ 		goto cleanup;
+diff --git a/fs/ocfs2/xattr.c b/fs/ocfs2/xattr.c
+index 750c1fc70d25a7..186183b90fa4c0 100644
+--- a/fs/ocfs2/xattr.c
++++ b/fs/ocfs2/xattr.c
+@@ -736,12 +736,10 @@ static int ocfs2_xattr_extend_allocation(struct inode *inode,
+ 					 prev_clusters;
+ 
+ 		if (why != RESTART_NONE && clusters_to_add) {
+-			/*
+-			 * We can only fail in case the alloc file doesn't give
+-			 * up enough clusters.
+-			 */
+-			BUG_ON(why == RESTART_META);
+-
++			if (why == RESTART_META) {
++				status = -ENOSPC;
++				break;
++			}
+ 			credits = ocfs2_calc_extend_credits(inode->i_sb,
+ 							    &vb->vb_xv->xr_list);
+ 			status = ocfs2_extend_trans(handle, credits);
+@@ -3210,6 +3208,14 @@ meta_guess:
+ 		} else
+ 			credits += OCFS2_SUBALLOC_ALLOC + 1;
+ 
++		/*
++		 * Reserve metadata for the new xattr's value extent tree.
++		 * The not_found path above adds credits for this tree but
++		 * omits meta_add, leaving meta_ac NULL for large values.
++		 */
++		if (xi->xi_value_len > OCFS2_XATTR_INLINE_SIZE)
++			meta_add += ocfs2_extend_meta_needed(&def_xv.xv.xr_list);
++
+ 		/*
+ 		 * This cluster will be used either for new bucket or for
+ 		 * new xattr block.
+diff --git a/fs/xfs/libxfs/xfs_attr_leaf.c b/fs/xfs/libxfs/xfs_attr_leaf.c
+index dcb09702cde26d..ff0b63a71f782b 100644
+--- a/fs/xfs/libxfs/xfs_attr_leaf.c
++++ b/fs/xfs/libxfs/xfs_attr_leaf.c
+@@ -267,6 +267,13 @@ xfs_attr3_leaf_verify_entry(
+ 	 */
+ 	if (ent->flags & XFS_ATTR_LOCAL) {
+ 		lentry = xfs_attr3_leaf_name_local(leaf, idx);
++
++		/* Validate lentry pointer is within bounds before field access */
++		if ((char *)lentry >= buf_end)
++			return __this_address;
++		if ((char *)lentry + offsetof(struct xfs_attr_leaf_name_local, nameval) > buf_end)
++			return __this_address;
++
+ 		namesize = xfs_attr_leaf_entsize_local(lentry->namelen,
+ 				be16_to_cpu(lentry->valuelen));
+ 		name_end = (char *)lentry + namesize;
+@@ -274,6 +281,13 @@ xfs_attr3_leaf_verify_entry(
+ 			return __this_address;
+ 	} else {
+ 		rentry = xfs_attr3_leaf_name_remote(leaf, idx);
++
++		/* Validate rentry pointer is within bounds before field access */
++		if ((char *)rentry >= buf_end)
++			return __this_address;
++		if ((char *)rentry + offsetof(struct xfs_attr_leaf_name_remote, name) > buf_end)
++			return __this_address;
++
+ 		namesize = xfs_attr_leaf_entsize_remote(rentry->namelen);
+ 		name_end = (char *)rentry + namesize;
+ 		if (rentry->namelen == 0)
+diff --git a/fs/xfs/libxfs/xfs_log_recover.h b/fs/xfs/libxfs/xfs_log_recover.h
+index c8e5d912895bcd..23268c88ce443b 100644
+--- a/fs/xfs/libxfs/xfs_log_recover.h
++++ b/fs/xfs/libxfs/xfs_log_recover.h
+@@ -95,7 +95,7 @@ struct xlog_recover_item {
+ 	struct list_head	ri_list;
+ 	int			ri_cnt;	/* count of regions found */
+ 	int			ri_total;	/* total regions */
+-	struct xfs_log_iovec	*ri_buf;	/* ptr to regions buffer */
++	struct kvec		*ri_buf;	/* ptr to regions buffer */
+ 	const struct xlog_recover_item_ops *ri_ops;
+ };
+ 
+@@ -108,7 +108,7 @@ struct xlog_recover {
+ 	struct list_head	r_itemq;	/* q for items */
+ };
+ 
+-#define ITEM_TYPE(i)	(*(unsigned short *)(i)->ri_buf[0].i_addr)
++#define ITEM_TYPE(i)	(*(unsigned short *)(i)->ri_buf[0].iov_base)
+ 
+ #define	XLOG_RECOVER_CRCPASS	0
+ #define	XLOG_RECOVER_PASS1	1
+diff --git a/fs/xfs/xfs_attr_item.c b/fs/xfs/xfs_attr_item.c
+index 440e50c3f5fcaa..19c954c477d1e2 100644
+--- a/fs/xfs/xfs_attr_item.c
++++ b/fs/xfs/xfs_attr_item.c
+@@ -729,13 +729,13 @@ xlog_recover_attri_commit_pass2(
+ 
+ 	/* Validate xfs_attri_log_format before the large memory allocation */
+ 	len = sizeof(struct xfs_attri_log_format);
+-	if (item->ri_buf[i].i_len != len) {
++	if (item->ri_buf[i].iov_len != len) {
+ 		XFS_CORRUPTION_ERROR(__func__, XFS_ERRLEVEL_LOW, mp,
+-				item->ri_buf[0].i_addr, item->ri_buf[0].i_len);
++				item->ri_buf[0].iov_base, item->ri_buf[0].iov_len);
+ 		return -EFSCORRUPTED;
+ 	}
+ 
+-	attri_formatp = item->ri_buf[i].i_addr;
++	attri_formatp = item->ri_buf[i].iov_base;
+ 	if (!xfs_attri_validate(mp, attri_formatp)) {
+ 		XFS_CORRUPTION_ERROR(__func__, XFS_ERRLEVEL_LOW, mp,
+ 				attri_formatp, len);
+@@ -770,14 +770,14 @@ xlog_recover_attri_commit_pass2(
+ 	i++;
+ 
+ 	/* Validate the attr name */
+-	if (item->ri_buf[i].i_len !=
++	if (item->ri_buf[i].iov_len !=
+ 			xlog_calc_iovec_len(attri_formatp->alfi_name_len)) {
+ 		XFS_CORRUPTION_ERROR(__func__, XFS_ERRLEVEL_LOW, mp,
+ 				attri_formatp, len);
+ 		return -EFSCORRUPTED;
+ 	}
+ 
+-	attr_name = item->ri_buf[i].i_addr;
++	attr_name = item->ri_buf[i].iov_base;
+ 	if (!xfs_attr_namecheck(attri_formatp->alfi_attr_filter, attr_name,
+ 				attri_formatp->alfi_name_len)) {
+ 		XFS_CORRUPTION_ERROR(__func__, XFS_ERRLEVEL_LOW, mp,
+@@ -788,14 +788,14 @@ xlog_recover_attri_commit_pass2(
+ 
+ 	/* Validate the attr value, if present */
+ 	if (attri_formatp->alfi_value_len != 0) {
+-		if (item->ri_buf[i].i_len != xlog_calc_iovec_len(attri_formatp->alfi_value_len)) {
++		if (item->ri_buf[i].iov_len != xlog_calc_iovec_len(attri_formatp->alfi_value_len)) {
+ 			XFS_CORRUPTION_ERROR(__func__, XFS_ERRLEVEL_LOW, mp,
+-					item->ri_buf[0].i_addr,
+-					item->ri_buf[0].i_len);
++					item->ri_buf[0].iov_base,
++					item->ri_buf[0].iov_len);
+ 			return -EFSCORRUPTED;
+ 		}
+ 
+-		attr_value = item->ri_buf[i].i_addr;
++		attr_value = item->ri_buf[i].iov_base;
+ 		i++;
+ 	}
+ 
+@@ -912,10 +912,10 @@ xlog_recover_attrd_commit_pass2(
+ {
+ 	struct xfs_attrd_log_format	*attrd_formatp;
+ 
+-	attrd_formatp = item->ri_buf[0].i_addr;
+-	if (item->ri_buf[0].i_len != sizeof(struct xfs_attrd_log_format)) {
++	attrd_formatp = item->ri_buf[0].iov_base;
++	if (item->ri_buf[0].iov_len != sizeof(struct xfs_attrd_log_format)) {
+ 		XFS_CORRUPTION_ERROR(__func__, XFS_ERRLEVEL_LOW, log->l_mp,
+-				item->ri_buf[0].i_addr, item->ri_buf[0].i_len);
++				item->ri_buf[0].iov_base, item->ri_buf[0].iov_len);
+ 		return -EFSCORRUPTED;
+ 	}
+ 
+diff --git a/fs/xfs/xfs_bmap_item.c b/fs/xfs/xfs_bmap_item.c
+index 59b438ac37a254..7b7fff959d96bd 100644
+--- a/fs/xfs/xfs_bmap_item.c
++++ b/fs/xfs/xfs_bmap_item.c
+@@ -669,24 +669,24 @@ xlog_recover_bui_commit_pass2(
+ 	struct xfs_bui_log_format	*bui_formatp;
+ 	size_t				len;
+ 
+-	bui_formatp = item->ri_buf[0].i_addr;
++	bui_formatp = item->ri_buf[0].iov_base;
+ 
+-	if (item->ri_buf[0].i_len < xfs_bui_log_format_sizeof(0)) {
++	if (item->ri_buf[0].iov_len < xfs_bui_log_format_sizeof(0)) {
+ 		XFS_CORRUPTION_ERROR(__func__, XFS_ERRLEVEL_LOW, mp,
+-				item->ri_buf[0].i_addr, item->ri_buf[0].i_len);
++				item->ri_buf[0].iov_base, item->ri_buf[0].iov_len);
+ 		return -EFSCORRUPTED;
+ 	}
+ 
+ 	if (bui_formatp->bui_nextents != XFS_BUI_MAX_FAST_EXTENTS) {
+ 		XFS_CORRUPTION_ERROR(__func__, XFS_ERRLEVEL_LOW, mp,
+-				item->ri_buf[0].i_addr, item->ri_buf[0].i_len);
++				item->ri_buf[0].iov_base, item->ri_buf[0].iov_len);
+ 		return -EFSCORRUPTED;
+ 	}
+ 
+ 	len = xfs_bui_log_format_sizeof(bui_formatp->bui_nextents);
+-	if (item->ri_buf[0].i_len != len) {
++	if (item->ri_buf[0].iov_len != len) {
+ 		XFS_CORRUPTION_ERROR(__func__, XFS_ERRLEVEL_LOW, mp,
+-				item->ri_buf[0].i_addr, item->ri_buf[0].i_len);
++				item->ri_buf[0].iov_base, item->ri_buf[0].iov_len);
+ 		return -EFSCORRUPTED;
+ 	}
+ 
+@@ -720,10 +720,10 @@ xlog_recover_bud_commit_pass2(
+ {
+ 	struct xfs_bud_log_format	*bud_formatp;
+ 
+-	bud_formatp = item->ri_buf[0].i_addr;
+-	if (item->ri_buf[0].i_len != sizeof(struct xfs_bud_log_format)) {
++	bud_formatp = item->ri_buf[0].iov_base;
++	if (item->ri_buf[0].iov_len != sizeof(struct xfs_bud_log_format)) {
+ 		XFS_CORRUPTION_ERROR(__func__, XFS_ERRLEVEL_LOW, log->l_mp,
+-				item->ri_buf[0].i_addr, item->ri_buf[0].i_len);
++				item->ri_buf[0].iov_base, item->ri_buf[0].iov_len);
+ 		return -EFSCORRUPTED;
+ 	}
+ 
+diff --git a/fs/xfs/xfs_buf_item.c b/fs/xfs/xfs_buf_item.c
+index 12134c79301a51..72d6e2dd5ef54b 100644
+--- a/fs/xfs/xfs_buf_item.c
++++ b/fs/xfs/xfs_buf_item.c
+@@ -35,16 +35,16 @@ static inline struct xfs_buf_log_item *BUF_ITEM(struct xfs_log_item *lip)
+ /* Is this log iovec plausibly large enough to contain the buffer log format? */
+ bool
+ xfs_buf_log_check_iovec(
+-	struct xfs_log_iovec		*iovec)
++	struct kvec			*iovec)
+ {
+-	struct xfs_buf_log_format	*blfp = iovec->i_addr;
++	struct xfs_buf_log_format	*blfp = iovec->iov_base;
+ 	char				*bmp_end;
+ 	char				*item_end;
+ 
+-	if (offsetof(struct xfs_buf_log_format, blf_data_map) > iovec->i_len)
++	if (offsetof(struct xfs_buf_log_format, blf_data_map) > iovec->iov_len)
+ 		return false;
+ 
+-	item_end = (char *)iovec->i_addr + iovec->i_len;
++	item_end = (char *)iovec->iov_base + iovec->iov_len;
+ 	bmp_end = (char *)&blfp->blf_data_map[blfp->blf_map_size];
+ 	return bmp_end <= item_end;
+ }
+diff --git a/fs/xfs/xfs_buf_item.h b/fs/xfs/xfs_buf_item.h
+index 4d8a6aece995d9..7ddda0aa9dac26 100644
+--- a/fs/xfs/xfs_buf_item.h
++++ b/fs/xfs/xfs_buf_item.h
+@@ -67,7 +67,7 @@ static inline void xfs_buf_dquot_io_fail(struct xfs_buf *bp)
+ }
+ #endif /* CONFIG_XFS_QUOTA */
+ void	xfs_buf_iodone(struct xfs_buf *);
+-bool	xfs_buf_log_check_iovec(struct xfs_log_iovec *iovec);
++bool	xfs_buf_log_check_iovec(struct kvec *iovec);
+ 
+ extern struct kmem_cache	*xfs_buf_item_cache;
+ 
+diff --git a/fs/xfs/xfs_buf_item_recover.c b/fs/xfs/xfs_buf_item_recover.c
+index c12dee0cb7fc96..4432726dfe8fb7 100644
+--- a/fs/xfs/xfs_buf_item_recover.c
++++ b/fs/xfs/xfs_buf_item_recover.c
+@@ -157,7 +157,7 @@ STATIC enum xlog_recover_reorder
+ xlog_recover_buf_reorder(
+ 	struct xlog_recover_item	*item)
+ {
+-	struct xfs_buf_log_format	*buf_f = item->ri_buf[0].i_addr;
++	struct xfs_buf_log_format	*buf_f = item->ri_buf[0].iov_base;
+ 
+ 	if (buf_f->blf_flags & XFS_BLF_CANCEL)
+ 		return XLOG_REORDER_CANCEL_LIST;
+@@ -171,7 +171,7 @@ xlog_recover_buf_ra_pass2(
+ 	struct xlog                     *log,
+ 	struct xlog_recover_item        *item)
+ {
+-	struct xfs_buf_log_format	*buf_f = item->ri_buf[0].i_addr;
++	struct xfs_buf_log_format	*buf_f = item->ri_buf[0].iov_base;
+ 
+ 	xlog_buf_readahead(log, buf_f->blf_blkno, buf_f->blf_len, NULL);
+ }
+@@ -185,11 +185,11 @@ xlog_recover_buf_commit_pass1(
+ 	struct xlog			*log,
+ 	struct xlog_recover_item	*item)
+ {
+-	struct xfs_buf_log_format	*bf = item->ri_buf[0].i_addr;
++	struct xfs_buf_log_format	*bf = item->ri_buf[0].iov_base;
+ 
+ 	if (!xfs_buf_log_check_iovec(&item->ri_buf[0])) {
+-		xfs_err(log->l_mp, "bad buffer log item size (%d)",
+-				item->ri_buf[0].i_len);
++		xfs_err(log->l_mp, "bad buffer log item size (%zd)",
++				item->ri_buf[0].iov_len);
+ 		return -EFSCORRUPTED;
+ 	}
+ 
+@@ -444,7 +444,7 @@ xlog_recover_validate_buf_type(
+  * given buffer.  The bitmap in the buf log format structure indicates
+  * where to place the logged data.
+  */
+-STATIC void
++STATIC int
+ xlog_recover_do_reg_buffer(
+ 	struct xfs_mount		*mp,
+ 	struct xlog_recover_item	*item,
+@@ -470,10 +470,26 @@ xlog_recover_do_reg_buffer(
+ 		nbits = xfs_contig_bits(buf_f->blf_data_map,
+ 					buf_f->blf_map_size, bit);
+ 		ASSERT(nbits > 0);
+-		ASSERT(item->ri_buf[i].i_addr != NULL);
+-		ASSERT(item->ri_buf[i].i_len % XFS_BLF_CHUNK == 0);
+-		ASSERT(BBTOB(bp->b_length) >=
+-		       ((uint)bit << XFS_BLF_SHIFT) + (nbits << XFS_BLF_SHIFT));
++		ASSERT(item->ri_buf[i].iov_base != NULL);
++		ASSERT(item->ri_buf[i].iov_len % XFS_BLF_CHUNK == 0);
++		/*
++		 * The bitmap is only trustworthy to the extent that it
++		 * describes a region that actually fits inside the buffer we
++		 * read in based on the (attacker-controlled) blf_len.  Do not
++		 * rely on an ASSERT() for this -- it compiles away entirely on
++		 * non-DEBUG kernels, which is exactly where this matters, so
++		 * validate it for real and abort recovery of this buffer rather
++		 * than copying past the end of it.
++		 */
++		if (XFS_IS_CORRUPT(mp, BBTOB(bp->b_length) <
++				((uint)bit << XFS_BLF_SHIFT) +
++				(nbits << XFS_BLF_SHIFT))) {
++			xfs_alert(mp,
++	"Bad buffer log item dirty bitmap (bit %d, nbits %d) for %d-byte buffer at daddr 0x%llx.",
++				bit, nbits, BBTOB(bp->b_length),
++				xfs_buf_daddr(bp));
++			return -EFSCORRUPTED;
++		}
+ 
+ 		/*
+ 		 * The dirty regions logged in the buffer, even though
+@@ -483,8 +499,8 @@ xlog_recover_do_reg_buffer(
+ 		 * the log. Hence we need to trim nbits back to the length of
+ 		 * the current region being copied out of the log.
+ 		 */
+-		if (item->ri_buf[i].i_len < (nbits << XFS_BLF_SHIFT))
+-			nbits = item->ri_buf[i].i_len >> XFS_BLF_SHIFT;
++		if (item->ri_buf[i].iov_len < (nbits << XFS_BLF_SHIFT))
++			nbits = item->ri_buf[i].iov_len >> XFS_BLF_SHIFT;
+ 
+ 		/*
+ 		 * Do a sanity check if this is a dquot buffer. Just checking
+@@ -494,18 +510,18 @@ xlog_recover_do_reg_buffer(
+ 		fa = NULL;
+ 		if (buf_f->blf_flags &
+ 		   (XFS_BLF_UDQUOT_BUF|XFS_BLF_PDQUOT_BUF|XFS_BLF_GDQUOT_BUF)) {
+-			if (item->ri_buf[i].i_addr == NULL) {
++			if (item->ri_buf[i].iov_base == NULL) {
+ 				xfs_alert(mp,
+ 					"XFS: NULL dquot in %s.", __func__);
+ 				goto next;
+ 			}
+-			if (item->ri_buf[i].i_len < size_disk_dquot) {
++			if (item->ri_buf[i].iov_len < size_disk_dquot) {
+ 				xfs_alert(mp,
+-					"XFS: dquot too small (%d) in %s.",
+-					item->ri_buf[i].i_len, __func__);
++					"XFS: dquot too small (%zd) in %s.",
++					item->ri_buf[i].iov_len, __func__);
+ 				goto next;
+ 			}
+-			fa = xfs_dquot_verify(mp, item->ri_buf[i].i_addr, -1);
++			fa = xfs_dquot_verify(mp, item->ri_buf[i].iov_base, -1);
+ 			if (fa) {
+ 				xfs_alert(mp,
+ 	"dquot corrupt at %pS trying to replay into block 0x%llx",
+@@ -516,7 +532,7 @@ xlog_recover_do_reg_buffer(
+ 
+ 		memcpy(xfs_buf_offset(bp,
+ 			(uint)bit << XFS_BLF_SHIFT),	/* dest */
+-			item->ri_buf[i].i_addr,		/* source */
++			item->ri_buf[i].iov_base,		/* source */
+ 			nbits<<XFS_BLF_SHIFT);		/* length */
+  next:
+ 		i++;
+@@ -527,6 +543,7 @@ xlog_recover_do_reg_buffer(
+ 	ASSERT(i == item->ri_total);
+ 
+ 	xlog_recover_validate_buf_type(mp, bp, buf_f, current_lsn);
++	return 0;
+ }
+ 
+ /*
+@@ -535,10 +552,10 @@ xlog_recover_do_reg_buffer(
+  * (ie. USR or GRP), then just toss this buffer away; don't recover it.
+  * Else, treat it as a regular buffer and do recovery.
+  *
+- * Return false if the buffer was tossed and true if we recovered the buffer to
+- * indicate to the caller if the buffer needs writing.
++ * Return 0 if the buffer was not recovered (tossed), 1 if it was recovered and
++ * needs writing, or a negative errno if recovery of the buffer failed.
+  */
+-STATIC bool
++STATIC int
+ xlog_recover_do_dquot_buffer(
+ 	struct xfs_mount		*mp,
+ 	struct xlog			*log,
+@@ -547,6 +564,7 @@ xlog_recover_do_dquot_buffer(
+ 	struct xfs_buf_log_format	*buf_f)
+ {
+ 	uint			type;
++	int			error;
+ 
+ 	trace_xfs_log_recover_buf_dquot_buf(log, buf_f);
+ 
+@@ -554,7 +572,7 @@ xlog_recover_do_dquot_buffer(
+ 	 * Filesystems are required to send in quota flags at mount time.
+ 	 */
+ 	if (!mp->m_qflags)
+-		return false;
++		return 0;
+ 
+ 	type = 0;
+ 	if (buf_f->blf_flags & XFS_BLF_UDQUOT_BUF)
+@@ -567,10 +585,12 @@ xlog_recover_do_dquot_buffer(
+ 	 * This type of quotas was turned off, so ignore this buffer
+ 	 */
+ 	if (log->l_quotaoffs_flag & type)
+-		return false;
++		return 0;
+ 
+-	xlog_recover_do_reg_buffer(mp, item, bp, buf_f, NULLCOMMITLSN);
+-	return true;
++	error = xlog_recover_do_reg_buffer(mp, item, bp, buf_f, NULLCOMMITLSN);
++	if (error)
++		return error;
++	return 1;
+ }
+ 
+ /*
+@@ -652,8 +672,8 @@ xlog_recover_do_inode_buffer(
+ 		if (next_unlinked_offset < reg_buf_offset)
+ 			continue;
+ 
+-		ASSERT(item->ri_buf[item_index].i_addr != NULL);
+-		ASSERT((item->ri_buf[item_index].i_len % XFS_BLF_CHUNK) == 0);
++		ASSERT(item->ri_buf[item_index].iov_base != NULL);
++		ASSERT((item->ri_buf[item_index].iov_len % XFS_BLF_CHUNK) == 0);
+ 		ASSERT((reg_buf_offset + reg_buf_bytes) <= BBTOB(bp->b_length));
+ 
+ 		/*
+@@ -661,7 +681,7 @@ xlog_recover_do_inode_buffer(
+ 		 * current di_next_unlinked field.  Extract its value
+ 		 * and copy it to the buffer copy.
+ 		 */
+-		logged_nextp = item->ri_buf[item_index].i_addr +
++		logged_nextp = item->ri_buf[item_index].iov_base +
+ 				next_unlinked_offset - reg_buf_offset;
+ 		if (XFS_IS_CORRUPT(mp, *logged_nextp == 0)) {
+ 			xfs_alert(mp,
+@@ -706,7 +726,9 @@ xlog_recover_do_primary_sb_buffer(
+ 	xfs_agnumber_t			orig_agcount = mp->m_sb.sb_agcount;
+ 	int				error;
+ 
+-	xlog_recover_do_reg_buffer(mp, item, bp, buf_f, current_lsn);
++	error = xlog_recover_do_reg_buffer(mp, item, bp, buf_f, current_lsn);
++	if (error)
++		return error;
+ 
+ 	if (orig_agcount == 0) {
+ 		xfs_alert(mp, "Trying to grow file system without AGs");
+@@ -951,7 +973,7 @@ xlog_recover_buf_commit_pass2(
+ 	struct xlog_recover_item	*item,
+ 	xfs_lsn_t			current_lsn)
+ {
+-	struct xfs_buf_log_format	*buf_f = item->ri_buf[0].i_addr;
++	struct xfs_buf_log_format	*buf_f = item->ri_buf[0].iov_base;
+ 	struct xfs_mount		*mp = log->l_mp;
+ 	struct xfs_buf			*bp;
+ 	int				error;
+@@ -1026,11 +1048,11 @@ xlog_recover_buf_commit_pass2(
+ 			goto out_release;
+ 	} else if (buf_f->blf_flags &
+ 		  (XFS_BLF_UDQUOT_BUF|XFS_BLF_PDQUOT_BUF|XFS_BLF_GDQUOT_BUF)) {
+-		bool	dirty;
+-
+-		dirty = xlog_recover_do_dquot_buffer(mp, log, item, bp, buf_f);
+-		if (!dirty)
++		error = xlog_recover_do_dquot_buffer(mp, log, item, bp, buf_f);
++		if (error <= 0)
+ 			goto out_release;
++		/* write dirty buffer */
++		error = 0;
+ 	} else if ((xfs_blft_from_flags(buf_f) & XFS_BLFT_SB_BUF) &&
+ 			xfs_buf_daddr(bp) == 0) {
+ 		error = xlog_recover_do_primary_sb_buffer(mp, item, bp, buf_f,
+@@ -1038,7 +1060,10 @@ xlog_recover_buf_commit_pass2(
+ 		if (error)
+ 			goto out_release;
+ 	} else {
+-		xlog_recover_do_reg_buffer(mp, item, bp, buf_f, current_lsn);
++		error = xlog_recover_do_reg_buffer(mp, item, bp, buf_f,
++						   current_lsn);
++		if (error)
++			goto out_release;
+ 	}
+ 
+ 	/*
+diff --git a/fs/xfs/xfs_dquot_item_recover.c b/fs/xfs/xfs_dquot_item_recover.c
+index adda4e0dc41c44..590412c8e61506 100644
+--- a/fs/xfs/xfs_dquot_item_recover.c
++++ b/fs/xfs/xfs_dquot_item_recover.c
+@@ -34,10 +34,10 @@ xlog_recover_dquot_ra_pass2(
+ 	if (mp->m_qflags == 0)
+ 		return;
+ 
+-	recddq = item->ri_buf[1].i_addr;
++	recddq = item->ri_buf[1].iov_base;
+ 	if (recddq == NULL)
+ 		return;
+-	if (item->ri_buf[1].i_len < sizeof(struct xfs_disk_dquot))
++	if (item->ri_buf[1].iov_len < sizeof(struct xfs_disk_dquot))
+ 		return;
+ 
+ 	type = recddq->d_type & XFS_DQTYPE_REC_MASK;
+@@ -45,7 +45,7 @@ xlog_recover_dquot_ra_pass2(
+ 	if (log->l_quotaoffs_flag & type)
+ 		return;
+ 
+-	dq_f = item->ri_buf[0].i_addr;
++	dq_f = item->ri_buf[0].iov_base;
+ 	ASSERT(dq_f);
+ 	ASSERT(dq_f->qlf_len == 1);
+ 
+@@ -79,14 +79,14 @@ xlog_recover_dquot_commit_pass2(
+ 	if (mp->m_qflags == 0)
+ 		return 0;
+ 
+-	recddq = item->ri_buf[1].i_addr;
++	recddq = item->ri_buf[1].iov_base;
+ 	if (recddq == NULL) {
+ 		xfs_alert(log->l_mp, "NULL dquot in %s.", __func__);
+ 		return -EFSCORRUPTED;
+ 	}
+-	if (item->ri_buf[1].i_len < sizeof(struct xfs_disk_dquot)) {
+-		xfs_alert(log->l_mp, "dquot too small (%d) in %s.",
+-			item->ri_buf[1].i_len, __func__);
++	if (item->ri_buf[1].iov_len < sizeof(struct xfs_disk_dquot)) {
++		xfs_alert(log->l_mp, "dquot too small (%zd) in %s.",
++			item->ri_buf[1].iov_len, __func__);
+ 		return -EFSCORRUPTED;
+ 	}
+ 
+@@ -108,7 +108,7 @@ xlog_recover_dquot_commit_pass2(
+ 	 * The other possibility, of course, is that the quota subsystem was
+ 	 * removed since the last mount - ENOSYS.
+ 	 */
+-	dq_f = item->ri_buf[0].i_addr;
++	dq_f = item->ri_buf[0].iov_base;
+ 	ASSERT(dq_f);
+ 	fa = xfs_dquot_verify(mp, recddq, dq_f->qlf_id);
+ 	if (fa) {
+@@ -147,7 +147,7 @@ xlog_recover_dquot_commit_pass2(
+ 		}
+ 	}
+ 
+-	memcpy(ddq, recddq, item->ri_buf[1].i_len);
++	memcpy(ddq, recddq, item->ri_buf[1].iov_len);
+ 	if (xfs_has_crc(mp)) {
+ 		xfs_update_cksum((char *)dqb, sizeof(struct xfs_dqblk),
+ 				 XFS_DQUOT_CRC_OFF);
+@@ -192,7 +192,7 @@ xlog_recover_quotaoff_commit_pass1(
+ 	struct xlog			*log,
+ 	struct xlog_recover_item	*item)
+ {
+-	struct xfs_qoff_logformat	*qoff_f = item->ri_buf[0].i_addr;
++	struct xfs_qoff_logformat	*qoff_f = item->ri_buf[0].iov_base;
+ 	ASSERT(qoff_f);
+ 
+ 	/*
+diff --git a/fs/xfs/xfs_extfree_item.c b/fs/xfs/xfs_extfree_item.c
+index 49e96ffd64e0c1..10208eedabf431 100644
+--- a/fs/xfs/xfs_extfree_item.c
++++ b/fs/xfs/xfs_extfree_item.c
+@@ -171,15 +171,18 @@ xfs_efi_init(
+  * It will handle the conversion of formats if necessary.
+  */
+ STATIC int
+-xfs_efi_copy_format(xfs_log_iovec_t *buf, xfs_efi_log_format_t *dst_efi_fmt)
++xfs_efi_copy_format(
++	struct kvec			*buf,
++	struct xfs_efi_log_format	*dst_efi_fmt)
+ {
+-	xfs_efi_log_format_t *src_efi_fmt = buf->i_addr;
+-	uint i;
+-	uint len = xfs_efi_log_format_sizeof(src_efi_fmt->efi_nextents);
+-	uint len32 = xfs_efi_log_format32_sizeof(src_efi_fmt->efi_nextents);
+-	uint len64 = xfs_efi_log_format64_sizeof(src_efi_fmt->efi_nextents);
++	struct xfs_efi_log_format	*src_efi_fmt = buf->iov_base;
++	uint				len, len32, len64, i;
+ 
+-	if (buf->i_len == len) {
++	len = xfs_efi_log_format_sizeof(src_efi_fmt->efi_nextents);
++	len32 = xfs_efi_log_format32_sizeof(src_efi_fmt->efi_nextents);
++	len64 = xfs_efi_log_format64_sizeof(src_efi_fmt->efi_nextents);
++
++	if (buf->iov_len == len) {
+ 		memcpy(dst_efi_fmt, src_efi_fmt,
+ 		       offsetof(struct xfs_efi_log_format, efi_extents));
+ 		for (i = 0; i < src_efi_fmt->efi_nextents; i++)
+@@ -187,8 +190,8 @@ xfs_efi_copy_format(xfs_log_iovec_t *buf, xfs_efi_log_format_t *dst_efi_fmt)
+ 			       &src_efi_fmt->efi_extents[i],
+ 			       sizeof(struct xfs_extent));
+ 		return 0;
+-	} else if (buf->i_len == len32) {
+-		xfs_efi_log_format_32_t *src_efi_fmt_32 = buf->i_addr;
++	} else if (buf->iov_len == len32) {
++		xfs_efi_log_format_32_t *src_efi_fmt_32 = buf->iov_base;
+ 
+ 		dst_efi_fmt->efi_type     = src_efi_fmt_32->efi_type;
+ 		dst_efi_fmt->efi_size     = src_efi_fmt_32->efi_size;
+@@ -201,8 +204,8 @@ xfs_efi_copy_format(xfs_log_iovec_t *buf, xfs_efi_log_format_t *dst_efi_fmt)
+ 				src_efi_fmt_32->efi_extents[i].ext_len;
+ 		}
+ 		return 0;
+-	} else if (buf->i_len == len64) {
+-		xfs_efi_log_format_64_t *src_efi_fmt_64 = buf->i_addr;
++	} else if (buf->iov_len == len64) {
++		xfs_efi_log_format_64_t *src_efi_fmt_64 = buf->iov_base;
+ 
+ 		dst_efi_fmt->efi_type     = src_efi_fmt_64->efi_type;
+ 		dst_efi_fmt->efi_size     = src_efi_fmt_64->efi_size;
+@@ -216,8 +219,8 @@ xfs_efi_copy_format(xfs_log_iovec_t *buf, xfs_efi_log_format_t *dst_efi_fmt)
+ 		}
+ 		return 0;
+ 	}
+-	XFS_CORRUPTION_ERROR(__func__, XFS_ERRLEVEL_LOW, NULL, buf->i_addr,
+-			buf->i_len);
++	XFS_CORRUPTION_ERROR(__func__, XFS_ERRLEVEL_LOW, NULL, buf->iov_base,
++			buf->iov_len);
+ 	return -EFSCORRUPTED;
+ }
+ 
+@@ -791,11 +794,11 @@ xlog_recover_efi_commit_pass2(
+ 	struct xfs_efi_log_format	*efi_formatp;
+ 	int				error;
+ 
+-	efi_formatp = item->ri_buf[0].i_addr;
++	efi_formatp = item->ri_buf[0].iov_base;
+ 
+-	if (item->ri_buf[0].i_len < xfs_efi_log_format_sizeof(0)) {
++	if (item->ri_buf[0].iov_len < xfs_efi_log_format_sizeof(0)) {
+ 		XFS_CORRUPTION_ERROR(__func__, XFS_ERRLEVEL_LOW, mp,
+-				item->ri_buf[0].i_addr, item->ri_buf[0].i_len);
++				item->ri_buf[0].iov_base, item->ri_buf[0].iov_len);
+ 		return -EFSCORRUPTED;
+ 	}
+ 
+@@ -832,9 +835,9 @@ xlog_recover_efd_commit_pass2(
+ 	xfs_lsn_t			lsn)
+ {
+ 	struct xfs_efd_log_format	*efd_formatp;
+-	int				buflen = item->ri_buf[0].i_len;
++	int				buflen = item->ri_buf[0].iov_len;
+ 
+-	efd_formatp = item->ri_buf[0].i_addr;
++	efd_formatp = item->ri_buf[0].iov_base;
+ 
+ 	if (buflen < sizeof(struct xfs_efd_log_format)) {
+ 		XFS_CORRUPTION_ERROR(__func__, XFS_ERRLEVEL_LOW, log->l_mp,
+@@ -842,9 +845,9 @@ xlog_recover_efd_commit_pass2(
+ 		return -EFSCORRUPTED;
+ 	}
+ 
+-	if (item->ri_buf[0].i_len != xfs_efd_log_format32_sizeof(
++	if (item->ri_buf[0].iov_len != xfs_efd_log_format32_sizeof(
+ 						efd_formatp->efd_nextents) &&
+-	    item->ri_buf[0].i_len != xfs_efd_log_format64_sizeof(
++	    item->ri_buf[0].iov_len != xfs_efd_log_format64_sizeof(
+ 						efd_formatp->efd_nextents)) {
+ 		XFS_CORRUPTION_ERROR(__func__, XFS_ERRLEVEL_LOW, log->l_mp,
+ 				efd_formatp, buflen);
+diff --git a/fs/xfs/xfs_icreate_item.c b/fs/xfs/xfs_icreate_item.c
+index b05314d48176f7..a01091444b6f37 100644
+--- a/fs/xfs/xfs_icreate_item.c
++++ b/fs/xfs/xfs_icreate_item.c
+@@ -158,7 +158,7 @@ xlog_recover_icreate_commit_pass2(
+ 	int				nbufs;
+ 	int				i;
+ 
+-	icl = (struct xfs_icreate_log *)item->ri_buf[0].i_addr;
++	icl = (struct xfs_icreate_log *)item->ri_buf[0].iov_base;
+ 	if (icl->icl_type != XFS_LI_ICREATE) {
+ 		xfs_warn(log->l_mp, "xlog_recover_do_icreate_trans: bad type");
+ 		return -EINVAL;
+diff --git a/fs/xfs/xfs_inode_item.c b/fs/xfs/xfs_inode_item.c
+index 77cd2f168a2b42..45e37e1899b32f 100644
+--- a/fs/xfs/xfs_inode_item.c
++++ b/fs/xfs/xfs_inode_item.c
+@@ -1177,12 +1177,12 @@ xfs_iflush_shutdown_abort(
+  */
+ int
+ xfs_inode_item_format_convert(
+-	struct xfs_log_iovec		*buf,
++	struct kvec			*buf,
+ 	struct xfs_inode_log_format	*in_f)
+ {
+-	struct xfs_inode_log_format_32	*in_f32 = buf->i_addr;
++	struct xfs_inode_log_format_32	*in_f32 = buf->iov_base;
+ 
+-	if (buf->i_len != sizeof(*in_f32)) {
++	if (buf->iov_len != sizeof(*in_f32)) {
+ 		XFS_ERROR_REPORT(__func__, XFS_ERRLEVEL_LOW, NULL);
+ 		return -EFSCORRUPTED;
+ 	}
+diff --git a/fs/xfs/xfs_inode_item.h b/fs/xfs/xfs_inode_item.h
+index 377e060078044e..ba92ce11a01111 100644
+--- a/fs/xfs/xfs_inode_item.h
++++ b/fs/xfs/xfs_inode_item.h
+@@ -46,8 +46,8 @@ extern void xfs_inode_item_init(struct xfs_inode *, struct xfs_mount *);
+ extern void xfs_inode_item_destroy(struct xfs_inode *);
+ extern void xfs_iflush_abort(struct xfs_inode *);
+ extern void xfs_iflush_shutdown_abort(struct xfs_inode *);
+-extern int xfs_inode_item_format_convert(xfs_log_iovec_t *,
+-					 struct xfs_inode_log_format *);
++int xfs_inode_item_format_convert(struct kvec *buf,
++		struct xfs_inode_log_format *in_f);
+ 
+ extern struct kmem_cache	*xfs_ili_cache;
+ 
+diff --git a/fs/xfs/xfs_inode_item_recover.c b/fs/xfs/xfs_inode_item_recover.c
+index 144198a6b2702c..a4a2275d791621 100644
+--- a/fs/xfs/xfs_inode_item_recover.c
++++ b/fs/xfs/xfs_inode_item_recover.c
+@@ -28,13 +28,13 @@ xlog_recover_inode_ra_pass2(
+ 	struct xlog                     *log,
+ 	struct xlog_recover_item        *item)
+ {
+-	if (item->ri_buf[0].i_len == sizeof(struct xfs_inode_log_format)) {
+-		struct xfs_inode_log_format	*ilfp = item->ri_buf[0].i_addr;
++	if (item->ri_buf[0].iov_len == sizeof(struct xfs_inode_log_format)) {
++		struct xfs_inode_log_format	*ilfp = item->ri_buf[0].iov_base;
+ 
+ 		xlog_buf_readahead(log, ilfp->ilf_blkno, ilfp->ilf_len,
+ 				   &xfs_inode_buf_ra_ops);
+ 	} else {
+-		struct xfs_inode_log_format_32	*ilfp = item->ri_buf[0].i_addr;
++		struct xfs_inode_log_format_32	*ilfp = item->ri_buf[0].iov_base;
+ 
+ 		xlog_buf_readahead(log, ilfp->ilf_blkno, ilfp->ilf_len,
+ 				   &xfs_inode_buf_ra_ops);
+@@ -288,8 +288,8 @@ xlog_recover_inode_commit_pass2(
+ 	int				need_free = 0;
+ 	xfs_failaddr_t			fa;
+ 
+-	if (item->ri_buf[0].i_len == sizeof(struct xfs_inode_log_format)) {
+-		in_f = item->ri_buf[0].i_addr;
++	if (item->ri_buf[0].iov_len == sizeof(struct xfs_inode_log_format)) {
++		in_f = item->ri_buf[0].iov_base;
+ 	} else {
+ 		in_f = kmem_alloc(sizeof(struct xfs_inode_log_format), 0);
+ 		need_free = 1;
+@@ -327,7 +327,7 @@ xlog_recover_inode_commit_pass2(
+ 		error = -EFSCORRUPTED;
+ 		goto out_release;
+ 	}
+-	ldip = item->ri_buf[1].i_addr;
++	ldip = item->ri_buf[1].iov_base;
+ 	if (XFS_IS_CORRUPT(mp, ldip->di_magic != XFS_DINODE_MAGIC)) {
+ 		xfs_alert(mp,
+ 			"%s: Bad inode log record, rec ptr "PTR_FMT", ino %lld",
+@@ -432,12 +432,12 @@ xlog_recover_inode_commit_pass2(
+ 		goto out_release;
+ 	}
+ 	isize = xfs_log_dinode_size(mp);
+-	if (unlikely(item->ri_buf[1].i_len > isize)) {
++	if (unlikely(item->ri_buf[1].iov_len > isize)) {
+ 		XFS_CORRUPTION_ERROR("Bad log dinode size", XFS_ERRLEVEL_LOW,
+ 				     mp, ldip, sizeof(*ldip));
+ 		xfs_alert(mp,
+-			"Bad inode 0x%llx log dinode size 0x%x",
+-			in_f->ilf_ino, item->ri_buf[1].i_len);
++			"Bad inode 0x%llx log dinode size 0x%zx",
++			in_f->ilf_ino, item->ri_buf[1].iov_len);
+ 		error = -EFSCORRUPTED;
+ 		goto out_release;
+ 	}
+@@ -460,8 +460,8 @@ xlog_recover_inode_commit_pass2(
+ 
+ 	if (in_f->ilf_size == 2)
+ 		goto out_owner_change;
+-	len = item->ri_buf[2].i_len;
+-	src = item->ri_buf[2].i_addr;
++	len = item->ri_buf[2].iov_len;
++	src = item->ri_buf[2].iov_base;
+ 	ASSERT(in_f->ilf_size <= 4);
+ 	ASSERT((in_f->ilf_size == 3) || (fields & XFS_ILOG_AFORK));
+ 	ASSERT(!(fields & XFS_ILOG_DFORK) ||
+@@ -498,8 +498,8 @@ xlog_recover_inode_commit_pass2(
+ 		} else {
+ 			attr_index = 2;
+ 		}
+-		len = item->ri_buf[attr_index].i_len;
+-		src = item->ri_buf[attr_index].i_addr;
++		len = item->ri_buf[attr_index].iov_len;
++		src = item->ri_buf[attr_index].iov_base;
+ 		ASSERT(len == xlog_calc_iovec_len(in_f->ilf_asize));
+ 
+ 		switch (in_f->ilf_fields & XFS_ILOG_AFORK) {
+diff --git a/fs/xfs/xfs_log_recover.c b/fs/xfs/xfs_log_recover.c
+index 6989c0253d376d..38ae42bbf9b5c1 100644
+--- a/fs/xfs/xfs_log_recover.c
++++ b/fs/xfs/xfs_log_recover.c
+@@ -2105,15 +2105,15 @@ xlog_recover_add_to_cont_trans(
+ 	item = list_entry(trans->r_itemq.prev, struct xlog_recover_item,
+ 			  ri_list);
+ 
+-	old_ptr = item->ri_buf[item->ri_cnt-1].i_addr;
+-	old_len = item->ri_buf[item->ri_cnt-1].i_len;
++	old_ptr = item->ri_buf[item->ri_cnt-1].iov_base;
++	old_len = item->ri_buf[item->ri_cnt-1].iov_len;
+ 
+ 	ptr = kvrealloc(old_ptr, old_len, len + old_len, GFP_KERNEL);
+ 	if (!ptr)
+ 		return -ENOMEM;
+ 	memcpy(&ptr[old_len], dp, len);
+-	item->ri_buf[item->ri_cnt-1].i_len += len;
+-	item->ri_buf[item->ri_cnt-1].i_addr = ptr;
++	item->ri_buf[item->ri_cnt-1].iov_len += len;
++	item->ri_buf[item->ri_cnt-1].iov_base = ptr;
+ 	trace_xfs_log_recover_item_add_cont(log, trans, item, 0);
+ 	return 0;
+ }
+@@ -2198,7 +2198,7 @@ xlog_recover_add_to_trans(
+ 
+ 		item->ri_total = in_f->ilf_size;
+ 		item->ri_buf =
+-			kmem_zalloc(item->ri_total * sizeof(xfs_log_iovec_t),
++			kmem_zalloc(item->ri_total * sizeof(*item->ri_buf),
+ 				    0);
+ 	}
+ 
+@@ -2212,8 +2212,8 @@ xlog_recover_add_to_trans(
+ 	}
+ 
+ 	/* Description region is ri_buf[0] */
+-	item->ri_buf[item->ri_cnt].i_addr = ptr;
+-	item->ri_buf[item->ri_cnt].i_len  = len;
++	item->ri_buf[item->ri_cnt].iov_base = ptr;
++	item->ri_buf[item->ri_cnt].iov_len  = len;
+ 	item->ri_cnt++;
+ 	trace_xfs_log_recover_item_add(log, trans, item, 0);
+ 	return 0;
+@@ -2237,7 +2237,7 @@ xlog_recover_free_trans(
+ 		/* Free the regions in the item. */
+ 		list_del(&item->ri_list);
+ 		for (i = 0; i < item->ri_cnt; i++)
+-			kmem_free(item->ri_buf[i].i_addr);
++			kmem_free(item->ri_buf[i].iov_base);
+ 		/* Free the item itself */
+ 		kmem_free(item->ri_buf);
+ 		kmem_free(item);
+diff --git a/fs/xfs/xfs_refcount_item.c b/fs/xfs/xfs_refcount_item.c
+index 48f1a38b272e1d..60e65da42329fa 100644
+--- a/fs/xfs/xfs_refcount_item.c
++++ b/fs/xfs/xfs_refcount_item.c
+@@ -631,18 +631,18 @@ xlog_recover_cui_commit_pass2(
+ 	struct xfs_cui_log_format	*cui_formatp;
+ 	size_t				len;
+ 
+-	cui_formatp = item->ri_buf[0].i_addr;
++	cui_formatp = item->ri_buf[0].iov_base;
+ 
+-	if (item->ri_buf[0].i_len < xfs_cui_log_format_sizeof(0)) {
++	if (item->ri_buf[0].iov_len < xfs_cui_log_format_sizeof(0)) {
+ 		XFS_CORRUPTION_ERROR(__func__, XFS_ERRLEVEL_LOW, mp,
+-				item->ri_buf[0].i_addr, item->ri_buf[0].i_len);
++				item->ri_buf[0].iov_base, item->ri_buf[0].iov_len);
+ 		return -EFSCORRUPTED;
+ 	}
+ 
+ 	len = xfs_cui_log_format_sizeof(cui_formatp->cui_nextents);
+-	if (item->ri_buf[0].i_len != len) {
++	if (item->ri_buf[0].iov_len != len) {
+ 		XFS_CORRUPTION_ERROR(__func__, XFS_ERRLEVEL_LOW, mp,
+-				item->ri_buf[0].i_addr, item->ri_buf[0].i_len);
++				item->ri_buf[0].iov_base, item->ri_buf[0].iov_len);
+ 		return -EFSCORRUPTED;
+ 	}
+ 
+@@ -676,10 +676,10 @@ xlog_recover_cud_commit_pass2(
+ {
+ 	struct xfs_cud_log_format	*cud_formatp;
+ 
+-	cud_formatp = item->ri_buf[0].i_addr;
+-	if (item->ri_buf[0].i_len != sizeof(struct xfs_cud_log_format)) {
++	cud_formatp = item->ri_buf[0].iov_base;
++	if (item->ri_buf[0].iov_len != sizeof(struct xfs_cud_log_format)) {
+ 		XFS_CORRUPTION_ERROR(__func__, XFS_ERRLEVEL_LOW, log->l_mp,
+-				item->ri_buf[0].i_addr, item->ri_buf[0].i_len);
++				item->ri_buf[0].iov_base, item->ri_buf[0].iov_len);
+ 		return -EFSCORRUPTED;
+ 	}
+ 
+diff --git a/fs/xfs/xfs_rmap_item.c b/fs/xfs/xfs_rmap_item.c
+index 23684bc2ab85a2..b42d1c80adc01a 100644
+--- a/fs/xfs/xfs_rmap_item.c
++++ b/fs/xfs/xfs_rmap_item.c
+@@ -684,18 +684,18 @@ xlog_recover_rui_commit_pass2(
+ 	struct xfs_rui_log_format	*rui_formatp;
+ 	size_t				len;
+ 
+-	rui_formatp = item->ri_buf[0].i_addr;
++	rui_formatp = item->ri_buf[0].iov_base;
+ 
+-	if (item->ri_buf[0].i_len < xfs_rui_log_format_sizeof(0)) {
++	if (item->ri_buf[0].iov_len < xfs_rui_log_format_sizeof(0)) {
+ 		XFS_CORRUPTION_ERROR(__func__, XFS_ERRLEVEL_LOW, mp,
+-				item->ri_buf[0].i_addr, item->ri_buf[0].i_len);
++				item->ri_buf[0].iov_base, item->ri_buf[0].iov_len);
+ 		return -EFSCORRUPTED;
+ 	}
+ 
+ 	len = xfs_rui_log_format_sizeof(rui_formatp->rui_nextents);
+-	if (item->ri_buf[0].i_len != len) {
++	if (item->ri_buf[0].iov_len != len) {
+ 		XFS_CORRUPTION_ERROR(__func__, XFS_ERRLEVEL_LOW, mp,
+-				item->ri_buf[0].i_addr, item->ri_buf[0].i_len);
++				item->ri_buf[0].iov_base, item->ri_buf[0].iov_len);
+ 		return -EFSCORRUPTED;
+ 	}
+ 
+@@ -729,10 +729,10 @@ xlog_recover_rud_commit_pass2(
+ {
+ 	struct xfs_rud_log_format	*rud_formatp;
+ 
+-	rud_formatp = item->ri_buf[0].i_addr;
+-	if (item->ri_buf[0].i_len != sizeof(struct xfs_rud_log_format)) {
++	rud_formatp = item->ri_buf[0].iov_base;
++	if (item->ri_buf[0].iov_len != sizeof(struct xfs_rud_log_format)) {
+ 		XFS_CORRUPTION_ERROR(__func__, XFS_ERRLEVEL_LOW, log->l_mp,
+-				rud_formatp, item->ri_buf[0].i_len);
++				rud_formatp, item->ri_buf[0].iov_len);
+ 		return -EFSCORRUPTED;
+ 	}
+ 
+diff --git a/fs/xfs/xfs_trans.h b/fs/xfs/xfs_trans.h
+index ae32ffe9a1b15c..eaca3a2fd36d26 100644
+--- a/fs/xfs/xfs_trans.h
++++ b/fs/xfs/xfs_trans.h
+@@ -15,7 +15,6 @@ struct xfs_efd_log_item;
+ struct xfs_efi_log_item;
+ struct xfs_inode;
+ struct xfs_item_ops;
+-struct xfs_log_iovec;
+ struct xfs_mount;
+ struct xfs_trans;
+ struct xfs_trans_res;
+diff --git a/include/linux/pci-ecam.h b/include/linux/pci-ecam.h
+index 6b1301e2498e9e..30e9d883549974 100644
+--- a/include/linux/pci-ecam.h
++++ b/include/linux/pci-ecam.h
+@@ -77,6 +77,9 @@ void __iomem *pci_ecam_map_bus(struct pci_bus *bus, unsigned int devfn,
+ /* default ECAM ops */
+ extern const struct pci_ecam_ops pci_generic_ecam_ops;
+ 
++/* default CAM ops */
++extern const struct pci_ecam_ops pci_generic_cam_ops;
++
+ #if defined(CONFIG_ACPI) && defined(CONFIG_PCI_QUIRKS)
+ extern const struct pci_ecam_ops pci_32b_ops;	/* 32-bit accesses only */
+ extern const struct pci_ecam_ops pci_32b_read_ops; /* 32-bit read only */
+diff --git a/include/linux/sched.h b/include/linux/sched.h
+index c5e90874096e92..4be7af82f813c3 100644
+--- a/include/linux/sched.h
++++ b/include/linux/sched.h
+@@ -1437,6 +1437,14 @@ struct task_struct {
+ 
+ 	/* Collect coverage from softirq context: */
+ 	unsigned int			kcov_softirq;
++
++	/* Temporary storage for preempting remote coverage collection: */
++	unsigned int			kcov_saved_mode;
++	unsigned int			kcov_saved_size;
++	void				*kcov_saved_area;
++	struct kcov			*kcov_saved_kcov;
++	int				kcov_saved_sequence;
++
+ #endif
+ 
+ #ifdef CONFIG_MEMCG
+diff --git a/include/net/inet_frag.h b/include/net/inet_frag.h
+index fcabb34fff35de..365925c9d26286 100644
+--- a/include/net/inet_frag.h
++++ b/include/net/inet_frag.h
+@@ -126,16 +126,16 @@ int fqdir_init(struct fqdir **fqdirp, struct inet_frags *f, struct net *net);
+ void fqdir_pre_exit(struct fqdir *fqdir);
+ void fqdir_exit(struct fqdir *fqdir);
+ 
+-void inet_frag_kill(struct inet_frag_queue *q);
++void inet_frag_kill(struct inet_frag_queue *q, int *refs);
+ void inet_frag_destroy(struct inet_frag_queue *q);
+ struct inet_frag_queue *inet_frag_find(struct fqdir *fqdir, void *key);
+ 
+ void inet_frag_queue_flush(struct inet_frag_queue *q,
+ 			   enum skb_drop_reason reason);
+ 
+-static inline void inet_frag_put(struct inet_frag_queue *q)
++static inline void inet_frag_putn(struct inet_frag_queue *q, int refs)
+ {
+-	if (refcount_dec_and_test(&q->refcnt))
++	if (refs && refcount_sub_and_test(refs, &q->refcnt))
+ 		inet_frag_destroy(q);
+ }
+ 
+diff --git a/include/net/ipv6_frag.h b/include/net/ipv6_frag.h
+index df61b98b521531..41d9fc6965f9a0 100644
+--- a/include/net/ipv6_frag.h
++++ b/include/net/ipv6_frag.h
+@@ -66,6 +66,7 @@ ip6frag_expire_frag_queue(struct net *net, struct frag_queue *fq)
+ {
+ 	struct net_device *dev = NULL;
+ 	struct sk_buff *head;
++	int refs = 1;
+ 
+ 	rcu_read_lock();
+ 	spin_lock(&fq->q.lock);
+@@ -74,7 +75,7 @@ ip6frag_expire_frag_queue(struct net *net, struct frag_queue *fq)
+ 		goto out;
+ 
+ 	fq->q.flags |= INET_FRAG_DROP;
+-	inet_frag_kill(&fq->q);
++	inet_frag_kill(&fq->q, &refs);
+ 
+ 	/* Paired with the WRITE_ONCE() in fqdir_pre_exit(). */
+ 	if (READ_ONCE(fq->q.fqdir->dead)) {
+@@ -112,7 +113,7 @@ out:
+ 	spin_unlock(&fq->q.lock);
+ out_rcu_unlock:
+ 	rcu_read_unlock();
+-	inet_frag_put(&fq->q);
++	inet_frag_putn(&fq->q, refs);
+ }
+ 
+ /* Check if the upper layer header is truncated in the first fragment. */
+diff --git a/kernel/events/core.c b/kernel/events/core.c
+index d45bce2acdbc75..3f86104eb4c5ac 100644
+--- a/kernel/events/core.c
++++ b/kernel/events/core.c
+@@ -2162,6 +2162,34 @@ static inline struct list_head *get_event_list(struct perf_event *event)
+ 				    &event->pmu_ctx->flexible_active;
+ }
+ 
++/* @sibling must already be unlinked from its old leader's sibling_list. */
++static void perf_promote_sibling_to_leader(struct perf_event *sibling,
++					   struct perf_event_context *ctx,
++					   int group_caps)
++{
++	/*
++	 * Events that have PERF_EV_CAP_SIBLING require being part of
++	 * a group and cannot exist on their own, schedule them out
++	 * and move them into the ERROR state. Also see
++	 * _perf_event_enable(), it will not be able to recover this
++	 * ERROR state.
++	 */
++	if (sibling->event_caps & PERF_EV_CAP_SIBLING)
++		__event_disable(sibling, ctx, PERF_EVENT_STATE_ERROR);
++
++	sibling->group_leader = sibling;
++	sibling->group_caps = group_caps;
++
++	if (sibling->attach_state & PERF_ATTACH_CONTEXT) {
++		add_event_to_groups(sibling, ctx);
++
++		if (sibling->state == PERF_EVENT_STATE_ACTIVE)
++			list_add_tail(&sibling->active_list, get_event_list(sibling));
++	}
++
++	perf_event__header_size(sibling);
++}
++
+ static void perf_group_detach(struct perf_event *event)
+ {
+ 	struct perf_event *leader = event->group_leader;
+@@ -2185,8 +2213,9 @@ static void perf_group_detach(struct perf_event *event)
+ 	 */
+ 	if (leader != event) {
+ 		list_del_init(&event->sibling_list);
+-		event->group_leader->nr_siblings--;
+-		event->group_leader->group_generation++;
++		leader->nr_siblings--;
++		leader->group_generation++;
++		perf_promote_sibling_to_leader(event, ctx, event->event_caps);
+ 		goto out;
+ 	}
+ 
+@@ -2196,32 +2225,14 @@ static void perf_group_detach(struct perf_event *event)
+ 	 * to whatever list we are on.
+ 	 */
+ 	list_for_each_entry_safe(sibling, tmp, &event->sibling_list, sibling_list) {
+-
+-		/*
+-		 * Events that have PERF_EV_CAP_SIBLING require being part of
+-		 * a group and cannot exist on their own, schedule them out
+-		 * and move them into the ERROR state. Also see
+-		 * _perf_event_enable(), it will not be able to recover this
+-		 * ERROR state.
+-		 */
+-		if (sibling->event_caps & PERF_EV_CAP_SIBLING)
+-			__event_disable(sibling, ctx, PERF_EVENT_STATE_ERROR);
+-
+-		sibling->group_leader = sibling;
+ 		list_del_init(&sibling->sibling_list);
+ 
+ 		/* Inherit group flags from the previous leader */
+-		sibling->group_caps = event->group_caps;
+-
+-		if (sibling->attach_state & PERF_ATTACH_CONTEXT) {
+-			add_event_to_groups(sibling, event->ctx);
+-
+-			if (sibling->state == PERF_EVENT_STATE_ACTIVE)
+-				list_add_tail(&sibling->active_list, get_event_list(sibling));
+-		}
++		perf_promote_sibling_to_leader(sibling, ctx, event->group_caps);
+ 
+ 		WARN_ON_ONCE(sibling->ctx != event->ctx);
+ 	}
++	event->nr_siblings = 0;
+ 
+ out:
+ 	for_each_sibling_event(tmp, leader)
+@@ -2387,12 +2398,8 @@ __perf_remove_from_context(struct perf_event *event,
+ 	if (flags & DETACH_DEAD)
+ 		state = PERF_EVENT_STATE_DEAD;
+ 
+-	event_sched_out(event, ctx);
++	__event_disable(event, ctx, state);
+ 
+-	if (event->state > PERF_EVENT_STATE_OFF)
+-		perf_cgroup_event_disable(event, ctx);
+-
+-	perf_event_set_state(event, min(event->state, state));
+ 	if (flags & DETACH_GROUP)
+ 		perf_group_detach(event);
+ 	if (flags & DETACH_CHILD)
+@@ -2461,8 +2468,9 @@ static void __event_disable(struct perf_event *event,
+ 			    enum perf_event_state state)
+ {
+ 	event_sched_out(event, ctx);
+-	perf_cgroup_event_disable(event, ctx);
+-	perf_event_set_state(event, state);
++	if (event->state > PERF_EVENT_STATE_OFF)
++		perf_cgroup_event_disable(event, ctx);
++	perf_event_set_state(event, min(event->state, state));
+ }
+ 
+ /*
+@@ -13276,13 +13284,11 @@ perf_event_exit_event(struct perf_event *event,
+ 	perf_event_wakeup(event);
+ }
+ 
+-static void perf_event_exit_task_context(struct task_struct *child)
++static void perf_event_exit_task_context(struct task_struct *child, bool exit)
+ {
+ 	struct perf_event_context *child_ctx, *clone_ctx = NULL;
+ 	struct perf_event *child_event, *next;
+ 
+-	WARN_ON_ONCE(child != current);
+-
+ 	child_ctx = perf_pin_task_context(child);
+ 	if (!child_ctx)
+ 		return;
+@@ -13305,7 +13311,8 @@ static void perf_event_exit_task_context(struct task_struct *child)
+ 	 * in.
+ 	 */
+ 	raw_spin_lock_irq(&child_ctx->lock);
+-	task_ctx_sched_out(child_ctx, EVENT_ALL);
++	if (exit)
++		task_ctx_sched_out(child_ctx, EVENT_ALL);
+ 
+ 	/*
+ 	 * Now that the context is inactive, destroy the task <-> ctx relation
+@@ -13314,7 +13321,7 @@ static void perf_event_exit_task_context(struct task_struct *child)
+ 	RCU_INIT_POINTER(child->perf_event_ctxp, NULL);
+ 	put_ctx(child_ctx); /* cannot be last */
+ 	WRITE_ONCE(child_ctx->task, TASK_TOMBSTONE);
+-	put_task_struct(current); /* cannot be last */
++	put_task_struct(child); /* cannot be last */
+ 
+ 	clone_ctx = unclone_ctx(child_ctx);
+ 	raw_spin_unlock_irq(&child_ctx->lock);
+@@ -13327,13 +13334,31 @@ static void perf_event_exit_task_context(struct task_struct *child)
+ 	 * won't get any samples after PERF_RECORD_EXIT. We can however still
+ 	 * get a few PERF_RECORD_READ events.
+ 	 */
+-	perf_event_task(child, child_ctx, 0);
++	if (exit)
++		perf_event_task(child, child_ctx, 0);
+ 
+ 	list_for_each_entry_safe(child_event, next, &child_ctx->event_list, event_entry)
+ 		perf_event_exit_event(child_event, child_ctx, 0);
+ 
+ 	mutex_unlock(&child_ctx->mutex);
+ 
++	if (!exit) {
++		/*
++		 * perf_event_release_kernel() could still have a reference on
++		 * this context. In that case we must wait for these events to
++		 * have been freed (in particular all their references to this
++		 * task must've been dropped).
++		 *
++		 * Without this copy_process() will unconditionally free this
++		 * task (irrespective of its reference count) and
++		 * _free_event()'s put_task_struct(event->hw.target) will be a
++		 * use-after-free.
++		 *
++		 * Wait for all events to drop their context reference.
++		 */
++		wait_var_event(&child_ctx->refcount,
++			       refcount_read(&child_ctx->refcount) == 1);
++	}
+ 	put_ctx(child_ctx);
+ }
+ 
+@@ -13361,7 +13386,7 @@ void perf_event_exit_task(struct task_struct *child)
+ 	}
+ 	mutex_unlock(&child->perf_event_mutex);
+ 
+-	perf_event_exit_task_context(child);
++	perf_event_exit_task_context(child, true);
+ 
+ 	/*
+ 	 * The perf_event_exit_task_context calls perf_event_task
+@@ -13372,27 +13397,6 @@ void perf_event_exit_task(struct task_struct *child)
+ 	perf_event_task(child, NULL, 0);
+ }
+ 
+-static void perf_free_event(struct perf_event *event,
+-			    struct perf_event_context *ctx)
+-{
+-	struct perf_event *parent = event->parent;
+-
+-	if (WARN_ON_ONCE(!parent))
+-		return;
+-
+-	mutex_lock(&parent->child_mutex);
+-	list_del_init(&event->child_list);
+-	mutex_unlock(&parent->child_mutex);
+-
+-	put_event(parent);
+-
+-	raw_spin_lock_irq(&ctx->lock);
+-	perf_group_detach(event);
+-	list_del_event(event, ctx);
+-	raw_spin_unlock_irq(&ctx->lock);
+-	free_event(event);
+-}
+-
+ /*
+  * Free a context as created by inheritance by perf_event_init_task() below,
+  * used by fork() in case of fail.
+@@ -13402,48 +13406,7 @@ static void perf_free_event(struct perf_event *event,
+  */
+ void perf_event_free_task(struct task_struct *task)
+ {
+-	struct perf_event_context *ctx;
+-	struct perf_event *event, *tmp;
+-
+-	ctx = rcu_access_pointer(task->perf_event_ctxp);
+-	if (!ctx)
+-		return;
+-
+-	mutex_lock(&ctx->mutex);
+-	raw_spin_lock_irq(&ctx->lock);
+-	/*
+-	 * Destroy the task <-> ctx relation and mark the context dead.
+-	 *
+-	 * This is important because even though the task hasn't been
+-	 * exposed yet the context has been (through child_list).
+-	 */
+-	RCU_INIT_POINTER(task->perf_event_ctxp, NULL);
+-	WRITE_ONCE(ctx->task, TASK_TOMBSTONE);
+-	put_task_struct(task); /* cannot be last */
+-	raw_spin_unlock_irq(&ctx->lock);
+-
+-
+-	list_for_each_entry_safe(event, tmp, &ctx->event_list, event_entry)
+-		perf_free_event(event, ctx);
+-
+-	mutex_unlock(&ctx->mutex);
+-
+-	/*
+-	 * perf_event_release_kernel() could've stolen some of our
+-	 * child events and still have them on its free_list. In that
+-	 * case we must wait for these events to have been freed (in
+-	 * particular all their references to this task must've been
+-	 * dropped).
+-	 *
+-	 * Without this copy_process() will unconditionally free this
+-	 * task (irrespective of its reference count) and
+-	 * _free_event()'s put_task_struct(event->hw.target) will be a
+-	 * use-after-free.
+-	 *
+-	 * Wait for all events to drop their context reference.
+-	 */
+-	wait_var_event(&ctx->refcount, refcount_read(&ctx->refcount) == 1);
+-	put_ctx(ctx); /* must be last */
++	perf_event_exit_task_context(task, false);
+ }
+ 
+ void perf_event_delayed_put(struct task_struct *task)
+diff --git a/kernel/kcov.c b/kernel/kcov.c
+index 097c8afa675578..e0822e47415561 100644
+--- a/kernel/kcov.c
++++ b/kernel/kcov.c
+@@ -85,17 +85,12 @@ struct kcov_remote {
+ 
+ static DEFINE_SPINLOCK(kcov_remote_lock);
+ static DEFINE_HASHTABLE(kcov_remote_map, 4);
+-static struct list_head kcov_remote_areas = LIST_HEAD_INIT(kcov_remote_areas);
++static struct list_head kcov_remote_areas[2] = {
++	LIST_HEAD_INIT(kcov_remote_areas[0]), LIST_HEAD_INIT(kcov_remote_areas[1])
++};
+ 
+ struct kcov_percpu_data {
+-	void			*irq_area;
+ 	local_lock_t		lock;
+-
+-	unsigned int		saved_mode;
+-	unsigned int		saved_size;
+-	void			*saved_area;
+-	struct kcov		*saved_kcov;
+-	int			saved_sequence;
+ };
+ 
+ static DEFINE_PER_CPU(struct kcov_percpu_data, kcov_percpu_data) = {
+@@ -131,12 +126,13 @@ static struct kcov_remote *kcov_remote_add(struct kcov *kcov, u64 handle)
+ }
+ 
+ /* Must be called with kcov_remote_lock locked. */
+-static struct kcov_remote_area *kcov_remote_area_get(unsigned int size)
++static struct kcov_remote_area *kcov_remote_area_get(unsigned int size, bool irq)
+ {
+ 	struct kcov_remote_area *area;
+ 	struct list_head *pos;
++	struct list_head *list = &kcov_remote_areas[irq];
+ 
+-	list_for_each(pos, &kcov_remote_areas) {
++	list_for_each(pos, list) {
+ 		area = list_entry(pos, struct kcov_remote_area, list);
+ 		if (area->size == size) {
+ 			list_del(&area->list);
+@@ -148,11 +144,11 @@ static struct kcov_remote_area *kcov_remote_area_get(unsigned int size)
+ 
+ /* Must be called with kcov_remote_lock locked. */
+ static void kcov_remote_area_put(struct kcov_remote_area *area,
+-					unsigned int size)
++				 unsigned int size, bool irq)
+ {
+ 	INIT_LIST_HEAD(&area->list);
+ 	area->size = size;
+-	list_add(&area->list, &kcov_remote_areas);
++	list_add(&area->list, &kcov_remote_areas[irq]);
+ 	/*
+ 	 * KMSAN doesn't instrument this file, so it may not know area->list
+ 	 * is initialized. Unpoison it explicitly to avoid reports in
+@@ -387,6 +383,12 @@ void kcov_task_init(struct task_struct *t)
+ {
+ 	kcov_task_reset(t);
+ 	t->kcov_handle = current->kcov_handle;
++	t->kcov_softirq = 0;
++	t->kcov_saved_mode = 0;
++	t->kcov_saved_size = 0;
++	t->kcov_saved_area = NULL;
++	t->kcov_saved_kcov = NULL;
++	t->kcov_saved_sequence = 0;
+ }
+ 
+ static void kcov_reset(struct kcov *kcov)
+@@ -813,34 +815,31 @@ static inline bool kcov_mode_enabled(unsigned int mode)
+ 
+ static void kcov_remote_softirq_start(struct task_struct *t)
+ {
+-	struct kcov_percpu_data *data = this_cpu_ptr(&kcov_percpu_data);
+ 	unsigned int mode;
+ 
+ 	mode = READ_ONCE(t->kcov_mode);
+ 	barrier();
+ 	if (kcov_mode_enabled(mode)) {
+-		data->saved_mode = mode;
+-		data->saved_size = t->kcov_size;
+-		data->saved_area = t->kcov_area;
+-		data->saved_sequence = t->kcov_sequence;
+-		data->saved_kcov = t->kcov;
++		t->kcov_saved_mode = mode;
++		t->kcov_saved_size = t->kcov_size;
++		t->kcov_saved_area = t->kcov_area;
++		t->kcov_saved_sequence = t->kcov_sequence;
++		t->kcov_saved_kcov = t->kcov;
+ 		kcov_stop(t);
+ 	}
+ }
+ 
+ static void kcov_remote_softirq_stop(struct task_struct *t)
+ {
+-	struct kcov_percpu_data *data = this_cpu_ptr(&kcov_percpu_data);
+-
+-	if (data->saved_kcov) {
+-		kcov_start(t, data->saved_kcov, data->saved_size,
+-				data->saved_area, data->saved_mode,
+-				data->saved_sequence);
+-		data->saved_mode = 0;
+-		data->saved_size = 0;
+-		data->saved_area = NULL;
+-		data->saved_sequence = 0;
+-		data->saved_kcov = NULL;
++	if (t->kcov_saved_kcov) {
++		kcov_start(t, t->kcov_saved_kcov, t->kcov_saved_size,
++			   t->kcov_saved_area, t->kcov_saved_mode,
++			   t->kcov_saved_sequence);
++		t->kcov_saved_mode = 0;
++		t->kcov_saved_size = 0;
++		t->kcov_saved_area = NULL;
++		t->kcov_saved_sequence = 0;
++		t->kcov_saved_kcov = NULL;
+ 	}
+ }
+ 
+@@ -901,17 +900,17 @@ void kcov_remote_start(u64 handle)
+ 	sequence = kcov->sequence;
+ 	if (in_task()) {
+ 		size = kcov->remote_size;
+-		area = kcov_remote_area_get(size);
++		area = kcov_remote_area_get(size, false);
+ 	} else {
+ 		size = CONFIG_KCOV_IRQ_AREA_SIZE;
+-		area = this_cpu_ptr(&kcov_percpu_data)->irq_area;
++		area = kcov_remote_area_get(size, true);
+ 	}
+ 	spin_unlock(&kcov_remote_lock);
+ 
+-	/* Can only happen when in_task(). */
++	/* Allocate new buffer if we can sleep. */
+ 	if (!area) {
+ 		local_unlock_irqrestore(&kcov_percpu_data.lock, flags);
+-		area = vmalloc(size * sizeof(unsigned long));
++		area = in_task() ? vmalloc(size * sizeof(unsigned long)) : NULL;
+ 		if (!area) {
+ 			kcov_put(kcov);
+ 			return;
+@@ -1044,11 +1043,9 @@ void kcov_remote_stop(void)
+ 		kcov_move_area(kcov->mode, kcov->area, kcov->size, area);
+ 	spin_unlock(&kcov->lock);
+ 
+-	if (in_task()) {
+-		spin_lock(&kcov_remote_lock);
+-		kcov_remote_area_put(area, size);
+-		spin_unlock(&kcov_remote_lock);
+-	}
++	spin_lock(&kcov_remote_lock);
++	kcov_remote_area_put(area, size, !in_task());
++	spin_unlock(&kcov_remote_lock);
+ 
+ 	local_unlock_irqrestore(&kcov_percpu_data.lock, flags);
+ 
+@@ -1068,14 +1065,21 @@ EXPORT_SYMBOL(kcov_common_handle);
+ 
+ static int __init kcov_init(void)
+ {
+-	int cpu;
++	int cpu = num_possible_cpus();
++
++#ifdef CONFIG_PREEMPT_RT
++	/* Allocate some extra buffers in order to prepare for softirq preemption. */
++	cpu = cpu >= 4 ? cpu * 2 : cpu + 4;
++#endif
++	while (cpu--) {
++		void *area = vmalloc(CONFIG_KCOV_IRQ_AREA_SIZE * sizeof(unsigned long));
++		unsigned long flags;
+ 
+-	for_each_possible_cpu(cpu) {
+-		void *area = vmalloc_node(CONFIG_KCOV_IRQ_AREA_SIZE *
+-				sizeof(unsigned long), cpu_to_node(cpu));
+ 		if (!area)
+ 			return -ENOMEM;
+-		per_cpu_ptr(&kcov_percpu_data, cpu)->irq_area = area;
++		spin_lock_irqsave(&kcov_remote_lock, flags);
++		kcov_remote_area_put(area, CONFIG_KCOV_IRQ_AREA_SIZE, true);
++		spin_unlock_irqrestore(&kcov_remote_lock, flags);
+ 	}
+ 
+ 	/*
+diff --git a/lib/Kconfig.debug b/lib/Kconfig.debug
+index e56f9e1b18fdf0..e394eb0f85abcb 100644
+--- a/lib/Kconfig.debug
++++ b/lib/Kconfig.debug
+@@ -2083,10 +2083,11 @@ config KCOV_INSTRUMENT_ALL
+ config KCOV_IRQ_AREA_SIZE
+ 	hex "Size of interrupt coverage collection area in words"
+ 	depends on KCOV
++	range 0x80 0x1000000
+ 	default 0x40000
+ 	help
+-	  KCOV uses preallocated per-cpu areas to collect coverage from
+-	  soft interrupts. This specifies the size of those areas in the
++	  KCOV uses preallocated areas to collect coverage from soft
++	  interrupts. This specifies the size of those areas in the
+ 	  number of unsigned long words.
+ 
+ menuconfig RUNTIME_TESTING_MENU
+diff --git a/net/bluetooth/hci_event.c b/net/bluetooth/hci_event.c
+index 14caf945aadde5..083b7db898fed4 100644
+--- a/net/bluetooth/hci_event.c
++++ b/net/bluetooth/hci_event.c
+@@ -294,8 +294,10 @@ static u8 hci_cc_reset(struct hci_dev *hdev, void *data, struct sk_buff *skb)
+ 
+ 	hdev->ssp_debug_mode = 0;
+ 
++	hci_dev_lock(hdev);
+ 	hci_bdaddr_list_clear(&hdev->le_accept_list);
+ 	hci_bdaddr_list_clear(&hdev->le_resolv_list);
++	hci_dev_unlock(hdev);
+ 
+ 	return rp->status;
+ }
+@@ -3796,8 +3798,10 @@ static u8 hci_cc_le_set_cig_params(struct hci_dev *hdev, void *data,
+ 	bt_dev_dbg(hdev, "status 0x%2.2x", rp->status);
+ 
+ 	cp = hci_sent_cmd_data(hdev, HCI_OP_LE_SET_CIG_PARAMS);
+-	if (!rp->status && (!cp || rp->num_handles != cp->num_cis ||
+-			    rp->cig_id != cp->cig_id)) {
++	if (!rp->status &&
++	    (!cp || rp->num_handles != cp->num_cis ||
++	     rp->cig_id != cp->cig_id ||
++	     skb->len < array_size(rp->num_handles, sizeof(*rp->handle)))) {
+ 		bt_dev_err(hdev, "unexpected Set CIG Parameters response data");
+ 		status = HCI_ERROR_UNSPECIFIED;
+ 	}
+diff --git a/net/bluetooth/hci_sync.c b/net/bluetooth/hci_sync.c
+index 6a5ec74eaf25ae..55fc529cc306d8 100644
+--- a/net/bluetooth/hci_sync.c
++++ b/net/bluetooth/hci_sync.c
+@@ -1253,10 +1253,11 @@ static int hci_set_adv_set_random_addr_sync(struct hci_dev *hdev, u8 instance,
+ }
+ 
+ static int
+-hci_set_ext_adv_params_sync(struct hci_dev *hdev, struct adv_info *adv,
++hci_set_ext_adv_params_sync(struct hci_dev *hdev, u8 instance,
+ 			    const struct hci_cp_le_set_ext_adv_params *cp,
+ 			    struct hci_rp_le_set_ext_adv_params *rp)
+ {
++	struct adv_info *adv;
+ 	struct sk_buff *skb;
+ 
+ 	skb = __hci_cmd_sync(hdev, HCI_OP_LE_SET_EXT_ADV_PARAMS, sizeof(*cp),
+@@ -1284,11 +1285,15 @@ hci_set_ext_adv_params_sync(struct hci_dev *hdev, struct adv_info *adv,
+ 
+ 	if (!rp->status) {
+ 		hdev->adv_addr_type = cp->own_addr_type;
+-		if (!cp->handle) {
++		if (!instance) {
+ 			/* Store in hdev for instance 0 */
+ 			hdev->adv_tx_power = rp->tx_power;
+-		} else if (adv) {
+-			adv->tx_power = rp->tx_power;
++		} else {
++			hci_dev_lock(hdev);
++			adv = hci_find_adv_instance(hdev, instance);
++			if (adv)
++				adv->tx_power = rp->tx_power;
++			hci_dev_unlock(hdev);
+ 		}
+ 	}
+ 
+@@ -1308,9 +1313,13 @@ static int hci_set_ext_adv_data_sync(struct hci_dev *hdev, u8 instance)
+ 	memset(&pdu, 0, sizeof(pdu));
+ 
+ 	if (instance) {
++		hci_dev_lock(hdev);
++
+ 		adv = hci_find_adv_instance(hdev, instance);
+-		if (!adv || !adv->adv_data_changed)
++		if (!adv || !adv->adv_data_changed) {
++			hci_dev_unlock(hdev);
+ 			return 0;
++		}
+ 	}
+ 
+ 	len = eir_create_adv_data(hdev, instance, pdu.data);
+@@ -1320,16 +1329,27 @@ static int hci_set_ext_adv_data_sync(struct hci_dev *hdev, u8 instance)
+ 	pdu.cp.operation = LE_SET_ADV_DATA_OP_COMPLETE;
+ 	pdu.cp.frag_pref = LE_SET_ADV_DATA_NO_FRAG;
+ 
++	if (adv) {
++		adv->adv_data_changed = false;
++		hci_dev_unlock(hdev);
++	}
++
+ 	err = __hci_cmd_sync_status(hdev, HCI_OP_LE_SET_EXT_ADV_DATA,
+ 				    sizeof(pdu.cp) + len, &pdu.cp,
+ 				    HCI_CMD_TIMEOUT);
+-	if (err)
++	if (err) {
++		if (instance) {
++			hci_dev_lock(hdev);
++			adv = hci_find_adv_instance(hdev, instance);
++			if (adv)
++				adv->adv_data_changed = true;
++			hci_dev_unlock(hdev);
++		}
++
+ 		return err;
++	}
+ 
+-	/* Update data if the command succeed */
+-	if (adv) {
+-		adv->adv_data_changed = false;
+-	} else {
++	if (!instance) {
+ 		memcpy(hdev->adv_data, pdu.data, len);
+ 		hdev->adv_data_len = len;
+ 	}
+@@ -1383,22 +1403,22 @@ int hci_setup_ext_adv_instance_sync(struct hci_dev *hdev, u8 instance)
+ 	struct adv_info *adv;
+ 	bool secondary_adv;
+ 
+-	if (instance > 0) {
+-		adv = hci_find_adv_instance(hdev, instance);
+-		if (!adv)
+-			return -EINVAL;
+-	} else {
+-		adv = NULL;
+-	}
+-
+ 	/* Updating parameters of an active instance will return a
+-	 * Command Disallowed error, so we must first disable the
+-	 * instance if it is active.
++	 * Command Disallowed error, so disable it before taking a snapshot.
+ 	 */
+-	if (adv) {
++	if (instance > 0) {
+ 		err = hci_disable_ext_adv_instance_sync(hdev, instance);
+ 		if (err)
+ 			return err;
++
++		hci_dev_lock(hdev);
++		adv = hci_find_adv_instance(hdev, instance);
++		if (!adv) {
++			hci_dev_unlock(hdev);
++			return -EINVAL;
++		}
++	} else {
++		adv = NULL;
+ 	}
+ 
+ 	flags = hci_adv_instance_flags(hdev, instance);
+@@ -1409,8 +1429,11 @@ int hci_setup_ext_adv_instance_sync(struct hci_dev *hdev, u8 instance)
+ 	connectable = (flags & MGMT_ADV_FLAG_CONNECTABLE) ||
+ 		      mgmt_get_connectable(hdev);
+ 
+-	if (!is_advertising_allowed(hdev, connectable))
++	if (!is_advertising_allowed(hdev, connectable)) {
++		if (instance)
++			hci_dev_unlock(hdev);
+ 		return -EPERM;
++	}
+ 
+ 	/* Set require_privacy to true only when non-connectable
+ 	 * advertising is used and it is not periodic.
+@@ -1421,8 +1444,11 @@ int hci_setup_ext_adv_instance_sync(struct hci_dev *hdev, u8 instance)
+ 	err = hci_get_random_address(hdev, require_privacy,
+ 				     adv_use_rpa(hdev, flags), adv,
+ 				     &own_addr_type, &random_addr);
+-	if (err < 0)
++	if (err < 0) {
++		if (instance)
++			hci_dev_unlock(hdev);
+ 		return err;
++	}
+ 
+ 	memset(&cp, 0, sizeof(cp));
+ 
+@@ -1471,6 +1497,9 @@ int hci_setup_ext_adv_instance_sync(struct hci_dev *hdev, u8 instance)
+ 	cp.channel_map = hdev->le_adv_channel_map;
+ 	cp.handle = instance;
+ 
++	if (instance)
++		hci_dev_unlock(hdev);
++
+ 	if (flags & MGMT_ADV_FLAG_SEC_2M) {
+ 		cp.primary_phy = HCI_ADV_PHY_1M;
+ 		cp.secondary_phy = HCI_ADV_PHY_2M;
+@@ -1483,12 +1512,12 @@ int hci_setup_ext_adv_instance_sync(struct hci_dev *hdev, u8 instance)
+ 		cp.secondary_phy = HCI_ADV_PHY_1M;
+ 	}
+ 
+-	err = hci_set_ext_adv_params_sync(hdev, adv, &cp, &rp);
++	err = hci_set_ext_adv_params_sync(hdev, instance, &cp, &rp);
+ 	if (err)
+ 		return err;
+ 
+ 	/* Update adv data as tx power is known now */
+-	err = hci_set_ext_adv_data_sync(hdev, cp.handle);
++	err = hci_set_ext_adv_data_sync(hdev, instance);
+ 	if (err)
+ 		return err;
+ 
+@@ -1496,9 +1525,14 @@ int hci_setup_ext_adv_instance_sync(struct hci_dev *hdev, u8 instance)
+ 	     own_addr_type == ADDR_LE_DEV_RANDOM_RESOLVED) &&
+ 	    bacmp(&random_addr, BDADDR_ANY)) {
+ 		/* Check if random address need to be updated */
+-		if (adv) {
+-			if (!bacmp(&random_addr, &adv->random_addr))
++		if (instance) {
++			hci_dev_lock(hdev);
++			adv = hci_find_adv_instance(hdev, instance);
++			if (!adv || !bacmp(&random_addr, &adv->random_addr)) {
++				hci_dev_unlock(hdev);
+ 				return 0;
++			}
++			hci_dev_unlock(hdev);
+ 		} else {
+ 			if (!bacmp(&random_addr, &hdev->random_addr))
+ 				return 0;
+@@ -1524,9 +1558,13 @@ static int hci_set_ext_scan_rsp_data_sync(struct hci_dev *hdev, u8 instance)
+ 	memset(&pdu, 0, sizeof(pdu));
+ 
+ 	if (instance) {
++		hci_dev_lock(hdev);
++
+ 		adv = hci_find_adv_instance(hdev, instance);
+-		if (!adv || !adv->scan_rsp_changed)
++		if (!adv || !adv->scan_rsp_changed) {
++			hci_dev_unlock(hdev);
+ 			return 0;
++		}
+ 	}
+ 
+ 	len = eir_create_scan_rsp(hdev, instance, pdu.data);
+@@ -1536,15 +1574,27 @@ static int hci_set_ext_scan_rsp_data_sync(struct hci_dev *hdev, u8 instance)
+ 	pdu.cp.operation = LE_SET_ADV_DATA_OP_COMPLETE;
+ 	pdu.cp.frag_pref = LE_SET_ADV_DATA_NO_FRAG;
+ 
++	if (adv) {
++		adv->scan_rsp_changed = false;
++		hci_dev_unlock(hdev);
++	}
++
+ 	err = __hci_cmd_sync_status(hdev, HCI_OP_LE_SET_EXT_SCAN_RSP_DATA,
+ 				    sizeof(pdu.cp) + len, &pdu.cp,
+ 				    HCI_CMD_TIMEOUT);
+-	if (err)
++	if (err) {
++		if (instance) {
++			hci_dev_lock(hdev);
++			adv = hci_find_adv_instance(hdev, instance);
++			if (adv)
++				adv->scan_rsp_changed = true;
++			hci_dev_unlock(hdev);
++		}
++
+ 		return err;
++	}
+ 
+-	if (adv) {
+-		adv->scan_rsp_changed = false;
+-	} else {
++	if (!instance) {
+ 		memcpy(hdev->scan_rsp_data, pdu.data, len);
+ 		hdev->scan_rsp_data_len = len;
+ 	}
+@@ -1559,8 +1609,14 @@ static int __hci_set_scan_rsp_data_sync(struct hci_dev *hdev, u8 instance)
+ 
+ 	memset(&cp, 0, sizeof(cp));
+ 
++	if (instance)
++		hci_dev_lock(hdev);
++
+ 	len = eir_create_scan_rsp(hdev, instance, cp.data);
+ 
++	if (instance)
++		hci_dev_unlock(hdev);
++
+ 	if (hdev->scan_rsp_data_len == len &&
+ 	    !memcmp(cp.data, hdev->scan_rsp_data, len))
+ 		return 0;
+@@ -1694,14 +1750,18 @@ static int hci_set_per_adv_data_sync(struct hci_dev *hdev, u8 instance)
+ 		u8 data[HCI_MAX_PER_AD_LENGTH];
+ 	} pdu;
+ 	u8 len;
++	struct adv_info *adv = NULL;
+ 
+ 	memset(&pdu, 0, sizeof(pdu));
+ 
+ 	if (instance) {
+-		struct adv_info *adv = hci_find_adv_instance(hdev, instance);
++		hci_dev_lock(hdev);
+ 
+-		if (!adv || !adv->periodic)
++		adv = hci_find_adv_instance(hdev, instance);
++		if (!adv || !adv->periodic) {
++			hci_dev_unlock(hdev);
+ 			return 0;
++		}
+ 	}
+ 
+ 	len = eir_create_per_adv_data(hdev, instance, pdu.data);
+@@ -1710,6 +1770,9 @@ static int hci_set_per_adv_data_sync(struct hci_dev *hdev, u8 instance)
+ 	pdu.cp.handle = instance;
+ 	pdu.cp.operation = LE_SET_ADV_DATA_OP_COMPLETE;
+ 
++	if (adv)
++		hci_dev_unlock(hdev);
++
+ 	return __hci_cmd_sync_status(hdev, HCI_OP_LE_SET_PER_ADV_DATA,
+ 				     sizeof(pdu.cp) + len, &pdu,
+ 				     HCI_CMD_TIMEOUT);
+@@ -6414,7 +6477,7 @@ static int hci_le_ext_directed_advertising_sync(struct hci_dev *hdev,
+ 	if (err)
+ 		return err;
+ 
+-	err = hci_set_ext_adv_params_sync(hdev, NULL, &cp, &rp);
++	err = hci_set_ext_adv_params_sync(hdev, 0, &cp, &rp);
+ 	if (err)
+ 		return err;
+ 
+diff --git a/net/bluetooth/rfcomm/core.c b/net/bluetooth/rfcomm/core.c
+index 41a6eda1a1498e..fbc165aff369e4 100644
+--- a/net/bluetooth/rfcomm/core.c
++++ b/net/bluetooth/rfcomm/core.c
+@@ -1334,7 +1334,10 @@ static struct rfcomm_session *rfcomm_recv_disc(struct rfcomm_session *s,
+ 	return s;
+ }
+ 
+-void rfcomm_dlc_accept(struct rfcomm_dlc *d)
++/* Must be called with rfcomm_mutex held, so that the session cannot be
++ * unlinked from under us.
++ */
++static void __rfcomm_dlc_accept(struct rfcomm_dlc *d)
+ {
+ 	struct sock *sk = d->session->sock->sk;
+ 	struct l2cap_conn *conn = l2cap_pi(sk)->chan->conn;
+@@ -1356,6 +1359,21 @@ void rfcomm_dlc_accept(struct rfcomm_dlc *d)
+ 	rfcomm_send_msc(d->session, 1, d->dlci, d->v24_sig);
+ }
+ 
++void rfcomm_dlc_accept(struct rfcomm_dlc *d)
++{
++	rfcomm_lock();
++
++	/* rfcomm_recv_disc() sets the dlc state to BT_CLOSED before calling
++	 * __rfcomm_dlc_close(), so the RFCOMM_DEFER_SETUP handshake there is
++	 * skipped and the session can already be unlinked by the time the
++	 * deferred accept runs from rfcomm_sock_recvmsg().
++	 */
++	if (d->session)
++		__rfcomm_dlc_accept(d);
++
++	rfcomm_unlock();
++}
++
+ static void rfcomm_check_accept(struct rfcomm_dlc *d)
+ {
+ 	if (rfcomm_check_security(d)) {
+@@ -1368,7 +1386,7 @@ static void rfcomm_check_accept(struct rfcomm_dlc *d)
+ 			d->state_change(d, 0);
+ 			rfcomm_dlc_unlock(d);
+ 		} else
+-			rfcomm_dlc_accept(d);
++			__rfcomm_dlc_accept(d);
+ 	} else {
+ 		set_bit(RFCOMM_AUTH_PENDING, &d->flags);
+ 		rfcomm_dlc_set_timer(d, RFCOMM_AUTH_TIMEOUT);
+@@ -1953,7 +1971,7 @@ static void rfcomm_process_dlcs(struct rfcomm_session *s)
+ 					d->state_change(d, 0);
+ 					rfcomm_dlc_unlock(d);
+ 				} else
+-					rfcomm_dlc_accept(d);
++					__rfcomm_dlc_accept(d);
+ 			}
+ 			continue;
+ 		} else if (test_and_clear_bit(RFCOMM_AUTH_REJECT, &d->flags)) {
+diff --git a/net/ceph/osd_client.c b/net/ceph/osd_client.c
+index a86ba8b7857546..8c1678f10440ce 100644
+--- a/net/ceph/osd_client.c
++++ b/net/ceph/osd_client.c
+@@ -5090,7 +5090,7 @@ static int decode_watchers(void **p, void *end,
+ 	if (ret)
+ 		return ret;
+ 
+-	*num_watchers = ceph_decode_32(p);
++	ceph_decode_32_safe(p, end, *num_watchers, bad);
+ 	*watchers = kcalloc(*num_watchers, sizeof(**watchers), GFP_NOIO);
+ 	if (!*watchers)
+ 		return -ENOMEM;
+@@ -5104,6 +5104,9 @@ static int decode_watchers(void **p, void *end,
+ 	}
+ 
+ 	return 0;
++
++bad:
++	return -EINVAL;
+ }
+ 
+ /*
+diff --git a/net/core/gro.c b/net/core/gro.c
+index e9ed98dc628d82..79f7a9d277a957 100644
+--- a/net/core/gro.c
++++ b/net/core/gro.c
+@@ -119,9 +119,12 @@ int skb_gro_receive(struct sk_buff *p, struct sk_buff *skb)
+ 
+ 	if (unlikely(p->len + len >= GRO_LEGACY_MAX_SIZE)) {
+ 		if (NAPI_GRO_CB(skb)->proto != IPPROTO_TCP ||
++		    NAPI_GRO_CB(skb)->encap_mark ||
++		    p->encapsulation ||
+ 		    (p->protocol == htons(ETH_P_IPV6) &&
+-		     skb_headroom(p) < sizeof(struct hop_jumbo_hdr)) ||
+-		    p->encapsulation)
++		     p->mac_header < sizeof(struct hop_jumbo_hdr)) ||
++		    (p->protocol != htons(ETH_P_IPV6) &&
++		     p->protocol != htons(ETH_P_IP)))
+ 			return -E2BIG;
+ 	}
+ 
+diff --git a/net/ieee802154/6lowpan/reassembly.c b/net/ieee802154/6lowpan/reassembly.c
+index 26506dd4b357d3..ea5dbcc300b153 100644
+--- a/net/ieee802154/6lowpan/reassembly.c
++++ b/net/ieee802154/6lowpan/reassembly.c
+@@ -31,7 +31,8 @@ static const char lowpan_frags_cache_name[] = "lowpan-frags";
+ static struct inet_frags lowpan_frags;
+ 
+ static int lowpan_frag_reasm(struct lowpan_frag_queue *fq, struct sk_buff *skb,
+-			     struct sk_buff *prev,  struct net_device *ldev);
++			     struct sk_buff *prev, struct net_device *ldev,
++			     int *refs);
+ 
+ static void lowpan_frag_init(struct inet_frag_queue *q, const void *a)
+ {
+@@ -45,6 +46,7 @@ static void lowpan_frag_expire(struct timer_list *t)
+ {
+ 	struct inet_frag_queue *frag = from_timer(frag, t, timer);
+ 	struct frag_queue *fq;
++	int refs = 1;
+ 
+ 	fq = container_of(frag, struct frag_queue, q);
+ 
+@@ -53,10 +55,10 @@ static void lowpan_frag_expire(struct timer_list *t)
+ 	if (fq->q.flags & INET_FRAG_COMPLETE)
+ 		goto out;
+ 
+-	inet_frag_kill(&fq->q);
++	inet_frag_kill(&fq->q, &refs);
+ out:
+ 	spin_unlock(&fq->q.lock);
+-	inet_frag_put(&fq->q);
++	inet_frag_putn(&fq->q, refs);
+ }
+ 
+ static inline struct lowpan_frag_queue *
+@@ -82,7 +84,8 @@ fq_find(struct net *net, const struct lowpan_802154_cb *cb,
+ }
+ 
+ static int lowpan_frag_queue(struct lowpan_frag_queue *fq,
+-			     struct sk_buff *skb, u8 frag_type)
++			     struct sk_buff *skb, u8 frag_type,
++			     int *refs)
+ {
+ 	struct sk_buff *prev_tail;
+ 	struct net_device *ldev;
+@@ -143,7 +146,7 @@ static int lowpan_frag_queue(struct lowpan_frag_queue *fq,
+ 		unsigned long orefdst = skb->_skb_refdst;
+ 
+ 		skb->_skb_refdst = 0UL;
+-		res = lowpan_frag_reasm(fq, skb, prev_tail, ldev);
++		res = lowpan_frag_reasm(fq, skb, prev_tail, ldev, refs);
+ 		skb->_skb_refdst = orefdst;
+ 		return res;
+ 	}
+@@ -162,11 +165,12 @@ err:
+  *	the last and the first frames arrived and all the bits are here.
+  */
+ static int lowpan_frag_reasm(struct lowpan_frag_queue *fq, struct sk_buff *skb,
+-			     struct sk_buff *prev_tail, struct net_device *ldev)
++			     struct sk_buff *prev_tail, struct net_device *ldev,
++			     int *refs)
+ {
+ 	void *reasm_data;
+ 
+-	inet_frag_kill(&fq->q);
++	inet_frag_kill(&fq->q, refs);
+ 
+ 	reasm_data = inet_frag_reasm_prepare(&fq->q, skb, prev_tail);
+ 	if (!reasm_data)
+@@ -300,17 +304,20 @@ int lowpan_frag_rcv(struct sk_buff *skb, u8 frag_type)
+ 		goto err;
+ 	}
+ 
++	rcu_read_lock();
+ 	fq = fq_find(net, cb, &hdr.source, &hdr.dest);
+ 	if (fq != NULL) {
+-		int ret;
++		int ret, refs = 0;
+ 
+ 		spin_lock(&fq->q.lock);
+-		ret = lowpan_frag_queue(fq, skb, frag_type);
++		ret = lowpan_frag_queue(fq, skb, frag_type, &refs);
+ 		spin_unlock(&fq->q.lock);
+ 
+-		inet_frag_put(&fq->q);
++		rcu_read_unlock();
++		inet_frag_putn(&fq->q, refs);
+ 		return ret;
+ 	}
++	rcu_read_unlock();
+ 
+ err:
+ 	kfree_skb(skb);
+diff --git a/net/ipv4/inet_fragment.c b/net/ipv4/inet_fragment.c
+index 00a4a7ac0d322d..1299413bc9804d 100644
+--- a/net/ipv4/inet_fragment.c
++++ b/net/ipv4/inet_fragment.c
+@@ -145,8 +145,7 @@ static void inet_frags_free_cb(void *ptr, void *arg)
+ 	}
+ 	spin_unlock_bh(&fq->lock);
+ 
+-	if (refcount_sub_and_test(count, &fq->refcnt))
+-		inet_frag_destroy(fq);
++	inet_frag_putn(fq, count);
+ }
+ 
+ static LLIST_HEAD(fqdir_free_list);
+@@ -261,10 +260,10 @@ void fqdir_exit(struct fqdir *fqdir)
+ }
+ EXPORT_SYMBOL(fqdir_exit);
+ 
+-void inet_frag_kill(struct inet_frag_queue *fq)
++void inet_frag_kill(struct inet_frag_queue *fq, int *refs)
+ {
+ 	if (del_timer(&fq->timer))
+-		refcount_dec(&fq->refcnt);
++		(*refs)++;
+ 
+ 	if (!(fq->flags & INET_FRAG_COMPLETE)) {
+ 		struct fqdir *fqdir = fq->fqdir;
+@@ -279,7 +278,7 @@ void inet_frag_kill(struct inet_frag_queue *fq)
+ 		if (!READ_ONCE(fqdir->dead)) {
+ 			rhashtable_remove_fast(&fqdir->rhashtable, &fq->node,
+ 					       fqdir->f->rhash_params);
+-			refcount_dec(&fq->refcnt);
++			(*refs)++;
+ 		} else {
+ 			fq->flags |= INET_FRAG_HASH_DEAD;
+ 		}
+@@ -376,7 +375,8 @@ static struct inet_frag_queue *inet_frag_alloc(struct fqdir *fqdir,
+ 
+ 	timer_setup(&q->timer, f->frag_expire, 0);
+ 	spin_lock_init(&q->lock);
+-	refcount_set(&q->refcnt, 3);
++	/* One reference for the timer, one for the hash table. */
++	refcount_set(&q->refcnt, 2);
+ 
+ 	return q;
+ }
+@@ -393,20 +393,25 @@ static struct inet_frag_queue *inet_frag_create(struct fqdir *fqdir,
+ 		*prev = ERR_PTR(-ENOMEM);
+ 		return NULL;
+ 	}
+-	mod_timer(&q->timer, jiffies + fqdir->timeout);
+ 
++	spin_lock_bh(&q->lock);
+ 	*prev = rhashtable_lookup_get_insert_key(&fqdir->rhashtable, &q->key,
+ 						 &q->node, f->rhash_params);
+ 	if (*prev) {
++		/* We could not insert in the hash table,
++		 * we need to cancel what inet_frag_alloc()
++		 * anticipated.
++		 */
+ 		q->flags |= INET_FRAG_COMPLETE;
+-		inet_frag_kill(q);
+-		inet_frag_destroy(q);
++		spin_unlock_bh(&q->lock);
++		inet_frag_putn(q, 2);
+ 		return NULL;
+ 	}
++	mod_timer(&q->timer, jiffies + fqdir->timeout);
++	spin_unlock_bh(&q->lock);
+ 	return q;
+ }
+ 
+-/* TODO : call from rcu_read_lock() and no longer use refcount_inc_not_zero() */
+ struct inet_frag_queue *inet_frag_find(struct fqdir *fqdir, void *key)
+ {
+ 	/* This pairs with WRITE_ONCE() in fqdir_pre_exit(). */
+@@ -416,17 +421,11 @@ struct inet_frag_queue *inet_frag_find(struct fqdir *fqdir, void *key)
+ 	if (!high_thresh || frag_mem_limit(fqdir) > high_thresh)
+ 		return NULL;
+ 
+-	rcu_read_lock();
+-
+ 	prev = rhashtable_lookup(&fqdir->rhashtable, key, fqdir->f->rhash_params);
+ 	if (!prev)
+ 		fq = inet_frag_create(fqdir, key, &prev);
+-	if (!IS_ERR_OR_NULL(prev)) {
++	if (!IS_ERR_OR_NULL(prev))
+ 		fq = prev;
+-		if (!refcount_inc_not_zero(&fq->refcnt))
+-			fq = NULL;
+-	}
+-	rcu_read_unlock();
+ 	return fq;
+ }
+ EXPORT_SYMBOL(inet_frag_find);
+diff --git a/net/ipv4/ip_fragment.c b/net/ipv4/ip_fragment.c
+index 66bd7e29f4c71e..8524f2ac2cf3a5 100644
+--- a/net/ipv4/ip_fragment.c
++++ b/net/ipv4/ip_fragment.c
+@@ -76,7 +76,8 @@ static u8 ip4_frag_ecn(u8 tos)
+ static struct inet_frags ip4_frags;
+ 
+ static int ip_frag_reasm(struct ipq *qp, struct sk_buff *skb,
+-			 struct sk_buff *prev_tail, struct net_device *dev);
++			 struct sk_buff *prev_tail, struct net_device *dev,
++			 int *refs);
+ 
+ 
+ static void ip4_frag_init(struct inet_frag_queue *q, const void *a)
+@@ -107,22 +108,6 @@ static void ip4_frag_free(struct inet_frag_queue *q)
+ 		inet_putpeer(qp->peer);
+ }
+ 
+-
+-/* Destruction primitives. */
+-
+-static void ipq_put(struct ipq *ipq)
+-{
+-	inet_frag_put(&ipq->q);
+-}
+-
+-/* Kill ipq entry. It is not destroyed immediately,
+- * because caller (and someone more) holds reference count.
+- */
+-static void ipq_kill(struct ipq *ipq)
+-{
+-	inet_frag_kill(&ipq->q);
+-}
+-
+ static bool frag_expire_skip_icmp(u32 user)
+ {
+ 	return user == IP_DEFRAG_AF_PACKET ||
+@@ -142,6 +127,7 @@ static void ip_expire(struct timer_list *t)
+ 	struct sk_buff *head = NULL;
+ 	struct net *net;
+ 	struct ipq *qp;
++	int refs = 1;
+ 	int err;
+ 
+ 	qp = container_of(frag, struct ipq, q);
+@@ -154,7 +140,7 @@ static void ip_expire(struct timer_list *t)
+ 		goto out;
+ 
+ 	qp->q.flags |= INET_FRAG_DROP;
+-	ipq_kill(qp);
++	inet_frag_kill(&qp->q, &refs);
+ 
+ 	/* Paired with WRITE_ONCE() in fqdir_pre_exit(). */
+ 	if (READ_ONCE(qp->q.fqdir->dead)) {
+@@ -203,7 +189,7 @@ out:
+ out_rcu_unlock:
+ 	rcu_read_unlock();
+ 	kfree_skb_reason(head, SKB_DROP_REASON_FRAG_REASM_TIMEOUT);
+-	ipq_put(qp);
++	inet_frag_putn(&qp->q, refs);
+ }
+ 
+ /* Find the correct entry in the "incomplete datagrams" queue for
+@@ -272,7 +258,7 @@ static int ip_frag_reinit(struct ipq *qp)
+ }
+ 
+ /* Add new segment to existing queue. */
+-static int ip_frag_queue(struct ipq *qp, struct sk_buff *skb)
++static int ip_frag_queue(struct ipq *qp, struct sk_buff *skb, int *refs)
+ {
+ 	struct net *net = qp->q.fqdir->net;
+ 	int ihl, end, flags, offset;
+@@ -292,7 +278,7 @@ static int ip_frag_queue(struct ipq *qp, struct sk_buff *skb)
+ 	if (!(IPCB(skb)->flags & IPSKB_FRAG_COMPLETE) &&
+ 	    unlikely(ip_frag_too_far(qp)) &&
+ 	    unlikely(err = ip_frag_reinit(qp))) {
+-		ipq_kill(qp);
++		inet_frag_kill(&qp->q, refs);
+ 		goto err;
+ 	}
+ 
+@@ -376,10 +362,10 @@ static int ip_frag_queue(struct ipq *qp, struct sk_buff *skb)
+ 		unsigned long orefdst = skb->_skb_refdst;
+ 
+ 		skb->_skb_refdst = 0UL;
+-		err = ip_frag_reasm(qp, skb, prev_tail, dev);
++		err = ip_frag_reasm(qp, skb, prev_tail, dev, refs);
+ 		skb->_skb_refdst = orefdst;
+ 		if (err)
+-			inet_frag_kill(&qp->q);
++			inet_frag_kill(&qp->q, refs);
+ 		return err;
+ 	}
+ 
+@@ -396,7 +382,7 @@ insert_error:
+ 	err = -EINVAL;
+ 	__IP_INC_STATS(net, IPSTATS_MIB_REASM_OVERLAPS);
+ discard_qp:
+-	inet_frag_kill(&qp->q);
++	inet_frag_kill(&qp->q, refs);
+ 	__IP_INC_STATS(net, IPSTATS_MIB_REASMFAILS);
+ err:
+ 	kfree_skb_reason(skb, reason);
+@@ -410,7 +396,8 @@ static bool ip_frag_coalesce_ok(const struct ipq *qp)
+ 
+ /* Build a new IP datagram from all its fragments. */
+ static int ip_frag_reasm(struct ipq *qp, struct sk_buff *skb,
+-			 struct sk_buff *prev_tail, struct net_device *dev)
++			 struct sk_buff *prev_tail, struct net_device *dev,
++			 int *refs)
+ {
+ 	struct net *net = qp->q.fqdir->net;
+ 	struct iphdr *iph;
+@@ -418,7 +405,7 @@ static int ip_frag_reasm(struct ipq *qp, struct sk_buff *skb,
+ 	int len, err;
+ 	u8 ecn;
+ 
+-	ipq_kill(qp);
++	inet_frag_kill(&qp->q, refs);
+ 
+ 	ecn = ip_frag_ecn_table[qp->ecn];
+ 	if (unlikely(ecn == 0xff)) {
+@@ -490,18 +477,21 @@ int ip_defrag(struct net *net, struct sk_buff *skb, u32 user)
+ 	__IP_INC_STATS(net, IPSTATS_MIB_REASMREQDS);
+ 
+ 	/* Lookup (or create) queue header */
++	rcu_read_lock();
+ 	qp = ip_find(net, ip_hdr(skb), user, vif);
+ 	if (qp) {
+-		int ret;
++		int ret, refs = 0;
+ 
+ 		spin_lock(&qp->q.lock);
+ 
+-		ret = ip_frag_queue(qp, skb);
++		ret = ip_frag_queue(qp, skb, &refs);
+ 
+ 		spin_unlock(&qp->q.lock);
+-		ipq_put(qp);
++		rcu_read_unlock();
++		inet_frag_putn(&qp->q, refs);
+ 		return ret;
+ 	}
++	rcu_read_unlock();
+ 
+ 	__IP_INC_STATS(net, IPSTATS_MIB_REASMFAILS);
+ 	kfree_skb(skb);
+diff --git a/net/ipv4/ip_output.c b/net/ipv4/ip_output.c
+index 8502cd34b578c0..150cdea8aacbe2 100644
+--- a/net/ipv4/ip_output.c
++++ b/net/ipv4/ip_output.c
+@@ -797,6 +797,10 @@ int ip_do_fragment(struct net *net, struct sock *sk, struct sk_buff *skb,
+ 	 */
+ 
+ 	hlen = iph->ihl * 4;
++	if (mtu < hlen + 8) {
++		err = -EMSGSIZE;
++		goto fail;
++	}
+ 	mtu = mtu - hlen;	/* Size of data space */
+ 	IPCB(skb)->flags |= IPSKB_FRAG_COMPLETE;
+ 	ll_rs = LL_RESERVED_SPACE(rt->dst.dev);
+diff --git a/net/ipv6/ip6_output.c b/net/ipv6/ip6_output.c
+index 5ee625d81942a8..2d18b2dcbafb1e 100644
+--- a/net/ipv6/ip6_output.c
++++ b/net/ipv6/ip6_output.c
+@@ -119,6 +119,8 @@ static int ip6_finish_output2(struct net *net, struct sock *sk, struct sk_buff *
+ 
+ 		if (res != LWTUNNEL_XMIT_CONTINUE)
+ 			return res;
++		hdr = ipv6_hdr(skb);
++		daddr = &hdr->daddr;
+ 	}
+ 
+ 	IP6_UPD_PO_STATS(net, idev, IPSTATS_MIB_OUT, skb->len);
+diff --git a/net/ipv6/ndisc.c b/net/ipv6/ndisc.c
+index 8adb31804f01bd..ab5d38906c4e88 100644
+--- a/net/ipv6/ndisc.c
++++ b/net/ipv6/ndisc.c
+@@ -1675,7 +1675,7 @@ static void ndisc_fill_redirect_hdr_option(struct sk_buff *skb,
+ void ndisc_send_redirect(struct sk_buff *skb, const struct in6_addr *target)
+ {
+ 	struct net_device *dev = skb->dev;
+-	struct net *net = dev_net(dev);
++	struct net *net = dev_net_rcu(dev);
+ 	struct sock *sk = net->ipv6.ndisc_sk;
+ 	int optlen = 0;
+ 	struct inet_peer *peer;
+@@ -1690,8 +1690,8 @@ void ndisc_send_redirect(struct sk_buff *skb, const struct in6_addr *target)
+ 	   ops_data_buf[NDISC_OPS_REDIRECT_DATA_SPACE], *ops_data = NULL;
+ 	bool ret;
+ 
+-	if (netif_is_l3_master(skb->dev)) {
+-		dev = dev_get_by_index_rcu(dev_net(skb->dev), IPCB(skb)->iif);
++	if (netif_is_l3_master(dev)) {
++		dev = dev_get_by_index_rcu(net, IPCB(skb)->iif);
+ 		if (!dev)
+ 			return;
+ 	}
+@@ -1729,12 +1729,10 @@ void ndisc_send_redirect(struct sk_buff *skb, const struct in6_addr *target)
+ 		goto release;
+ 	}
+ 
+-	rcu_read_lock();
+ 	peer = inet_getpeer_v6(net->ipv6.peers, &ipv6_hdr(skb)->saddr);
+ 	if (!peer)
+ 		goto release;
+ 	ret = inet_peer_xrlim_allow(peer, 1*HZ);
+-	rcu_read_unlock();
+ 
+ 	if (!ret)
+ 		goto release;
+diff --git a/net/ipv6/netfilter/nf_conntrack_reasm.c b/net/ipv6/netfilter/nf_conntrack_reasm.c
+index aee6d8eee8c9f9..662e3c78b741d7 100644
+--- a/net/ipv6/netfilter/nf_conntrack_reasm.c
++++ b/net/ipv6/netfilter/nf_conntrack_reasm.c
+@@ -124,7 +124,8 @@ static void __net_exit nf_ct_frags6_sysctl_unregister(struct net *net)
+ #endif
+ 
+ static int nf_ct_frag6_reasm(struct frag_queue *fq, struct sk_buff *skb,
+-			     struct sk_buff *prev_tail, struct net_device *dev);
++			     struct sk_buff *prev_tail, struct net_device *dev,
++			     int *refs);
+ 
+ static inline u8 ip6_frag_ecn(const struct ipv6hdr *ipv6h)
+ {
+@@ -168,7 +169,8 @@ static struct frag_queue *fq_find(struct net *net, __be32 id, u32 user,
+ 
+ 
+ static int nf_ct_frag6_queue(struct frag_queue *fq, struct sk_buff *skb,
+-			     const struct frag_hdr *fhdr, int nhoff)
++			     const struct frag_hdr *fhdr, int nhoff,
++			     int *refs)
+ {
+ 	unsigned int payload_len;
+ 	struct net_device *dev;
+@@ -222,7 +224,7 @@ static int nf_ct_frag6_queue(struct frag_queue *fq, struct sk_buff *skb,
+ 			 * this case. -DaveM
+ 			 */
+ 			pr_debug("end of fragment not rounded to 8 bytes.\n");
+-			inet_frag_kill(&fq->q);
++			inet_frag_kill(&fq->q, refs);
+ 			return -EPROTO;
+ 		}
+ 		if (end > fq->q.len) {
+@@ -288,7 +290,7 @@ static int nf_ct_frag6_queue(struct frag_queue *fq, struct sk_buff *skb,
+ 		unsigned long orefdst = skb->_skb_refdst;
+ 
+ 		skb->_skb_refdst = 0UL;
+-		err = nf_ct_frag6_reasm(fq, skb, prev, dev);
++		err = nf_ct_frag6_reasm(fq, skb, prev, dev, refs);
+ 		skb->_skb_refdst = orefdst;
+ 
+ 		/* After queue has assumed skb ownership, only 0 or
+@@ -302,7 +304,7 @@ static int nf_ct_frag6_queue(struct frag_queue *fq, struct sk_buff *skb,
+ 	return -EINPROGRESS;
+ 
+ insert_error:
+-	inet_frag_kill(&fq->q);
++	inet_frag_kill(&fq->q, refs);
+ err:
+ 	skb_dst_drop(skb);
+ 	return -EINVAL;
+@@ -316,13 +318,14 @@ err:
+  *	the last and the first frames arrived and all the bits are here.
+  */
+ static int nf_ct_frag6_reasm(struct frag_queue *fq, struct sk_buff *skb,
+-			     struct sk_buff *prev_tail, struct net_device *dev)
++			     struct sk_buff *prev_tail, struct net_device *dev,
++			     int *refs)
+ {
+ 	void *reasm_data;
+ 	int payload_len;
+ 	u8 ecn;
+ 
+-	inet_frag_kill(&fq->q);
++	inet_frag_kill(&fq->q, refs);
+ 
+ 	ecn = ip_frag_ecn_table[fq->ecn];
+ 	if (unlikely(ecn == 0xff))
+@@ -374,7 +377,7 @@ static int nf_ct_frag6_reasm(struct frag_queue *fq, struct sk_buff *skb,
+ 	return 0;
+ 
+ err:
+-	inet_frag_kill(&fq->q);
++	inet_frag_kill(&fq->q, refs);
+ 	return -EINVAL;
+ }
+ 
+@@ -449,6 +452,7 @@ int nf_ct_frag6_gather(struct net *net, struct sk_buff *skb, u32 user)
+ 	struct frag_hdr *fhdr;
+ 	struct frag_queue *fq;
+ 	struct ipv6hdr *hdr;
++	int refs = 0;
+ 	u8 prevhdr;
+ 
+ 	/* Jumbo payload inhibits frag. header */
+@@ -475,23 +479,26 @@ int nf_ct_frag6_gather(struct net *net, struct sk_buff *skb, u32 user)
+ 	hdr = ipv6_hdr(skb);
+ 	fhdr = (struct frag_hdr *)skb_transport_header(skb);
+ 
++	rcu_read_lock();
+ 	fq = fq_find(net, fhdr->identification, user, hdr,
+ 		     skb->dev ? skb->dev->ifindex : 0);
+ 	if (fq == NULL) {
++		rcu_read_unlock();
+ 		pr_debug("Can't find and can't create new queue\n");
+ 		return -ENOMEM;
+ 	}
+ 
+ 	spin_lock_bh(&fq->q.lock);
+ 
+-	ret = nf_ct_frag6_queue(fq, skb, fhdr, nhoff);
++	ret = nf_ct_frag6_queue(fq, skb, fhdr, nhoff, &refs);
+ 	if (ret == -EPROTO) {
+ 		skb->transport_header = savethdr;
+ 		ret = 0;
+ 	}
+ 
+ 	spin_unlock_bh(&fq->q.lock);
+-	inet_frag_put(&fq->q);
++	rcu_read_unlock();
++	inet_frag_putn(&fq->q, refs);
+ 	return ret;
+ }
+ EXPORT_SYMBOL_GPL(nf_ct_frag6_gather);
+diff --git a/net/ipv6/reassembly.c b/net/ipv6/reassembly.c
+index 225a23f7fefa72..359b0b4ec1bbc6 100644
+--- a/net/ipv6/reassembly.c
++++ b/net/ipv6/reassembly.c
+@@ -68,7 +68,8 @@ static u8 ip6_frag_ecn(const struct ipv6hdr *ipv6h)
+ static struct inet_frags ip6_frags;
+ 
+ static int ip6_frag_reasm(struct frag_queue *fq, struct sk_buff *skb,
+-			  struct sk_buff *prev_tail, struct net_device *dev);
++			  struct sk_buff *prev_tail, struct net_device *dev,
++			  int *refs);
+ 
+ static void ip6_frag_expire(struct timer_list *t)
+ {
+@@ -105,7 +106,7 @@ fq_find(struct net *net, __be32 id, const struct ipv6hdr *hdr, int iif)
+ 
+ static int ip6_frag_queue(struct frag_queue *fq, struct sk_buff *skb,
+ 			  struct frag_hdr *fhdr, int nhoff,
+-			  u32 *prob_offset)
++			  u32 *prob_offset, int *refs)
+ {
+ 	struct net *net = dev_net(skb_dst(skb)->dev);
+ 	int offset, end, fragsize;
+@@ -220,7 +221,7 @@ static int ip6_frag_queue(struct frag_queue *fq, struct sk_buff *skb,
+ 		unsigned long orefdst = skb->_skb_refdst;
+ 
+ 		skb->_skb_refdst = 0UL;
+-		err = ip6_frag_reasm(fq, skb, prev_tail, dev);
++		err = ip6_frag_reasm(fq, skb, prev_tail, dev, refs);
+ 		skb->_skb_refdst = orefdst;
+ 		return err;
+ 	}
+@@ -238,7 +239,7 @@ insert_error:
+ 	__IP6_INC_STATS(net, ip6_dst_idev(skb_dst(skb)),
+ 			IPSTATS_MIB_REASM_OVERLAPS);
+ discard_fq:
+-	inet_frag_kill(&fq->q);
++	inet_frag_kill(&fq->q, refs);
+ 	__IP6_INC_STATS(net, ip6_dst_idev(skb_dst(skb)),
+ 			IPSTATS_MIB_REASMFAILS);
+ err:
+@@ -254,7 +255,8 @@ err:
+  *	the last and the first frames arrived and all the bits are here.
+  */
+ static int ip6_frag_reasm(struct frag_queue *fq, struct sk_buff *skb,
+-			  struct sk_buff *prev_tail, struct net_device *dev)
++			  struct sk_buff *prev_tail, struct net_device *dev,
++			  int *refs)
+ {
+ 	struct net *net = fq->q.fqdir->net;
+ 	unsigned int nhoff;
+@@ -262,7 +264,7 @@ static int ip6_frag_reasm(struct frag_queue *fq, struct sk_buff *skb,
+ 	int payload_len;
+ 	u8 ecn;
+ 
+-	inet_frag_kill(&fq->q);
++	inet_frag_kill(&fq->q, refs);
+ 
+ 	ecn = ip_frag_ecn_table[fq->ecn];
+ 	if (unlikely(ecn == 0xff))
+@@ -303,9 +305,7 @@ static int ip6_frag_reasm(struct frag_queue *fq, struct sk_buff *skb,
+ 	skb_postpush_rcsum(skb, skb_network_header(skb),
+ 			   skb_network_header_len(skb));
+ 
+-	rcu_read_lock();
+ 	__IP6_INC_STATS(net, __in6_dev_stats_get(dev, skb), IPSTATS_MIB_REASMOKS);
+-	rcu_read_unlock();
+ 	fq->q.rb_fragments = RB_ROOT;
+ 	fq->q.fragments_tail = NULL;
+ 	fq->q.last_run_head = NULL;
+@@ -317,10 +317,8 @@ out_oversize:
+ out_oom:
+ 	net_dbg_ratelimited("ip6_frag_reasm: no memory for reassembly\n");
+ out_fail:
+-	rcu_read_lock();
+ 	__IP6_INC_STATS(net, __in6_dev_stats_get(dev, skb), IPSTATS_MIB_REASMFAILS);
+-	rcu_read_unlock();
+-	inet_frag_kill(&fq->q);
++	inet_frag_kill(&fq->q, refs);
+ 	return -1;
+ }
+ 
+@@ -377,19 +375,21 @@ static int ipv6_frag_rcv(struct sk_buff *skb)
+ 	}
+ 
+ 	iif = skb->dev ? skb->dev->ifindex : 0;
++	rcu_read_lock();
+ 	fq = fq_find(net, fhdr->identification, hdr, iif);
+ 	if (fq) {
+ 		u32 prob_offset = 0;
+-		int ret;
++		int ret, refs = 0;
+ 
+ 		spin_lock(&fq->q.lock);
+ 
+ 		fq->iif = iif;
+ 		ret = ip6_frag_queue(fq, skb, fhdr, IP6CB(skb)->nhoff,
+-				     &prob_offset);
++				     &prob_offset, &refs);
+ 
+ 		spin_unlock(&fq->q.lock);
+-		inet_frag_put(&fq->q);
++		rcu_read_unlock();
++		inet_frag_putn(&fq->q, refs);
+ 		if (prob_offset) {
+ 			__IP6_INC_STATS(net, __in6_dev_get_safely(skb->dev),
+ 					IPSTATS_MIB_INHDRERRORS);
+@@ -398,6 +398,7 @@ static int ipv6_frag_rcv(struct sk_buff *skb)
+ 		}
+ 		return ret;
+ 	}
++	rcu_read_unlock();
+ 
+ 	__IP6_INC_STATS(net, ip6_dst_idev(skb_dst(skb)), IPSTATS_MIB_REASMFAILS);
+ 	kfree_skb(skb);
+diff --git a/net/mptcp/pm_netlink.c b/net/mptcp/pm_netlink.c
+index 242011de052a8b..2be19e1877c886 100644
+--- a/net/mptcp/pm_netlink.c
++++ b/net/mptcp/pm_netlink.c
+@@ -297,6 +297,7 @@ static void mptcp_pm_add_timer(struct timer_list *timer)
+ 	struct mptcp_sock *msk = entry->sock;
+ 	struct sock *sk = (struct sock *)msk;
+ 	unsigned int timeout = 0;
++	bool retransmit;
+ 
+ 	pr_debug("msk=%p\n", msk);
+ 
+@@ -334,12 +335,13 @@ static void mptcp_pm_add_timer(struct timer_list *timer)
+ 		entry->retrans_times++;
+ 	}
+ 
+-	if (entry->retrans_times >= ADD_ADDR_RETRANS_MAX)
++	retransmit = entry->retrans_times < ADD_ADDR_RETRANS_MAX;
++	if (!retransmit)
+ 		timeout = 0;
+ 
+ 	spin_unlock_bh(&msk->pm.lock);
+ 
+-	if (entry->retrans_times == ADD_ADDR_RETRANS_MAX)
++	if (!retransmit)
+ 		mptcp_pm_subflow_established(msk);
+ 
+ out:
+@@ -396,6 +398,9 @@ bool mptcp_pm_alloc_anno_list(struct mptcp_sock *msk,
+ 
+ 	lockdep_assert_held(&msk->pm.lock);
+ 
++	if (msk->pm.status & BIT(MPTCP_PM_DESTROYING))
++		return false;
++
+ 	add_entry = mptcp_lookup_anno_list_by_saddr(msk, addr);
+ 
+ 	if (add_entry) {
+diff --git a/net/mptcp/pm_userspace.c b/net/mptcp/pm_userspace.c
+index ded7a4d4169190..12dd30d63c7176 100644
+--- a/net/mptcp/pm_userspace.c
++++ b/net/mptcp/pm_userspace.c
+@@ -13,9 +13,6 @@ void mptcp_free_local_addr_list(struct mptcp_sock *msk)
+ 	struct sock *sk = (struct sock *)msk;
+ 	LIST_HEAD(free_list);
+ 
+-	if (!mptcp_pm_is_userspace(msk))
+-		return;
+-
+ 	spin_lock_bh(&msk->pm.lock);
+ 	list_splice_init(&msk->pm.userspace_pm_local_addr_list, &free_list);
+ 	spin_unlock_bh(&msk->pm.lock);
+@@ -53,6 +50,10 @@ static int mptcp_userspace_pm_append_new_local_addr(struct mptcp_sock *msk,
+ 	bitmap_zero(id_bitmap, MPTCP_PM_MAX_ADDR_ID + 1);
+ 
+ 	spin_lock_bh(&msk->pm.lock);
++	if (msk->pm.status & BIT(MPTCP_PM_DESTROYING)) {
++		ret = -EINVAL;
++		goto append_err;
++	}
+ 	list_for_each_entry(e, &msk->pm.userspace_pm_local_addr_list, list) {
+ 		addr_match = mptcp_addresses_equal(&e->addr, &entry->addr, true);
+ 		if (addr_match && entry->addr.id == 0 && needs_id)
+diff --git a/net/mptcp/protocol.c b/net/mptcp/protocol.c
+index ef7479937ee566..127438ef120e6a 100644
+--- a/net/mptcp/protocol.c
++++ b/net/mptcp/protocol.c
+@@ -3536,7 +3536,16 @@ void mptcp_destroy_common(struct mptcp_sock *msk)
+ 	sk_forward_alloc_add(sk, msk->rmem_fwd_alloc);
+ 	WRITE_ONCE(msk->rmem_fwd_alloc, 0);
+ 	mptcp_token_destroy(msk);
++
++	spin_lock_bh(&msk->pm.lock);
++	msk->pm.status |= BIT(MPTCP_PM_DESTROYING);
++	spin_unlock_bh(&msk->pm.lock);
++
+ 	mptcp_pm_free_anno_list(msk);
++
++	/* Free the userspace local address list unconditionally: the socket
++	 * can be reused (mptcp_disconnect()) and re-selected to a different PM
++	 */
+ 	mptcp_free_local_addr_list(msk);
+ }
+ 
+diff --git a/net/mptcp/protocol.h b/net/mptcp/protocol.h
+index aae8ca0bfabfa4..af00d64e61f4b6 100644
+--- a/net/mptcp/protocol.h
++++ b/net/mptcp/protocol.h
+@@ -190,9 +190,10 @@ enum mptcp_pm_status {
+ 	MPTCP_PM_ESTABLISHED,
+ 	MPTCP_PM_SUBFLOW_ESTABLISHED,
+ 	MPTCP_PM_ALREADY_ESTABLISHED,	/* persistent status, set after ESTABLISHED event */
+-	MPTCP_PM_MPC_ENDPOINT_ACCOUNTED /* persistent status, set after MPC local address is
+-					 * accounted int id_avail_bitmap
+-					 */
++	MPTCP_PM_MPC_ENDPOINT_ACCOUNTED, /* persistent status, set after MPC local address is
++					  * accounted int id_avail_bitmap
++					  */
++	MPTCP_PM_DESTROYING,		/* To fence out PM list allocs */
+ };
+ 
+ enum mptcp_pm_type {
+diff --git a/net/nfc/digital_technology.c b/net/nfc/digital_technology.c
+index e29dd10f280ed7..3c2d225d694a59 100644
+--- a/net/nfc/digital_technology.c
++++ b/net/nfc/digital_technology.c
+@@ -778,6 +778,8 @@ static void digital_in_recv_sensf_res(struct nfc_digital_dev *ddev, void *arg,
+ 
+ 	sensf_res = (struct digital_sensf_res *)resp->data;
+ 
++	resp->len = min_t(unsigned int, resp->len, NFC_SENSF_RES_MAXSIZE);
++
+ 	memcpy(target.sensf_res, sensf_res, resp->len);
+ 	target.sensf_res_len = resp->len;
+ 
+diff --git a/net/nfc/llcp_commands.c b/net/nfc/llcp_commands.c
+index b652323bc2c12b..a93bf0b43d5047 100644
+--- a/net/nfc/llcp_commands.c
++++ b/net/nfc/llcp_commands.c
+@@ -193,7 +193,8 @@ int nfc_llcp_parse_gb_tlv(struct nfc_llcp_local *local,
+ 			  const u8 *tlv_array, u16 tlv_array_len)
+ {
+ 	const u8 *tlv = tlv_array;
+-	u8 type, length, offset = 0;
++	u8 type, length;
++	u16 offset = 0;
+ 
+ 	pr_debug("TLV array length %d\n", tlv_array_len);
+ 
+@@ -201,9 +202,15 @@ int nfc_llcp_parse_gb_tlv(struct nfc_llcp_local *local,
+ 		return -ENODEV;
+ 
+ 	while (offset < tlv_array_len) {
++		if (offset + 2 > tlv_array_len)
++			return -EINVAL;
++
+ 		type = tlv[0];
+ 		length = tlv[1];
+ 
++		if (offset + 2 + length > tlv_array_len)
++			return -EINVAL;
++
+ 		pr_debug("type 0x%x length %d\n", type, length);
+ 
+ 		switch (type) {
+@@ -243,7 +250,8 @@ int nfc_llcp_parse_connection_tlv(struct nfc_llcp_sock *sock,
+ 				  const u8 *tlv_array, u16 tlv_array_len)
+ {
+ 	const u8 *tlv = tlv_array;
+-	u8 type, length, offset = 0;
++	u8 type, length;
++	u16 offset = 0;
+ 
+ 	pr_debug("TLV array length %d\n", tlv_array_len);
+ 
+@@ -251,9 +259,15 @@ int nfc_llcp_parse_connection_tlv(struct nfc_llcp_sock *sock,
+ 		return -ENOTCONN;
+ 
+ 	while (offset < tlv_array_len) {
++		if (offset + 2 > tlv_array_len)
++			return -EINVAL;
++
+ 		type = tlv[0];
+ 		length = tlv[1];
+ 
++		if (offset + 2 + length > tlv_array_len)
++			return -EINVAL;
++
+ 		pr_debug("type 0x%x length %d\n", type, length);
+ 
+ 		switch (type) {
+diff --git a/net/nfc/llcp_core.c b/net/nfc/llcp_core.c
+index 62b0f2d6686eb8..db050f4faa5b6a 100644
+--- a/net/nfc/llcp_core.c
++++ b/net/nfc/llcp_core.c
+@@ -847,13 +847,16 @@ static struct nfc_llcp_sock *nfc_llcp_sock_get_sn(struct nfc_llcp_local *local,
+ static const u8 *nfc_llcp_connect_sn(const struct sk_buff *skb, size_t *sn_len)
+ {
+ 	u8 type, length;
+-	const u8 *tlv = &skb->data[2];
+-	size_t tlv_array_len = skb->len - LLCP_HEADER_SIZE, offset = 0;
++	const u8 *tlv = &skb->data[LLCP_HEADER_SIZE];
++	const u8 *tlv_end = skb_tail_pointer(skb);
+ 
+-	while (offset < tlv_array_len) {
++	while (tlv + 2 < tlv_end) {
+ 		type = tlv[0];
+ 		length = tlv[1];
+ 
++		if (tlv + 2 + length > tlv_end)
++			break;
++
+ 		pr_debug("type 0x%x length %d\n", type, length);
+ 
+ 		if (type == LLCP_TLV_SN) {
+@@ -861,7 +864,6 @@ static const u8 *nfc_llcp_connect_sn(const struct sk_buff *skb, size_t *sn_len)
+ 			return &tlv[2];
+ 		}
+ 
+-		offset += length + 2;
+ 		tlv += length + 2;
+ 	}
+ 
+@@ -1550,6 +1552,11 @@ static void nfc_llcp_rx_work(struct work_struct *work)
+ 
+ static void __nfc_llcp_recv(struct nfc_llcp_local *local, struct sk_buff *skb)
+ {
++	if (!pskb_may_pull(skb, LLCP_HEADER_SIZE)) {
++		kfree_skb(skb);
++		return;
++	}
++
+ 	local->rx_pending = skb;
+ 	del_timer(&local->link_timer);
+ 	schedule_work(&local->rx_work);
+diff --git a/net/nfc/nci/ntf.c b/net/nfc/nci/ntf.c
+index df0f1200082cfd..f97a38b0fcabf8 100644
+--- a/net/nfc/nci/ntf.c
++++ b/net/nfc/nci/ntf.c
+@@ -440,7 +440,7 @@ void nci_clear_target_list(struct nci_dev *ndev)
+ static int nci_rf_discover_ntf_packet(struct nci_dev *ndev,
+ 				      const struct sk_buff *skb)
+ {
+-	struct nci_rf_discover_ntf ntf;
++	struct nci_rf_discover_ntf ntf = {};
+ 	const __u8 *data;
+ 	bool add_target = true;
+ 
+@@ -603,6 +603,12 @@ static void nci_target_auto_activated(struct nci_dev *ndev,
+ 	struct nfc_target *target;
+ 	int rc;
+ 
++	/* This is a new target, check if we've enough room */
++	if (ndev->n_targets == NCI_MAX_DISCOVERED_TARGETS) {
++		pr_debug("not enough room, ignoring new target...\n");
++		return;
++	}
++
+ 	target = &ndev->targets[ndev->n_targets];
+ 
+ 	rc = nci_add_new_protocol(ndev, target, ntf->rf_protocol,
+@@ -666,7 +672,7 @@ static int nci_rf_intf_activated_ntf_packet(struct nci_dev *ndev,
+ 					    const struct sk_buff *skb)
+ {
+ 	struct nci_conn_info *conn_info;
+-	struct nci_rf_intf_activated_ntf ntf;
++	struct nci_rf_intf_activated_ntf ntf = {};
+ 	const __u8 *data;
+ 	int err = NCI_STATUS_OK;
+ 
+diff --git a/net/nfc/nci/rsp.c b/net/nfc/nci/rsp.c
+index b911ab78bed9aa..fccd7ce69bb7b2 100644
+--- a/net/nfc/nci/rsp.c
++++ b/net/nfc/nci/rsp.c
+@@ -336,6 +336,7 @@ static void nci_core_conn_close_rsp_packet(struct nci_dev *ndev,
+ 			list_del(&conn_info->list);
+ 			if (conn_info == ndev->rf_conn_info)
+ 				ndev->rf_conn_info = NULL;
++			devm_kfree(&ndev->nfc_dev->dev, conn_info->dest_params);
+ 			devm_kfree(&ndev->nfc_dev->dev, conn_info);
+ 		}
+ 	}
+diff --git a/net/xfrm/xfrm_state.c b/net/xfrm/xfrm_state.c
+index aab20bc35674e3..c4593f87872fc3 100644
+--- a/net/xfrm/xfrm_state.c
++++ b/net/xfrm/xfrm_state.c
+@@ -2711,7 +2711,7 @@ int xfrm_user_policy(struct sock *sk, int optname, sockptr_t optval, int optlen)
+ 	if (sockptr_is_null(optval) && !optlen) {
+ 		xfrm_sk_policy_insert(sk, XFRM_POLICY_IN, NULL);
+ 		xfrm_sk_policy_insert(sk, XFRM_POLICY_OUT, NULL);
+-		__sk_dst_reset(sk);
++		sk_dst_reset(sk);
+ 		return 0;
+ 	}
+ 
+@@ -2751,7 +2751,7 @@ int xfrm_user_policy(struct sock *sk, int optname, sockptr_t optval, int optlen)
+ 	if (err >= 0) {
+ 		xfrm_sk_policy_insert(sk, err, pol);
+ 		xfrm_pol_put(pol);
+-		__sk_dst_reset(sk);
++		sk_dst_reset(sk);
+ 		err = 0;
+ 	}
+ 
+diff --git a/sound/drivers/dummy.c b/sound/drivers/dummy.c
+index 4317677ba24aaf..1f156cb2d2a47c 100644
+--- a/sound/drivers/dummy.c
++++ b/sound/drivers/dummy.c
+@@ -1025,6 +1025,12 @@ static int snd_dummy_probe(struct platform_device *devptr)
+ 	int idx, err;
+ 	int dev = devptr->id;
+ 
++	if (dev < 0 || dev >= SNDRV_CARDS) {
++		dev_warn(&devptr->dev,
++			 "Invalid card index %d, using default 0\n", dev);
++		dev = 0;
++	}
++
+ 	err = snd_devm_card_new(&devptr->dev, index[dev], id[dev], THIS_MODULE,
+ 				sizeof(struct snd_dummy), &card);
+ 	if (err < 0)
+diff --git a/sound/soc/codecs/lpass-tx-macro.c b/sound/soc/codecs/lpass-tx-macro.c
+index 150ed10c8377ab..4f40eace3a0eee 100644
+--- a/sound/soc/codecs/lpass-tx-macro.c
++++ b/sound/soc/codecs/lpass-tx-macro.c
+@@ -1019,7 +1019,7 @@ static int tx_macro_dec_mode_get(struct snd_kcontrol *kcontrol,
+ 	struct soc_enum *e = (struct soc_enum *)kcontrol->private_value;
+ 	int path = e->shift_l;
+ 
+-	ucontrol->value.integer.value[0] = tx->dec_mode[path];
++	ucontrol->value.enumerated.item[0] = tx->dec_mode[path];
+ 
+ 	return 0;
+ }
+@@ -1028,7 +1028,7 @@ static int tx_macro_dec_mode_put(struct snd_kcontrol *kcontrol,
+ 				 struct snd_ctl_elem_value *ucontrol)
+ {
+ 	struct snd_soc_component *component = snd_soc_kcontrol_component(kcontrol);
+-	int value = ucontrol->value.integer.value[0];
++	int value = ucontrol->value.enumerated.item[0];
+ 	struct soc_enum *e = (struct soc_enum *)kcontrol->private_value;
+ 	int path = e->shift_l;
+ 	struct tx_macro *tx = snd_soc_component_get_drvdata(component);
+diff --git a/sound/soc/sof/ipc3-pcm.c b/sound/soc/sof/ipc3-pcm.c
+index 720bd9bd2667ae..87e2250b4ee4e4 100644
+--- a/sound/soc/sof/ipc3-pcm.c
++++ b/sound/soc/sof/ipc3-pcm.c
+@@ -117,22 +117,23 @@ static int sof_ipc3_pcm_hw_params(struct snd_soc_component *component,
+ 	if (platform_params->cont_update_posn)
+ 		pcm.params.cont_update_posn = 1;
+ 
+-	dev_dbg(component->dev, "stream_tag %d", pcm.params.stream_tag);
++	spcm_dbg(spcm, substream->stream, "stream_tag %d\n",
++		 pcm.params.stream_tag);
+ 
+ 	/* send hw_params IPC to the DSP */
+ 	ret = sof_ipc_tx_message(sdev->ipc, &pcm, sizeof(pcm),
+ 				 &ipc_params_reply, sizeof(ipc_params_reply));
+ 	if (ret < 0) {
+-		dev_err(component->dev, "HW params ipc failed for stream %d\n",
+-			pcm.params.stream_tag);
++		spcm_err(spcm, substream->stream,
++			 "STREAM_PCM_PARAMS ipc failed for stream_tag %d\n",
++			 pcm.params.stream_tag);
+ 		return ret;
+ 	}
+ 
+ 	ret = snd_sof_set_stream_data_offset(sdev, &spcm->stream[substream->stream],
+ 					     ipc_params_reply.posn_offset);
+ 	if (ret < 0) {
+-		dev_err(component->dev, "%s: invalid stream data offset for PCM %d\n",
+-			__func__, spcm->pcm.pcm_id);
++		spcm_err(spcm, substream->stream, "invalid stream data offset\n");
+ 		return ret;
+ 	}
+ 
+@@ -171,7 +172,7 @@ static int sof_ipc3_pcm_trigger(struct snd_soc_component *component,
+ 		stream.hdr.cmd |= SOF_IPC_STREAM_TRIG_STOP;
+ 		break;
+ 	default:
+-		dev_err(component->dev, "Unhandled trigger cmd %d\n", cmd);
++		spcm_err(spcm, substream->stream, "Unhandled trigger cmd %d\n", cmd);
+ 		return -EINVAL;
+ 	}
+ 
+diff --git a/sound/soc/sof/ipc3-topology.c b/sound/soc/sof/ipc3-topology.c
+index 0db8c4b2f0ff2e..7c813e3d09e21a 100644
+--- a/sound/soc/sof/ipc3-topology.c
++++ b/sound/soc/sof/ipc3-topology.c
+@@ -2295,28 +2295,16 @@ static int sof_ipc3_set_up_all_pipelines(struct snd_sof_dev *sdev, bool verify)
+ static int sof_tear_down_left_over_pipelines(struct snd_sof_dev *sdev)
+ {
+ 	struct snd_sof_widget *swidget;
+-	struct snd_sof_pcm *spcm;
+-	int dir, ret;
++	int ret;
+ 
+ 	/*
+ 	 * free all PCMs and their associated DAPM widgets if their connected DAPM widget
+ 	 * list is not NULL. This should only be true for paused streams at this point.
+ 	 * This is equivalent to the handling of FE DAI suspend trigger for running streams.
+ 	 */
+-	list_for_each_entry(spcm, &sdev->pcm_list, list) {
+-		for_each_pcm_streams(dir) {
+-			struct snd_pcm_substream *substream = spcm->stream[dir].substream;
+-
+-			if (!substream || !substream->runtime || spcm->stream[dir].suspend_ignored)
+-				continue;
+-
+-			if (spcm->stream[dir].list) {
+-				ret = sof_pcm_stream_free(sdev, substream, spcm, dir, true);
+-				if (ret < 0)
+-					return ret;
+-			}
+-		}
+-	}
++	ret = sof_pcm_free_all_streams(sdev);
++	if (ret)
++		return ret;
+ 
+ 	/*
+ 	 * free any left over DAI widgets. This is equivalent to the handling of suspend trigger
+diff --git a/sound/soc/sof/ipc4-pcm.c b/sound/soc/sof/ipc4-pcm.c
+index a29632423ccda1..9547437103e5db 100644
+--- a/sound/soc/sof/ipc4-pcm.c
++++ b/sound/soc/sof/ipc4-pcm.c
+@@ -291,12 +291,12 @@ static int sof_ipc4_trigger_pipelines(struct snd_soc_component *component,
+ 	int ret;
+ 	int i;
+ 
+-	dev_dbg(sdev->dev, "trigger cmd: %d state: %d\n", cmd, state);
+-
+ 	spcm = snd_sof_find_spcm_dai(component, rtd);
+ 	if (!spcm)
+ 		return -EINVAL;
+ 
++	spcm_dbg(spcm, substream->stream, "cmd: %d, state: %d\n", cmd, state);
++
+ 	pipeline_list = &spcm->stream[substream->stream].pipeline_list;
+ 
+ 	/* nothing to trigger if the list is empty */
+@@ -358,8 +358,20 @@ static int sof_ipc4_trigger_pipelines(struct snd_soc_component *component,
+ 	 */
+ 	ret = sof_ipc4_set_multi_pipeline_state(sdev, SOF_IPC4_PIPE_PAUSED, trigger_list);
+ 	if (ret < 0) {
+-		dev_err(sdev->dev, "failed to pause all pipelines\n");
+-		goto free;
++		spcm_err(spcm, substream->stream, "failed to pause all pipelines\n");
++		/*
++		 * workaround: if the firmware is crashed or the IPC timed out
++		 * while setting the pipeline state we must ignore the error
++		 * code and proceed to set adjust the local pipeline states.
++		 *
++		 * If the firmware is crashed we will not send IPC messages
++		 * and we are going to see errors printed, but the state of the
++		 * widgets will be correct for the next boot.
++		 */
++		if (sdev->fw_state != SOF_FW_CRASHED && ret != -ETIMEDOUT)
++			goto free;
++
++		ret = 0;
+ 	}
+ 
+ 	/* update PAUSED state for all pipelines just triggered */
+@@ -376,16 +388,19 @@ skip_pause_transition:
+ 	/* else set the RUNNING/RESET state in the DSP */
+ 	ret = sof_ipc4_set_multi_pipeline_state(sdev, state, trigger_list);
+ 	if (ret < 0) {
+-		dev_err(sdev->dev, "failed to set final state %d for all pipelines\n", state);
++		spcm_err(spcm, substream->stream,
++			 "failed to set final state %d for all pipelines\n",
++			 state);
+ 		/*
+-		 * workaround: if the firmware is crashed while setting the
+-		 * pipelines to reset state we must ignore the error code and
+-		 * reset it to 0.
+-		 * Since the firmware is crashed we will not send IPC messages
++		 * workaround: if the firmware is crashed or the IPC timed out
++		 * while setting the pipeline state we must ignore the error
++		 * code and proceed to set adjust the local pipeline states.
++		 *
++		 * If the firmware is crashed we will not send IPC messages
+ 		 * and we are going to see errors printed, but the state of the
+ 		 * widgets will be correct for the next boot.
+ 		 */
+-		if (sdev->fw_state != SOF_FW_CRASHED || state != SOF_IPC4_PIPE_RESET)
++		if (sdev->fw_state != SOF_FW_CRASHED && ret != -ETIMEDOUT)
+ 			goto free;
+ 
+ 		ret = 0;
+diff --git a/sound/soc/sof/ipc4-topology.c b/sound/soc/sof/ipc4-topology.c
+index 43040d4d724bcb..39e4f0fdd5e45a 100644
+--- a/sound/soc/sof/ipc4-topology.c
++++ b/sound/soc/sof/ipc4-topology.c
+@@ -2951,9 +2951,6 @@ static int sof_ipc4_dai_get_clk(struct snd_sof_dev *sdev, struct snd_sof_dai *da
+ 
+ static int sof_ipc4_tear_down_all_pipelines(struct snd_sof_dev *sdev, bool verify)
+ {
+-	struct snd_sof_pcm *spcm;
+-	int dir, ret;
+-
+ 	/*
+ 	 * This function is called during system suspend, we need to make sure
+ 	 * that all streams have been freed up.
+@@ -2965,21 +2962,8 @@ static int sof_ipc4_tear_down_all_pipelines(struct snd_sof_dev *sdev, bool verif
+ 	 *
+ 	 * This will also make sure that paused streams handled correctly.
+ 	 */
+-	list_for_each_entry(spcm, &sdev->pcm_list, list) {
+-		for_each_pcm_streams(dir) {
+-			struct snd_pcm_substream *substream = spcm->stream[dir].substream;
+-
+-			if (!substream || !substream->runtime || spcm->stream[dir].suspend_ignored)
+-				continue;
+ 
+-			if (spcm->stream[dir].list) {
+-				ret = sof_pcm_stream_free(sdev, substream, spcm, dir, true);
+-				if (ret < 0)
+-					return ret;
+-			}
+-		}
+-	}
+-	return 0;
++	return sof_pcm_free_all_streams(sdev);
+ }
+ 
+ static int sof_ipc4_link_setup(struct snd_sof_dev *sdev, struct snd_soc_dai_link *link)
+diff --git a/sound/soc/sof/pcm.c b/sound/soc/sof/pcm.c
+index 7a8eebb078e83d..0db40c262d9d67 100644
+--- a/sound/soc/sof/pcm.c
++++ b/sound/soc/sof/pcm.c
+@@ -99,8 +99,8 @@ sof_pcm_setup_connected_widgets(struct snd_sof_dev *sdev, struct snd_soc_pcm_run
+ 		ret = snd_soc_dapm_dai_get_connected_widgets(dai, dir, &list,
+ 							     dpcm_end_walk_at_be);
+ 		if (ret < 0) {
+-			dev_err(sdev->dev, "error: dai %s has no valid %s path\n", dai->name,
+-				dir == SNDRV_PCM_STREAM_PLAYBACK ? "playback" : "capture");
++			spcm_err(spcm, dir, "dai %s has no valid %s path\n",
++				 dai->name, snd_pcm_direction_name(dir));
+ 			return ret;
+ 		}
+ 
+@@ -108,8 +108,7 @@ sof_pcm_setup_connected_widgets(struct snd_sof_dev *sdev, struct snd_soc_pcm_run
+ 
+ 		ret = sof_widget_list_setup(sdev, spcm, params, platform_params, dir);
+ 		if (ret < 0) {
+-			dev_err(sdev->dev, "error: failed widget list set up for pcm %d dir %d\n",
+-				spcm->pcm.pcm_id, dir);
++			spcm_err(spcm, dir, "Widget list set up failed\n");
+ 			spcm->stream[dir].list = NULL;
+ 			snd_soc_dapm_dai_free_widgets(&list);
+ 			return ret;
+@@ -139,6 +138,8 @@ static int sof_pcm_hw_params(struct snd_soc_component *component,
+ 	if (!spcm)
+ 		return -EINVAL;
+ 
++	spcm_dbg(spcm, substream->stream, "Entry: hw_params\n");
++
+ 	/*
+ 	 * Handle repeated calls to hw_params() without free_pcm() in
+ 	 * between. At least ALSA OSS emulation depends on this.
+@@ -151,12 +152,9 @@ static int sof_pcm_hw_params(struct snd_soc_component *component,
+ 		spcm->prepared[substream->stream] = false;
+ 	}
+ 
+-	dev_dbg(component->dev, "pcm: hw params stream %d dir %d\n",
+-		spcm->pcm.pcm_id, substream->stream);
+-
+ 	ret = snd_sof_pcm_platform_hw_params(sdev, substream, params, &platform_params);
+ 	if (ret < 0) {
+-		dev_err(component->dev, "platform hw params failed\n");
++		spcm_err(spcm, substream->stream, "platform hw params failed\n");
+ 		return ret;
+ 	}
+ 
+@@ -191,6 +189,72 @@ static int sof_pcm_hw_params(struct snd_soc_component *component,
+ 	return 0;
+ }
+ 
++static int sof_pcm_stream_free(struct snd_sof_dev *sdev,
++			       struct snd_pcm_substream *substream,
++			       struct snd_sof_pcm *spcm, int dir,
++			       bool free_widget_list)
++{
++	const struct sof_ipc_pcm_ops *pcm_ops = sof_ipc_get_ops(sdev, pcm);
++	int ret;
++
++	if (spcm->prepared[substream->stream]) {
++		/* stop DMA first if needed */
++		if (pcm_ops && pcm_ops->platform_stop_during_hw_free)
++			snd_sof_pcm_platform_trigger(sdev, substream,
++						     SNDRV_PCM_TRIGGER_STOP);
++
++		/* Send PCM_FREE IPC to reset pipeline */
++		if (pcm_ops && pcm_ops->hw_free) {
++			ret = pcm_ops->hw_free(sdev->component, substream);
++			if (ret < 0)
++				return ret;
++		}
++
++		spcm->prepared[substream->stream] = false;
++	}
++
++	/* reset the DMA */
++	ret = snd_sof_pcm_platform_hw_free(sdev, substream);
++	if (ret < 0)
++		return ret;
++
++	/* free widget list */
++	if (free_widget_list) {
++		ret = sof_widget_list_free(sdev, spcm, dir);
++		if (ret < 0)
++			spcm_err(spcm, substream->stream,
++				 "failed to free widgets during suspend\n");
++	}
++
++	return ret;
++}
++
++int sof_pcm_free_all_streams(struct snd_sof_dev *sdev)
++{
++	struct snd_pcm_substream *substream;
++	struct snd_sof_pcm *spcm;
++	int dir, ret;
++
++	list_for_each_entry(spcm, &sdev->pcm_list, list) {
++		for_each_pcm_streams(dir) {
++			substream = spcm->stream[dir].substream;
++
++			if (!substream || !substream->runtime ||
++			    spcm->stream[dir].suspend_ignored)
++				continue;
++
++			if (spcm->stream[dir].list) {
++				ret = sof_pcm_stream_free(sdev, substream, spcm,
++							  dir, true);
++				if (ret < 0)
++					return ret;
++			}
++		}
++	}
++
++	return 0;
++}
++
+ static int sof_pcm_hw_free(struct snd_soc_component *component,
+ 			   struct snd_pcm_substream *substream)
+ {
+@@ -208,8 +272,7 @@ static int sof_pcm_hw_free(struct snd_soc_component *component,
+ 	if (!spcm)
+ 		return -EINVAL;
+ 
+-	dev_dbg(component->dev, "pcm: free stream %d dir %d\n",
+-		spcm->pcm.pcm_id, substream->stream);
++	spcm_dbg(spcm, substream->stream, "Entry: hw_free\n");
+ 
+ 	if (spcm->prepared[substream->stream]) {
+ 		/* stop DMA first if needed */
+@@ -258,18 +321,17 @@ static int sof_pcm_prepare(struct snd_soc_component *component,
+ 	if (!spcm)
+ 		return -EINVAL;
+ 
++	spcm_dbg(spcm, substream->stream, "Entry: prepare\n");
++
+ 	if (spcm->prepared[substream->stream])
+ 		return 0;
+ 
+-	dev_dbg(component->dev, "pcm: prepare stream %d dir %d\n",
+-		spcm->pcm.pcm_id, substream->stream);
+-
+ 	/* set hw_params */
+ 	ret = sof_pcm_hw_params(component,
+ 				substream, &spcm->params[substream->stream]);
+ 	if (ret < 0) {
+-		dev_err(component->dev,
+-			"error: set pcm hw_params after resume\n");
++		spcm_err(spcm, substream->stream,
++			 "failed to set hw_params after resume\n");
+ 		return ret;
+ 	}
+ 
+@@ -299,8 +361,7 @@ static int sof_pcm_trigger(struct snd_soc_component *component,
+ 	if (!spcm)
+ 		return -EINVAL;
+ 
+-	dev_dbg(component->dev, "pcm: trigger stream %d dir %d cmd %d\n",
+-		spcm->pcm.pcm_id, substream->stream, cmd);
++	spcm_dbg(spcm, substream->stream, "Entry: trigger (cmd: %d)\n", cmd);
+ 
+ 	switch (cmd) {
+ 	case SNDRV_PCM_TRIGGER_PAUSE_PUSH:
+@@ -347,7 +408,7 @@ static int sof_pcm_trigger(struct snd_soc_component *component,
+ 			reset_hw_params = true;
+ 		break;
+ 	default:
+-		dev_err(component->dev, "Unhandled trigger cmd %d\n", cmd);
++		spcm_err(spcm, substream->stream, "Unhandled trigger cmd %d\n", cmd);
+ 		return -EINVAL;
+ 	}
+ 
+@@ -432,9 +493,7 @@ static int sof_pcm_open(struct snd_soc_component *component,
+ 	if (!spcm)
+ 		return -EINVAL;
+ 
+-	dev_dbg(component->dev, "pcm: open stream %d dir %d\n",
+-		spcm->pcm.pcm_id, substream->stream);
+-
++	spcm_dbg(spcm, substream->stream, "Entry: open\n");
+ 
+ 	caps = &spcm->pcm.caps[substream->stream];
+ 
+@@ -454,15 +513,6 @@ static int sof_pcm_open(struct snd_soc_component *component,
+ 	 */
+ 	runtime->hw.buffer_bytes_max = le32_to_cpu(caps->buffer_size_max);
+ 
+-	dev_dbg(component->dev, "period min %zd max %zd bytes\n",
+-		runtime->hw.period_bytes_min,
+-		runtime->hw.period_bytes_max);
+-	dev_dbg(component->dev, "period count %d max %d\n",
+-		runtime->hw.periods_min,
+-		runtime->hw.periods_max);
+-	dev_dbg(component->dev, "buffer max %zd bytes\n",
+-		runtime->hw.buffer_bytes_max);
+-
+ 	/* set wait time - TODO: come from topology */
+ 	substream->wait_time = 500;
+ 
+@@ -472,10 +522,19 @@ static int sof_pcm_open(struct snd_soc_component *component,
+ 	spcm->prepared[substream->stream] = false;
+ 
+ 	ret = snd_sof_pcm_platform_open(sdev, substream);
+-	if (ret < 0)
+-		dev_err(component->dev, "error: pcm open failed %d\n", ret);
++	if (ret < 0) {
++		spcm_err(spcm, substream->stream,
++			 "platform pcm open failed %d\n", ret);
++		return ret;
++	}
+ 
+-	return ret;
++	spcm_dbg(spcm, substream->stream, "period bytes min %zd, max %zd\n",
++		 runtime->hw.period_bytes_min, runtime->hw.period_bytes_max);
++	spcm_dbg(spcm, substream->stream, "period count min %d, max %d\n",
++		 runtime->hw.periods_min, runtime->hw.periods_max);
++	spcm_dbg(spcm, substream->stream, "buffer bytes max %zd\n", runtime->hw.buffer_bytes_max);
++
++	return 0;
+ }
+ 
+ static int sof_pcm_close(struct snd_soc_component *component,
+@@ -494,13 +553,12 @@ static int sof_pcm_close(struct snd_soc_component *component,
+ 	if (!spcm)
+ 		return -EINVAL;
+ 
+-	dev_dbg(component->dev, "pcm: close stream %d dir %d\n",
+-		spcm->pcm.pcm_id, substream->stream);
++	spcm_dbg(spcm, substream->stream, "Entry: close\n");
+ 
+ 	err = snd_sof_pcm_platform_close(sdev, substream);
+ 	if (err < 0) {
+-		dev_err(component->dev, "error: pcm close failed %d\n",
+-			err);
++		spcm_err(spcm, substream->stream,
++			 "platform pcm close failed %d\n", err);
+ 		/*
+ 		 * keep going, no point in preventing the close
+ 		 * from happening
+@@ -534,7 +592,8 @@ static int sof_pcm_new(struct snd_soc_component *component,
+ 		return 0;
+ 	}
+ 
+-	dev_dbg(component->dev, "creating new PCM %s\n", spcm->pcm.pcm_name);
++	dev_dbg(spcm->scomp->dev, "pcm%u (%s): Entry: pcm_construct\n",
++		spcm->pcm.pcm_id, spcm->pcm.pcm_name);
+ 
+ 	/* do we need to pre-allocate playback audio buffer pages */
+ 	if (!spcm->pcm.playback)
+@@ -542,16 +601,15 @@ static int sof_pcm_new(struct snd_soc_component *component,
+ 
+ 	caps = &spcm->pcm.caps[stream];
+ 
+-	/* pre-allocate playback audio buffer pages */
+-	dev_dbg(component->dev,
+-		"spcm: allocate %s playback DMA buffer size 0x%x max 0x%x\n",
+-		caps->name, caps->buffer_size_min, caps->buffer_size_max);
+-
+ 	if (!pcm->streams[stream].substream) {
+-		dev_err(component->dev, "error: NULL playback substream!\n");
++		spcm_err(spcm, stream, "NULL playback substream!\n");
+ 		return -EINVAL;
+ 	}
+ 
++	/* pre-allocate playback audio buffer pages */
++	spcm_dbg(spcm, stream, "allocate %s playback DMA buffer size 0x%x max 0x%x\n",
++		 caps->name, caps->buffer_size_min, caps->buffer_size_max);
++
+ 	snd_pcm_set_managed_buffer(pcm->streams[stream].substream,
+ 				   SNDRV_DMA_TYPE_DEV_SG, sdev->dev,
+ 				   0, le32_to_cpu(caps->buffer_size_max));
+@@ -564,16 +622,15 @@ capture:
+ 
+ 	caps = &spcm->pcm.caps[stream];
+ 
+-	/* pre-allocate capture audio buffer pages */
+-	dev_dbg(component->dev,
+-		"spcm: allocate %s capture DMA buffer size 0x%x max 0x%x\n",
+-		caps->name, caps->buffer_size_min, caps->buffer_size_max);
+-
+ 	if (!pcm->streams[stream].substream) {
+-		dev_err(component->dev, "error: NULL capture substream!\n");
++		spcm_err(spcm, stream, "NULL capture substream!\n");
+ 		return -EINVAL;
+ 	}
+ 
++	/* pre-allocate capture audio buffer pages */
++	spcm_dbg(spcm, stream, "allocate %s capture DMA buffer size 0x%x max 0x%x\n",
++		 caps->name, caps->buffer_size_min, caps->buffer_size_max);
++
+ 	snd_pcm_set_managed_buffer(pcm->streams[stream].substream,
+ 				   SNDRV_DMA_TYPE_DEV_SG, sdev->dev,
+ 				   0, le32_to_cpu(caps->buffer_size_max));
+diff --git a/sound/soc/sof/sof-audio.c b/sound/soc/sof/sof-audio.c
+index 22a5df6aed2a94..ff5d3428346b50 100644
+--- a/sound/soc/sof/sof-audio.c
++++ b/sound/soc/sof/sof-audio.c
+@@ -831,42 +831,6 @@ bool snd_sof_stream_suspend_ignored(struct snd_sof_dev *sdev)
+ 	return false;
+ }
+ 
+-int sof_pcm_stream_free(struct snd_sof_dev *sdev, struct snd_pcm_substream *substream,
+-			struct snd_sof_pcm *spcm, int dir, bool free_widget_list)
+-{
+-	const struct sof_ipc_pcm_ops *pcm_ops = sof_ipc_get_ops(sdev, pcm);
+-	int ret;
+-
+-	if (spcm->prepared[substream->stream]) {
+-		/* stop DMA first if needed */
+-		if (pcm_ops && pcm_ops->platform_stop_during_hw_free)
+-			snd_sof_pcm_platform_trigger(sdev, substream, SNDRV_PCM_TRIGGER_STOP);
+-
+-		/* Send PCM_FREE IPC to reset pipeline */
+-		if (pcm_ops && pcm_ops->hw_free) {
+-			ret = pcm_ops->hw_free(sdev->component, substream);
+-			if (ret < 0)
+-				return ret;
+-		}
+-
+-		spcm->prepared[substream->stream] = false;
+-	}
+-
+-	/* reset the DMA */
+-	ret = snd_sof_pcm_platform_hw_free(sdev, substream);
+-	if (ret < 0)
+-		return ret;
+-
+-	/* free widget list */
+-	if (free_widget_list) {
+-		ret = sof_widget_list_free(sdev, spcm, dir);
+-		if (ret < 0)
+-			dev_err(sdev->dev, "failed to free widgets during suspend\n");
+-	}
+-
+-	return ret;
+-}
+-
+ /*
+  * Generic object lookup APIs.
+  */
+diff --git a/sound/soc/sof/sof-audio.h b/sound/soc/sof/sof-audio.h
+index 3606595a7500c2..7620596ead07da 100644
+--- a/sound/soc/sof/sof-audio.h
++++ b/sound/soc/sof/sof-audio.h
+@@ -601,6 +601,20 @@ struct snd_sof_pcm *snd_sof_find_spcm_comp(struct snd_soc_component *scomp,
+ void snd_sof_pcm_period_elapsed(struct snd_pcm_substream *substream);
+ void snd_sof_pcm_init_elapsed_work(struct work_struct *work);
+ 
++/*
++ * snd_sof_pcm specific wrappers for dev_dbg() and dev_err() to provide
++ * consistent and useful prints.
++ */
++#define spcm_dbg(__spcm, __dir, __fmt, ...)					\
++	dev_dbg((__spcm)->scomp->dev, "pcm%u (%s), dir %d: " __fmt,		\
++		(__spcm)->pcm.pcm_id, (__spcm)->pcm.pcm_name, __dir,		\
++		##__VA_ARGS__)
++
++#define spcm_err(__spcm, __dir, __fmt, ...)					\
++	dev_err((__spcm)->scomp->dev, "%s: pcm%u (%s), dir %d: " __fmt,		\
++		__func__, (__spcm)->pcm.pcm_id, (__spcm)->pcm.pcm_name, __dir,	\
++		##__VA_ARGS__)
++
+ #if IS_ENABLED(CONFIG_SND_SOC_SOF_COMPRESS)
+ void snd_sof_compr_fragment_elapsed(struct snd_compr_stream *cstream);
+ void snd_sof_compr_init_elapsed_work(struct work_struct *work);
+@@ -633,8 +647,7 @@ int sof_widget_list_setup(struct snd_sof_dev *sdev, struct snd_sof_pcm *spcm,
+ int sof_widget_list_free(struct snd_sof_dev *sdev, struct snd_sof_pcm *spcm, int dir);
+ int sof_pcm_dsp_pcm_free(struct snd_pcm_substream *substream, struct snd_sof_dev *sdev,
+ 			 struct snd_sof_pcm *spcm);
+-int sof_pcm_stream_free(struct snd_sof_dev *sdev, struct snd_pcm_substream *substream,
+-			struct snd_sof_pcm *spcm, int dir, bool free_widget_list);
++int sof_pcm_free_all_streams(struct snd_sof_dev *sdev);
+ int get_token_u32(void *elem, void *object, u32 offset);
+ int get_token_u16(void *elem, void *object, u32 offset);
+ int get_token_comp_format(void *elem, void *object, u32 offset);

--- a/patch/kernel/archive/odroidxu4-6.6/patch-6.6.154-155.patch
+++ b/patch/kernel/archive/odroidxu4-6.6/patch-6.6.154-155.patch
@@ -1,0 +1,31 @@
+diff --git a/Makefile b/Makefile
+index f196561476c3b4..17803a7f6f3009 100644
+--- a/Makefile
++++ b/Makefile
+@@ -1,7 +1,7 @@
+ # SPDX-License-Identifier: GPL-2.0
+ VERSION = 6
+ PATCHLEVEL = 6
+-SUBLEVEL = 154
++SUBLEVEL = 155
+ EXTRAVERSION =
+ NAME = Pinguïn Aangedreven
+ 
+diff --git a/net/ipv4/inet_fragment.c b/net/ipv4/inet_fragment.c
+index 1299413bc9804d..3b47126d606e2c 100644
+--- a/net/ipv4/inet_fragment.c
++++ b/net/ipv4/inet_fragment.c
+@@ -435,6 +435,13 @@ int inet_frag_queue_insert(struct inet_frag_queue *q, struct sk_buff *skb,
+ {
+ 	struct sk_buff *last = q->fragments_tail;
+ 
++	/* An IP fragment is never a GSO packet, but an untrusted source
++	 * (virtio_net_hdr) may have attached GSO metadata to it. Do not let
++	 * that reach the reassembled skb, whose head keeps the first
++	 * fragment's shinfo and whose frag_list is not GRO-shaped.
++	 */
++	skb_gso_reset(skb);
++
+ 	/* RFC5722, Section 4, amended by Errata ID : 3089
+ 	 *                          When reassembling an IPv6 datagram, if
+ 	 *   one or more its constituent fragments is determined to be an


### PR DESCRIPTION
# Description

Update odroidxu4-current kernel to 6.6.155.

# How Has This Been Tested?

- [x] Warm reboot of my Odroid HC1

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved network packet reassembly safety by clearing untrusted offload metadata before fragmented packets are queued.
  * Updated the included Linux kernel patch to version 6.6.155.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->