### PR TITLE
Fix Ayn Odin 2 Mini (& Portal?) audio/USB/battery support.

### DIFF
--- a/config/boards/ayn-odin2.csc
+++ b/config/boards/ayn-odin2.csc
@@ -113,18 +113,18 @@ function post_family_tweaks_bsp__ayn-odin2_bsp_firmware_in_initrd() {
 		#!/bin/bash
 		[[ "$1" == "prereqs" ]] && exit 0
 		. /usr/share/initramfs-tools/hook-functions
-		for f in $(find /lib/firmware/qcom/sm8550 -type f) ; do
+		for f in $(find /lib/firmware/qcom/sm8550 -type f -follow) ; do
 		add_firmware "${f#/lib/firmware/}"
 		done
 		add_firmware "qcom/a740_sqe.fw" # Extra one for dpu
 		add_firmware "qcom/gmu_gen70200.bin" # Extra one for gpu
 		add_firmware "qcom/vpu/vpu30_p4.mbn" # Extra one for vpu
 		# Extra one for wifi
-		for f in $(find /lib/firmware/ath12k/WCN7850/hw2.0 -type f) ; do
+		for f in $(find /lib/firmware/ath12k/WCN7850/hw2.0 -type f -follow) ; do
 		add_firmware "${f#/lib/firmware/}"
 		done
 		# Extra one for bt
-		for f in $(find /lib/firmware/qca -type f) ; do
+		for f in $(find /lib/firmware/qca -type f -follow) ; do
 		add_firmware "${f#/lib/firmware/}"
 		done
 	FIRMWARE_HOOK


### PR DESCRIPTION
The `Armbian_community_26.11.0-trunk.19_Ayn-odin2mini_resolute_current_6.18.45_kde-plasma_desktop` build found at 'https://armbian.com/boards/ayn-odin2mini' just so happens to work fine on my Ayn Odin 2 Mini, but as soon as I update it (or switch from the developer build to the stable build), audio, USB-C, and battery support all disappear.

Comparing the `dmesg` output between a working build and a broken build, I found one difference:

Success:
```
[    1.428471] Run /init as init process
[    1.428472]   with arguments:
[    1.428474]     /init
[    1.428474]   with environment:
[    1.428475]     HOME=/
[    1.428476]     TERM=linux
(...)
[    3.404914] EXT4-fs (mmcblk0p2): mounted filesystem 922d114c-c6a9-4c64-86cd-84cae0326d11 ro with writeback data mode. Quota mode: none.
(...)
[    6.608309] remoteproc remoteproc0: adsp is available
[    6.609558] remoteproc remoteproc1: cdsp is available
(...)
[    6.829048] remoteproc remoteproc1: powering up cdsp
[    6.833590] remoteproc remoteproc1: Booting fw image qcom/sm8550/ayn/cdsp.mbn, size 7086504
(...)
[    6.909040] remoteproc remoteproc1: remote processor cdsp is now up
(...)
[    7.180015] remoteproc remoteproc0: powering up adsp
(...)
[    7.194469] remoteproc remoteproc0: Booting fw image qcom/sm8550/ayn/odin2mini/adsp.mbn, size 28379480
```

Fail:
```
[    1.415189] Run /init as init process
[    1.415191]   with arguments:
[    1.415192]     /init
[    1.415193]   with environment:
[    1.415193]     HOME=/
[    1.415194]     TERM=linux
(...)
[    1.685605] remoteproc remoteproc0: adsp is available
[    1.685642] remoteproc remoteproc0: Direct firmware load for qcom/sm8550/ayn/odin2mini/adsp.mbn failed with error -2
[    1.685645] remoteproc remoteproc0: powering up adsp
[    1.685654] remoteproc remoteproc0: Direct firmware load for qcom/sm8550/ayn/odin2mini/adsp.mbn failed with error -2
[    1.685655] remoteproc remoteproc0: request_firmware failed: -2
[    1.690042] remoteproc remoteproc1: cdsp is available
[    1.696068] remoteproc remoteproc1: powering up cdsp
[    1.699586] remoteproc remoteproc1: Booting fw image qcom/sm8550/ayn/cdsp.mbn, size 7086504
[    1.794079] remoteproc remoteproc1: remote processor cdsp is now up
(...)
[    3.006954] EXT4-fs (mmcblk0p2): mounted filesystem 922d114c-c6a9-4c64-86cd-84cae0326d11 ro with writeback data mode. Quota mode: none.
```

In the successful run, `remoteproc` runs after the EXT4 filesystem is mounted, and successfully loads `qcom/sm8550/ayn/odin2mini/adsp.mbn`, whereas the failed runs `remoteproc` before the filesystem is mounted, and fails to load the firmware with a 'file not found' error code.

I am not aware of any way to delay `remoteproc`, so the alternative is load the firmware into the initramfs so that it is available before the filesystem is loaded. There is already an `initramfs-tool` hook for this, but it ignores symlinks; this is relevant because `qcom/sm8550/ayn/odin2mini/adsp.mbn` is actually a symlink to `qcom/sm8550/ayn/odin2/adsp.mbn`.

This is fixed by making `find` follow symlinks, so that the missing firmware is correctly included in the initramfs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved firmware detection for the Ayn Odin2 device.
  * Symlinked firmware files are now included in the initramfs, helping ensure required hardware components initialize correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->