### PR TITLE
kernel: enable the IP tunnel drivers for every kernel

### DIFF
--- a/lib/functions/compilation/armbian-kernel.sh
+++ b/lib/functions/compilation/armbian-kernel.sh
@@ -410,6 +410,49 @@ function armbian_kernel_config__select_nftables() {
 	opts_m+=("IP_SET_BITMAP_PORT")    # IP set bitmap:port type
 }
 
+# Enables the IP tunnel and encapsulation drivers for every kernel we build.
+#
+# Armbian boards are routinely used as routers and VPN endpoints, and the tunnel
+# drivers are what that needs. They were never decided fleet-wide, so the shipped
+# configs drifted: across the 122 of them the IPv4 half is nearly universal
+# (NET_IPIP 85, NET_IPGRE 78) while the IPv6 half is patchy (IPV6_GRE 62,
+# IPV6_SIT 54) and IPV6_TUNNEL is enabled in only 24 -- with 8 configs setting it
+# to "not set" outright. Whether a given board can terminate a tunnel came down
+# to which family config it happened to be built from.
+#
+# The IPv6 side is the one that bites. DS-Lite (RFC 6333) terminates an
+# IPv4-in-IPv6 tunnel on the customer router and needs ip6_tnl; it is the
+# standard deployment on a large share of European fibre and cable lines, where
+# the carrier hands out CGNAT-only IPv4 that is not routed. Without it a board
+# used as a router there has working IPv6 and no IPv4 at all.
+#
+# All modules, so nothing is paid for until a tunnel is actually created. The two
+# built-ins are bool options extending a driver, not separate modules. Kernels
+# whose dependencies are unmet drop them at olddefconfig, so families without
+# IPv6 are unaffected. Note this also normalises the handful of configs that
+# built one of these in (=y) down to a module.
+#
+# Deliberately not here: NET_FOU (foo-over-UDP) is genuinely niche, and WIREGUARD
+# is a VPN rather than a tunnel driver -- and is already in 101 of 122 configs.
+function armbian_kernel_config__select_tunnels() {
+	# IPv4 tunnelling
+	opts_m+=("NET_IPIP")            # IP-in-IP tunnelling (ipip)
+	opts_m+=("NET_IPGRE_DEMUX")     # GRE demultiplexer, required by the GRE drivers
+	opts_m+=("NET_IPGRE")           # GRE tunnels over IPv4 (ip_gre)
+	opts_y+=("NET_IPGRE_BROADCAST") # bool: broadcast/multicast GRE
+
+	# IPv6 tunnelling
+	opts_m+=("IPV6_SIT")     # 6in4 / 6to4 tunnels (sit) -- HE tunnelbroker et al
+	opts_y+=("IPV6_SIT_6RD") # bool: 6RD extension to sit
+	opts_m+=("IPV6_TUNNEL")  # IP-in-IPv6 tunnel, RFC2473 (ip6_tnl) -- DS-Lite
+	opts_m+=("IPV6_GRE")     # GRE tunnels over IPv6 (ip6_gre)
+	opts_m+=("IPV6_VTI")     # virtual tunnel interface for IPsec over IPv6
+
+	# Overlay encapsulation. VXLAN is already forced by the Docker hook; GENEVE is
+	# its counterpart and was in only 68 configs, so pair them up.
+	opts_m+=("GENEVE") # Generic Network Virtualization Encapsulation
+}
+
 # Enables netfilter legacy xtables and ebtables support for kernels 6.18+.
 #
 # Linux 6.18 removed legacy xtables (iptables-legacy) support by default in favor


### PR DESCRIPTION
Generalises #10568. That PR enables `CONFIG_IPV6_TUNNEL=m` for `filogic-current`, with a good write-up of why it matters; this does the same thing for every kernel we build, along with the rest of the tunnel family it belongs to.

## The configs drifted

Armbian boards are routinely used as routers and VPN endpoints, and the tunnel drivers are what that needs — but this was never decided fleet-wide. Across the 122 shipped kernel configs:

| Symbol | enabled | `is not set` | absent |
| --- | ---: | ---: | ---: |
| `NET_IPIP` | 85 | 7 | 30 |
| `NET_IPGRE_DEMUX` | 79 | 7 | 36 |
| `NET_IPGRE` | 78 | 1 | 43 |
| `IPV6_VTI` | 66 | 10 | 46 |
| `IPV6_SIT_6RD` | 64 | 10 | 48 |
| `IPV6_GRE` | 62 | 4 | 56 |
| `IPV6_SIT` | 54 | 4 | 64 |
| **`IPV6_TUNNEL`** | **24** | **8** | **90** |

The IPv4 half is nearly universal, the IPv6 half is patchy, and `IPV6_TUNNEL` is the outlier of outliers. Which tunnels a given board can terminate came down to which family config it happened to be built from. Filogic shows the shape of it: `edge` has it, `current` and `legacy` do not, while the tree all three build from enables it in the board defconfig.

The IPv6 side is the one that bites, and #10568 explains it well: DS-Lite (RFC 6333) terminates an IPv4-in-IPv6 tunnel on the customer router and needs `ip6_tnl`. It is the standard deployment on a large share of European fibre and cable lines, where the carrier hands out CGNAT-only IPv4 that is not routed — so a board used as a router there has working IPv6 and **no IPv4 at all**.

## The change

One hook, ten options — the same mechanism `select_nftables` already uses to enable a large netfilter set fleet-wide:

```bash
function armbian_kernel_config__select_tunnels() {
	opts_m+=("NET_IPIP" "NET_IPGRE_DEMUX" "NET_IPGRE")         # IPv4
	opts_y+=("NET_IPGRE_BROADCAST")
	opts_m+=("IPV6_SIT" "IPV6_TUNNEL" "IPV6_GRE" "IPV6_VTI")   # IPv6
	opts_y+=("IPV6_SIT_6RD")
	opts_m+=("GENEVE")                                          # pairs with VXLAN
}
```
*(flattened here for readability; the real hook is one option per line with comments)*

`GENEVE` is included because `VXLAN` is already forced by the Docker hook and the two are counterparts — `GENEVE` was in only 68 configs.

Doing it in the hook covers all three shapes the configs come in — absent, `# ... is not set`, and already enabled — because `scripts/config` rewrites the line either way. That is also why this supersedes #10568 rather than conflicting with it.

**`NET_IPGRE_BROADCAST` and `IPV6_SIT_6RD` are bool, not tristate.** They appear only ever as `=y` across all 122 configs, never `=m`, so they go in `opts_y` — putting them in `opts_m` would have been wrong.

## Verified

Ran the kernel's own `scripts/config` against one config of each shape and checked all ten land with the right value:

| Config | Shape | Result |
| --- | --- | --- |
| `linux-imx7d-current` | full `.config`, sets `IPV6_TUNNEL` to *not set* | all 10 applied |
| `linux-filogic-current` | #10568's target | all 10 applied |
| `linux-bcm2711-edge` | minimal savedefconfig style | all 10 applied |

## Worth knowing before merging

- **Every kernel rebuilds.** This lands in `kernel_config_modifying_hashes`, so it changes the kernel artifact version fleet-wide and invalidates cached kernels.
- **A few `=y` become `=m`.** Eight configs build `IPV6_SIT` in and five build `IPV6_TUNNEL` in; those normalise down to modules. Harmless for tunnels — nothing here is boot-critical and the module autoloads — but it is a real change for those boards.
- Everything else is a module, so nothing is paid for until a tunnel is created. Kernels whose dependencies are unmet drop them at `olddefconfig`, so families without IPv6 are unaffected.

## Left out

`NET_FOU` (foo-over-UDP) is genuinely niche, and its dependency picture in the shipped configs looks inconsistent enough to deserve its own look — 59 configs have `NET_FOU_IP_TUNNELS=y` while only 17 have `NET_FOU`. `WIREGUARD` is a VPN rather than a tunnel driver, and is already in 101 of 122. Happy to fold either in.

cc @kaffeetas — your investigation in #10568 is what established the case; this just widens it so no other board hits the same wall.

Signed-off-by: Igor Pecovnik <igor@armbian.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for IP tunneling, IPv6 tunneling, and GENEVE network encapsulation across Armbian kernels.
  * Tunnel and encapsulation drivers are now consistently available as loadable modules or built-in kernel features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->