### PR TITLE
firstlogin: let the console with a user take the setup

### DIFF
--- a/packages/bsp/common/usr/lib/armbian/armbian-firstlogin
+++ b/packages/bsp/common/usr/lib/armbian/armbian-firstlogin
@@ -786,13 +786,19 @@ set_user_icon() {
 
 if [[ -f /root/.not_logged_in_yet ]] && tty -s; then
 
-	# tty1, the serial console and an early ssh login all start the setup at once.
-	# Let the first one own it, or they race each other through the prompts.
-	exec 9> /run/armbian-firstlogin.lock || exit 1
-	if ! flock -n 9; then
-		echo -e "\nFirst login setup is already running in another session.\n"
-		exit 0
-	fi
+	# All autologin consoles start the setup at once and the one that wins is
+	# often a console nobody is at, so let the newest session take it over.
+	# SIGTERM is the holder's clean-exit path: the marker survives a power
+	# loss the same way, and the setup simply runs again here.
+	exec 9<> /run/armbian-firstlogin.lock || exit 1
+	until flock -n 9; do
+		kill -TERM "$(< /run/armbian-firstlogin.lock)" 2> /dev/null
+		sleep 1
+	done
+	echo $$ > /run/armbian-firstlogin.lock
+
+	# it may have been finished by the session we just displaced
+	[[ -f /root/.not_logged_in_yet ]] || exit 0
 
 	. /root/.not_logged_in_yet
 


### PR DESCRIPTION
Follow-up to #10480 @igorpecovnik 

Every autologin console starts the setup at once and `flock -n` gives it to whichever ran first, usually the one nobody is sitting at. It then waits for input on an empty screen. Before #10480 all sessions ran the prompts in parallel, so the unattended one never got past its first `read` and the attended one always won. the lock kept the race fix but lost that.

Give it to the session that arrived last instead. The holder names itself in the lock file and is asked to step aside with `SIGTERM`, which the script already traps as a clean exit where `FIRSTLOGIN_SUCCESS` stays `0`, the marker survives and the setup reruns in the new session, the same path a power loss takes. The lock still serializes the run, since the prompt phase creates the user. A single console is unaffected - it takes the lock on the first try.

But there's a tradeoff, and i think the price is low. a second interactive login now restarts a setup in progress. Only
terminals can do that - the existing `tty -s` guard means `ssh host command`, cron and the like never reach the lock.

Tested on an Orange Pi Zero, Armbian community 26.11 trunk, trixie, running the
real script with a stub in place of the prompts:

| case | result |
|---|---|
| unattended console got there first | holds the setup |
| user logs in elsewhere | first steps aside, second takes over, marker intact |
| setup already finished | new session goes straight to its shell |
| holder finished while newcomer waited | newcomer takes the lock, sees the work is done, leaves silently |
| stale pid in the lock file | no signal sent, bystander untouched |
| two consoles, nobody at either | one instance left, the newest |

`bash -n` and `shellcheck -S warning` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved first-login setup handling when another setup session is already active.
  * The latest setup session now cleanly takes over instead of exiting immediately.
  * Prevented setup from continuing if the first-login completion marker is removed during the handoff.
  * Improved reliability by waiting for the previous session to stop before proceeding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->