### PR TITLE
mt7623: bananapi-r2: disable PMIC keys for the shorted power button

### DIFF
--- a/patch/kernel/archive/mt7623-6.18/bananapi-r2-disable-shorted-power-key.patch
+++ b/patch/kernel/archive/mt7623-6.18/bananapi-r2-disable-shorted-power-key.patch
@@ -1,0 +1,52 @@
+Subject: [PATCH] ARM: dts: mt7623: bananapi-r2: disable PMIC keys (shorted power button)
+
+The power button on this unit is physically shorted so the board
+auto-powers-on the moment DC is applied. The MT6323 PMIC then sees KEY_POWER
+permanently held and the board reboots as soon as userspace starts acting on
+the stuck power key (same failure as frank-w/BPI-Router-Linux#35).
+
+Disable the whole &mt6323keys node so the mtk-pmic-keys driver never binds -
+the device-tree equivalent of the community fix (blacklisting the
+mtk_pmic_keys module). The MFD core skips a child node whose status is
+"disabled" (mfd_add_device -> of_device_is_available), so the keys device is
+never created and neither the KEY_POWER input nor the PMIC long-press reset is
+set up.
+
+Disabling only the "power" child does NOT work: mtk_pmic_keys_probe()
+iterates the key children by index with for_each_child_of_node_scoped() and
+never checks of_device_is_available(), so a child left in the node is still
+registered regardless of its status (this is also why mainline's disabled
+"home" child is ineffective).
+
+Applied to both mt7623 kernel targets (current 6.18, edge 7.1). u-boot needs
+no change - its BPI-R2 device tree carries no mt6323/keys node. Verified
+on-device via the runtime DTB (fdtput status=disabled on the keys node).
+
+Link: https://github.com/frank-w/BPI-Router-Linux/issues/35
+
+Signed-off-by: Igor Pecovnik <igor@armbian.com>
+
+--- a/arch/arm/boot/dts/mediatek/mt7623n-bananapi-bpi-r2.dts
++++ b/arch/arm/boot/dts/mediatek/mt7623n-bananapi-bpi-r2.dts
+@@ -346,9 +346,18 @@
+ };
+ 
+ &mt6323keys {
+-	home {
+-		status = "disabled";
+-	};
++	/* The power button is physically shorted on this unit (the board
++	 * auto-powers-on when DC is applied), so the MT6323 sees the power key
++	 * permanently held and the board reboots as soon as userspace starts
++	 * acting on KEY_POWER. Disable the whole PMIC keys node so mtk-pmic-keys
++	 * never binds - the device-tree equivalent of blacklisting the
++	 * mtk_pmic_keys module. NB: disabling only the "power" child does not
++	 * work - the driver iterates key children by index and ignores their
++	 * status (mtk_pmic_keys_probe / for_each_child_of_node_scoped).
++	 *
++	 * Link: https://github.com/frank-w/BPI-Router-Linux/issues/35
++	 */
++	status = "disabled";
+ };
+ 
+ &mt6323_leds {

--- a/patch/kernel/archive/mt7623-7.1/bananapi-r2-disable-shorted-power-key.patch
+++ b/patch/kernel/archive/mt7623-7.1/bananapi-r2-disable-shorted-power-key.patch
@@ -1,0 +1,52 @@
+Subject: [PATCH] ARM: dts: mt7623: bananapi-r2: disable PMIC keys (shorted power button)
+
+The power button on this unit is physically shorted so the board
+auto-powers-on the moment DC is applied. The MT6323 PMIC then sees KEY_POWER
+permanently held and the board reboots as soon as userspace starts acting on
+the stuck power key (same failure as frank-w/BPI-Router-Linux#35).
+
+Disable the whole &mt6323keys node so the mtk-pmic-keys driver never binds -
+the device-tree equivalent of the community fix (blacklisting the
+mtk_pmic_keys module). The MFD core skips a child node whose status is
+"disabled" (mfd_add_device -> of_device_is_available), so the keys device is
+never created and neither the KEY_POWER input nor the PMIC long-press reset is
+set up.
+
+Disabling only the "power" child does NOT work: mtk_pmic_keys_probe()
+iterates the key children by index with for_each_child_of_node_scoped() and
+never checks of_device_is_available(), so a child left in the node is still
+registered regardless of its status (this is also why mainline's disabled
+"home" child is ineffective).
+
+Applied to both mt7623 kernel targets (current 6.18, edge 7.1). u-boot needs
+no change - its BPI-R2 device tree carries no mt6323/keys node. Verified
+on-device via the runtime DTB (fdtput status=disabled on the keys node).
+
+Link: https://github.com/frank-w/BPI-Router-Linux/issues/35
+
+Signed-off-by: Igor Pecovnik <igor@armbian.com>
+
+--- a/arch/arm/boot/dts/mediatek/mt7623n-bananapi-bpi-r2.dts
++++ b/arch/arm/boot/dts/mediatek/mt7623n-bananapi-bpi-r2.dts
+@@ -346,9 +346,18 @@
+ };
+ 
+ &mt6323keys {
+-	home {
+-		status = "disabled";
+-	};
++	/* The power button is physically shorted on this unit (the board
++	 * auto-powers-on when DC is applied), so the MT6323 sees the power key
++	 * permanently held and the board reboots as soon as userspace starts
++	 * acting on KEY_POWER. Disable the whole PMIC keys node so mtk-pmic-keys
++	 * never binds - the device-tree equivalent of blacklisting the
++	 * mtk_pmic_keys module. NB: disabling only the "power" child does not
++	 * work - the driver iterates key children by index and ignores their
++	 * status (mtk_pmic_keys_probe / for_each_child_of_node_scoped).
++	 *
++	 * Link: https://github.com/frank-w/BPI-Router-Linux/issues/35
++	 */
++	status = "disabled";
+ };
+ 
+ &mt6323_leds {


### PR DESCRIPTION
### Context

On this Banana Pi R2 the power button is **physically shorted** so the board
auto-powers-on the moment DC is applied. The MT6323 PMIC then sees `KEY_POWER`
**permanently held**, and the board **reboots continuously** as soon as
userspace starts acting on the stuck power key — the exact failure reported
upstream in **frank-w/BPI-Router-Linux#35** (community fix there: blacklist the
`mtk_pmic_keys` module).

### Fix

Disable the **whole `&mt6323keys` node** for both mt7623 kernel targets
(`mt7623-6.18` current, `mt7623-7.1` edge):

```dts
&mt6323keys {
	status = "disabled";
};
```

The MFD core skips a child whose `status` is `disabled`
(`mfd_add_device` → `of_device_is_available`, mfd-core.c), so the
`mtk-pmic-keys` device is never created and the driver never binds — the DT
equivalent of blacklisting the module. That removes **both** the `KEY_POWER`
input and the PMIC long-press reset setup.

### Why not just disable the `power` child (thanks @coderabbitai)

Disabling only the `power` subnode does **not** work: `mtk_pmic_keys_probe()`
iterates the key children by **index** with `for_each_child_of_node_scoped()`
and **never checks `of_device_is_available()`** — so a child left in the node
is registered regardless of its `status`. (This is also why mainline's disabled
`home` child is ineffective.) Disabling the parent node is the reliable DT fix.

### Validation & scope

- Verified on-device by disabling the node in the runtime DTB (`fdtput
  status=disabled`).
- **u-boot: no change** — its BPI-R2 device tree has no `mt6323`/keys node.
- This disables the PMIC power/home keys for **all** BPI-R2 builds on these
  kernels — appropriate for a board whose button has been shorted (the button
  is unusable anyway), but flagging it as board-wide, not per-unit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue on Bananapi R2 boards where a shorted power button could register as `KEY_POWER`.
  * Prevented unintended reboots or power-offs caused by the PMIC interpreting the stuck button as a long press.
  * Applied the fix across supported kernel versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->