### PR TITLE
fix NanoPi NEO3 Plus (current): select correct SPI controller to let spidev registration not fail

### DIFF
--- a/patch/kernel/archive/rockchip64-6.18/dt/rk3528-nanopi-neo3-plus.dts
+++ b/patch/kernel/archive/rockchip64-6.18/dt/rk3528-nanopi-neo3-plus.dts
@@ -343,9 +343,9 @@
 	pinctrl-0 = <&spi1_pins>, <&spi1_csn1>;
 	status = "okay";
 
-	spidev@1 {
+	spidev@0 {
 		compatible = "armbian,spi-dev";
-		reg = <1>;
+		reg = <0>;
 		spi-max-frequency = <10000000>;
 		status = "okay";
 	};


### PR DESCRIPTION
Confirmed via dmesg output [before](https://paste.armbian.com/osulunefus) [after](https://paste.armbian.com/zocaparufi)

# Description

We had an error while selecting the SPI controller interface by a wrong index (reported back in dmesg).

# Checklist:

- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected SPI device addressing on the RK3528 NanoPi NEO3 Plus.
  * Improved compatibility with SPI devices connected to chip-select 0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->