### PR TITLE
SpacemiT K1: Set KERNEL_BTF="no" on both `legacy` and `current`

### DIFF
--- a/config/sources/families/spacemit.conf
+++ b/config/sources/families/spacemit.conf
@@ -37,6 +37,7 @@ case "${BRANCH}" in
 		declare -g EXTRAWIFI="no" # WiFi drivers are already included in the kernel
 		declare -g KERNEL_MAJOR_MINOR="6.6"
 		declare -g LINUXCONFIG="linux-${LINUXFAMILY}-legacy"
+		declare -g KERNEL_BTF="no"
 		;;
 	current)
 		declare -g KERNELSOURCE="https://gitlab.com/jmontleon/kernel-ark"
@@ -44,6 +45,7 @@ case "${BRANCH}" in
 		declare -g EXTRAWIFI="no" # WiFi drivers are already included in the kernel
 		declare -g KERNEL_MAJOR_MINOR="6.18"
 		declare -g LINUXCONFIG="linux-${LINUXFAMILY}-current"
+		declare -g KERNEL_BTF="no"
 		;;
 	edge)
 		declare -g KERNEL_MAJOR_MINOR="7.2" # Major and minor versions of this kernel.


### PR DESCRIPTION
When booting Debian Trixie the system hangs when loading udev.
As discussed here https://github.com/armbian/build/pull/10462


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Disabled BTF generation for legacy and current SpacemiT K1 kernel branches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->