### PR TITLE
oci: link pushed packages to their GitHub repository

### DIFF
--- a/lib/functions/general/oci-oras.sh
+++ b/lib/functions/general/oci-oras.sh
@@ -130,6 +130,25 @@ function try_download_oras_tooling() {
 	run_host_command_logged chmod +x "${ORAS_BIN}"
 }
 
+# Derive "https://github.com/<owner>/<repo>" from OCI coordinates shaped like
+# "ghcr.io/<owner>/<repo>/<package>[:<tag>]". Echoes nothing for anything else.
+#
+# Only ghcr.io: the org.opencontainers.image.source link is a GitHub Container
+# Registry feature, and other registries ignore it.
+#
+# At least three path segments are required. A flat "ghcr.io/<owner>/<package>"
+# would otherwise resolve to a repository that does not exist, so it is skipped
+# rather than pointed somewhere wrong.
+function oci_derive_source_url() {
+	declare coords="${1}"
+	[[ "${coords}" != "ghcr.io/"* ]] && return 0
+	coords="${coords%:*}" # drop the :tag, if any
+	declare -a seg
+	IFS='/' read -r -a seg <<< "${coords#ghcr.io/}"
+	[[ ${#seg[@]} -lt 3 ]] && return 0
+	echo "https://github.com/${seg[0]}/${seg[1]}"
+}
+
 function oras_push_artifact_file() {
 	declare image_full_oci="${1}" # Something like "ghcr.io/rpardini/armbian-git-shallow/kernel-git:latest"
 	declare upload_file="${2}"    # Absolute path to the file to upload including the path and name
@@ -141,6 +160,23 @@ function oras_push_artifact_file() {
 	oras_add_param_plain_http
 	oras_add_param_insecure
 	extra_params+=("--annotation" "org.opencontainers.image.description=${description}")
+
+	# Connect the package to its GitHub repository. GHCR links a package to a repo
+	# automatically ONLY when it is pushed with GITHUB_TOKEN; Armbian's CI pushes
+	# with a PAT (the builtin token cannot write org packages), so nothing links
+	# these and each package inherits no repository access permissions at all.
+	# This annotation does the linking explicitly.
+	#
+	# It does NOT make packages public: GitHub publishes every new package as
+	# private and offers no API to change that -- visibility is a web-UI action.
+	# This only fixes the permissions half.
+	#
+	# OCI_SOURCE_URL overrides the derived value; set it to the empty string to
+	# skip the annotation entirely.
+	declare oci_source_url="${OCI_SOURCE_URL-$(oci_derive_source_url "${image_full_oci}")}"
+	if [[ -n "${oci_source_url}" ]]; then
+		extra_params+=("--annotation" "org.opencontainers.image.source=${oci_source_url}")
+	fi
 
 	# make sure file exists
 	if [[ ! -f "${upload_file}" ]]; then


### PR DESCRIPTION
TL;DR — none of Armbian's GHCR packages are linked to a repository, so they inherit no repository access permissions. One annotation fixes that.

### Why they're unlinked

GHCR connects a package to a repo automatically **only** when it's pushed with `GITHUB_TOKEN`. The build workflows push with a PAT — `secrets.ACCESS_TOKEN`, because as their own comment says, *"builtin GITHUB_TOKEN can't write org packages"*. So nothing links them, and `.repository` is null on every package.

Per GitHub's docs: *"If you publish a package that is linked to a repository, the package automatically inherits the access permissions of the linked repository, and GitHub Actions workflows in the linked repository automatically get access to the package."* Unlinked, none of that applies — which is why reading these needs a bespoke PAT rather than just org membership.

### The change

One extra annotation next to the `description` one already set in `oras_push_artifact_file`, derived from the coordinates:

```
ghcr.io/armbian/os/kernel-meson64-current:VER  ->  https://github.com/armbian/os
```

Guarded: only `ghcr.io` (the link is a GHCR feature, other registries ignore it), and only when a repo namespace is actually present — a flat `ghcr.io/<owner>/<package>` is skipped rather than pointed at a repository that doesn't exist. `OCI_SOURCE_URL` overrides it, or set it empty to skip.

### Verified

Exercised against every coordinate shape in use:

| coordinates | result |
|---|---|
| `ghcr.io/armbian/os/kernel-meson-s4t7-current:7.1.12-abc` | `https://github.com/armbian/os` |
| `ghcr.io/rpardini/armbian-git-shallow/kernel-git:latest` | `https://github.com/rpardini/armbian-git-shallow` |
| `ghcr.io/armbian/cache-kernel/kernel-meson64-edge:x` | `https://github.com/armbian/cache-kernel` (repo exists — checked) |
| `ghcr.io/armbian/kernel-meson64-edge:1.2.3` (legacy flat) | skipped |
| `docker.io/armbian/os/kernel:1` | skipped |
| `registry.local:5000/foo/bar/baz:1` | skipped |

`bash -n` clean.

### What this does *not* do

It does **not** make packages public. GitHub publishes every new package as private and offers no API to change it — the org package endpoints are list/get/delete/restore only, visibility is a web-UI action, and it's one-way. This fixes the permissions half. armbian/ci#64 reports the private ones so the manual flip stays visible.

The permanent fix for the visibility half is to stop minting new package names — move family/branch out of the package name and into the tag — so each package is made public once and no new one is ever created.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic links from pushed OCI packages to their associated GitHub repository.
  * Added support for overriding the repository link when publishing packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->