### PR TITLE
uefi-x86-7.2: fix T2 magicmouse patches against Linux 7.2

### DIFF
--- a/patch/kernel/archive/uefi-x86-7.2/4001-asahi-trackpad.patch
+++ b/patch/kernel/archive/uefi-x86-7.2/4001-asahi-trackpad.patch
@@ -444,14 +444,23 @@ Will be used for supporting MacBook trackpads connected via SPI.
 
 Signed-off-by: Janne Grunau <j@jannau.net>
 ---
- drivers/hid/hid-magicmouse.c | 32 +++++++++++++++++++++++++++++++-
- 1 file changed, 31 insertions(+), 1 deletion(-)
+[Armbian] Rebased for Linux 7.2. Upstream hardened the DOUBLE_REPORT_ID path
+against unbounded recursion: the parser became __magicmouse_raw_event() with a
+'nested' flag, wrapped by magicmouse_raw_event(). This patch splits that same
+parser into a per-bus handler, so applying it unchanged left the 'if (nested)'
+guard behind in the split-out body, which no longer has that parameter
+("'nested' undeclared"), while the flag itself was silently dropped at the new
+dispatch. Move the guard into the dispatcher instead: it is the single choke
+point every report passes through, so the check keeps working without adding
+'nested' to the input_ops signature that later patches build on.
+
+ drivers/hid/hid-magicmouse.c | 50 ++++++++++++++++++++++++++++++++++++++++----------
+ 1 file changed, 40 insertions(+), 10 deletions(-)
 
 diff --git a/drivers/hid/hid-magicmouse.c b/drivers/hid/hid-magicmouse.c
-index 956aad89e..c4498bc8e 100644
 --- a/drivers/hid/hid-magicmouse.c
 +++ b/drivers/hid/hid-magicmouse.c
-@@ -114,6 +114,13 @@ MODULE_PARM_DESC(report_undeciphered, "Report undeciphered multi-touch state fie
+@@ -114,6 +114,13 @@ MODULE_PARM_DESC(report_undeciphered, "R
  #define TRACKPAD2_RES_Y \
  	((TRACKPAD2_MAX_Y - TRACKPAD2_MIN_Y) / (TRACKPAD2_DIMENSION_Y / 100))
  
@@ -465,7 +474,7 @@ index 956aad89e..c4498bc8e 100644
  /**
   * struct magicmouse_sc - Tracks Magic Mouse-specific data.
   * @input: Input device through which we report events.
-@@ -127,6 +134,7 @@ MODULE_PARM_DESC(report_undeciphered, "Report undeciphered multi-touch state fie
+@@ -127,6 +134,7 @@ MODULE_PARM_DESC(report_undeciphered, "R
   * @hdev: Pointer to the underlying HID device.
   * @work: Workqueue to handle initialization retry for quirky devices.
   * @battery_timer: Timer for obtaining battery level information.
@@ -481,10 +490,19 @@ index 956aad89e..c4498bc8e 100644
  };
  
  static int magicmouse_firm_touch(struct magicmouse_sc *msc)
-@@ -389,6 +398,14 @@ static int magicmouse_raw_event(struct hid_device *hdev,
- 		struct hid_report *report, u8 *data, int size)
+@@ -389,6 +398,23 @@ static int __magicmouse_raw_event(struct
+ 		struct hid_report *report, u8 *data, int size, bool nested)
  {
  	struct magicmouse_sc *msc = hid_get_drvdata(hdev);
++
++	/*
++	 * A double report only ever wraps two normal reports, so it is never
++	 * nested. Refuse to recurse a second time; otherwise a malicious
++	 * device could chain DOUBLE_REPORT_ID packets to drive unbounded
++	 * recursion and overflow the kernel stack.
++	 */
++	if (nested && size >= 1 && data[0] == DOUBLE_REPORT_ID)
++		return 0;
 +
 +	return msc->input_ops.raw_event(hdev, report, data, size);
 +}
@@ -496,7 +514,23 @@ index 956aad89e..c4498bc8e 100644
  	struct input_dev *input = msc->input;
  	int x = 0, y = 0, ii, clicks = 0, npoints;
  
-@@ -538,7 +555,17 @@ static int magicmouse_event(struct hid_device *hdev, struct hid_field *field,
+@@ -497,15 +523,6 @@ static int __magicmouse_raw_event(struct
+ 		 * packet.
+ 		 */
+ 
+-		/*
+-		 * A double report only ever wraps two normal reports, so it is
+-		 * never nested. Refuse to recurse a second time; otherwise a
+-		 * malicious device could chain DOUBLE_REPORT_ID packets to drive
+-		 * unbounded recursion and overflow the kernel stack.
+-		 */
+-		if (nested)
+-			return 0;
+-
+ 		/* Ensure that we have at least 2 elements (report type and size) */
+ 		if (size < 2)
+ 			return 0;
+@@ -569,7 +586,17 @@ static int magicmouse_event(struct hid_d
  	return 0;
  }
  
@@ -515,7 +549,7 @@ index 956aad89e..c4498bc8e 100644
  {
  	int error;
  	int mt_flags = 0;
-@@ -865,6 +892,9 @@ static int magicmouse_probe(struct hid_device *hdev,
+@@ -905,6 +932,9 @@ static int magicmouse_probe(struct hid_d
  		return -ENOMEM;
  	}
  

--- a/patch/kernel/archive/uefi-x86-7.2/4001-asahi-trackpad.patch
+++ b/patch/kernel/archive/uefi-x86-7.2/4001-asahi-trackpad.patch
@@ -1089,41 +1089,31 @@ The trackpad has to request multi touch reports during resume.
 
 Signed-off-by: Janne Grunau <j@jannau.net>
 ---
- drivers/hid/hid-magicmouse.c | 14 ++++++++++++++
- 1 file changed, 14 insertions(+)
+[Armbian] Rebased for Linux 7.2, which gained its own magicmouse_reset_resume()
+and the matching .reset_resume entry in magicmouse_driver (for USB Magic Mouse
+2). Adding a second function of the same name is a redefinition error, and the
+struct hunk no longer applies. Fold the SPI branch into the upstream handler
+instead; the driver-struct hunk is dropped as already-upstream.
+
+ drivers/hid/hid-magicmouse.c | 6 ++++++
+ 1 file changed, 6 insertions(+)
 
 diff --git a/drivers/hid/hid-magicmouse.c b/drivers/hid/hid-magicmouse.c
-index 230934ddb..92d7d4f40 100644
 --- a/drivers/hid/hid-magicmouse.c
 +++ b/drivers/hid/hid-magicmouse.c
-@@ -1355,6 +1355,16 @@ static const struct hid_device_id magic_mice[] = {
- };
- MODULE_DEVICE_TABLE(hid, magic_mice);
+@@ -1361,6 +1361,12 @@ static int magicmouse_reset_resume(struct hid_device *hdev)
+ {
+ 	struct magicmouse_sc *msc = hid_get_drvdata(hdev);
  
-+#ifdef CONFIG_PM
-+static int magicmouse_reset_resume(struct hid_device *hdev)
-+{
++	/* SPI trackpads have to request multi touch reports during resume.
++	 * They accept the enable report inline, so send it here directly.
++	 */
 +	if (hdev->bus == BUS_SPI)
 +		return magicmouse_enable_multitouch(hdev);
 +
-+	return 0;
-+}
-+#endif
-+
- static struct hid_driver magicmouse_driver = {
- 	.name = "magicmouse",
- 	.id_table = magic_mice,
-@@ -1365,6 +1375,10 @@ static struct hid_driver magicmouse_driver = {
- 	.event = magicmouse_event,
- 	.input_mapping = magicmouse_input_mapping,
- 	.input_configured = magicmouse_input_configured,
-+#ifdef CONFIG_PM
-+        .reset_resume = magicmouse_reset_resume,
-+#endif
-+
- };
- module_hid_driver(magicmouse_driver);
- 
+ 	/* The device drops out of multitouch mode on resume; re-send the
+ 	 * enable report.  Only the HID_TYPE_USBMOUSE interface accepts it, and
+ 	 * it must be deferred. Sending it inline here is too early.
 -- 
 2.52.0
 


### PR DESCRIPTION
Fixes the T2 (Apple hid-magicmouse) sub-patches in the `uefi-x86-7.2`
kernel patch series so `kernel-x86-edge` (7.2.2) builds again.

Two problems, both in `4001-asahi-trackpad.patch`:

- **`.reset_resume`** hunk no longer matched the 7.2 `hid_driver` layout
  and had to be rebased.
- **`raw_event` split (sub-patch 09/18)** cut the parser in the wrong
  place after 7.2 hardened `DOUBLE_REPORT_ID` against unbounded recursion
  (`magicmouse_raw_event` → `__magicmouse_raw_event(..., nested)`). Applied
  unchanged it left `if (nested) return 0;` in `magicmouse_raw_event_usb()`
  (which has no such parameter → `'nested' undeclared` build error) and
  silently discarded the recursion guard. Rebased so the guard moves into
  the `input_ops` dispatcher — the single choke point every report passes
  through — keeping the 4-arg `raw_event` signature that sub-patches 10, 11,
  13 and 4004 build on.

Verified by replaying the series over upstream `hid-magicmouse.c`
(`52c36105f76e`): sub-patches 07-14 + 4004/4005 apply with no rejects,
`nested` survives only in the dispatcher, all four `raw_event` handlers
match the ops signature, no undefined/duplicated `magicmouse_*` symbols.

CI-tested: https://github.com/armbian/ci/actions/runs/33364227937/job/99413600700

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Apple Silicon keyboards and trackpads connected through SPI and HOST HID interfaces.
  * Added Apple DockChannel transport support for compatible devices and accessories.
  * Added support for configurable SPI HID and DockChannel HID connections.
* **Enhancements**
  * Improved trackpad report handling, device-specific key mappings, multitouch behavior, and recovery after controller resets or suspend/resume.
  * Increased support for larger HID reports and improved Magic Mouse touch handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->