### PR TITLE
info: strip bash trailing comments before parsing board vars

### DIFF
--- a/lib/tools/common/armbian_utils.py
+++ b/lib/tools/common/armbian_utils.py
@@ -120,6 +120,27 @@ def to_yaml(gha_workflow):
 	return yaml.safe_dump(gha_workflow, explicit_start=True, default_flow_style=False, sort_keys=False, allow_unicode=True, indent=2, width=1000)
 
 
+# Cut a bash trailing comment off one line: the first '#' that starts a word and
+# is not inside quotes. ARMBIAN_BOARD_CONFIG_REGEX_GENERIC closes its value on
+# either quote character, greedily, so a comment carrying an apostrophe or a
+# quote swallows the rest of the line -- BOARD_NAME="Khadas VIM1S" # don't ...
+# parsed as 'Khadas VIM1S" # don', which then rode into image-info.json and
+# every consumer of it. Strip the comment before matching and the regex sees a
+# clean assignment. A '#' inside the value survives, and a line whose only '#'
+# is quoted (UBOOT_HASH_EXTRA's nested command substitution) is left untouched.
+def strip_bash_trailing_comment(line: str) -> str:
+	quote = None
+	for i, char in enumerate(line):
+		if quote is not None:
+			if char == quote:
+				quote = None
+		elif char in "'\"":
+			quote = char
+		elif char == "#" and (i == 0 or line[i - 1] in " \t"):
+			return line[:i]
+	return line
+
+
 # I've to read the first line from the board file, that's the hardware description in a pound comment.
 # Also, 'KERNEL_TARGET="legacy,current,edge"' which we need to parse.
 def armbian_parse_board_file_for_static_info(board_file, board_id, core_or_userpatched):
@@ -136,7 +157,8 @@ def armbian_parse_board_file_for_static_info(board_file, board_id, core_or_userp
 
 	# Parse generic bash vars, with a horrendous regex.
 	generic_vars = {}
-	generic_var_matches = re.findall(ARMBIAN_BOARD_CONFIG_REGEX_GENERIC, "\n".join(file_lines), re.MULTILINE)
+	board_file_body = "\n".join(strip_bash_trailing_comment(line) for line in file_lines)
+	generic_var_matches = re.findall(ARMBIAN_BOARD_CONFIG_REGEX_GENERIC, board_file_body, re.MULTILINE)
 	for generic_var_match in generic_var_matches:
 		generic_vars[generic_var_match[0]] = generic_var_match[1]
 


### PR DESCRIPTION
## The bug

`ARMBIAN_BOARD_CONFIG_REGEX_GENERIC` closes its value on **either** quote character, **greedily**:

```python
r"^(?!\s)(?:[export |declare \-g]?)+([A-Z0-9_]+)=(?:'|\")(.*)(?:'|\")"
```

So a trailing comment containing an apostrophe or a quote swallows the rest of the line. From `config/boards/khadas-vim1s.conf`:

```
BOARD_NAME="Khadas VIM1S" # don't confuse with VIM1 (S905X)
                        └────── captured ──────┘
```

parses as `'Khadas VIM1S" # don'` — the match runs past the real closing quote and ends on the apostrophe in `don't`.

That value rides into the published `image-info.json` (it is wrong there right now), and out to every consumer. `armbian/autotests` names its NetBox device from `BOARD_NAME`, so the lab currently holds a board literally called `Khadas VIM1S" # don 01`.

## Wider than one name

Across `config/boards/` this corrupts **14 values on 12 boards**:

| Board(s) | Variable |
|---|---|
| khadas-vim1s | `BOARD_NAME` |
| khadas-vim3, khadas-vim3l, odroidn2l | `BOOTPATCHDIR` |
| radxa-e24c, radxa-nio-12l | `BOOTCONFIG` |
| nanopct6-lts | `BOOT_FDT_FILE` |
| mixtile-blade3 | `BOOT_SOC`, `BOOT_SCENARIO` |
| aml-t95z-plus | `BOOTPATCHDIR`, `BOOT_FDT_FILE`, `SRC_CMDLINE` |
| odroidhc4 | `PACKAGE_LIST_BOARD` |
| tinkerboard-2 | `BOOT_SCENARIO` |

Builds themselves are unaffected — bash sources these files properly. It is the Python info tooling that misreads them, so the damage lands in `image-info.json` and the JSON matrix metadata.

## Why not just fix the regex

Tightening the regex is wrong in **both** directions:

- **Lazy match with a backreferenced quote** (`=(['\"])(.*?)\2`) truncates `UBOOT_HASH_EXTRA` on cubie-a7z, orangepi4pro and orangepizero3w — its value legitimately nests quotes inside a command substitution: `"$(cat "${A}" "${B}" | sha256sum | cut -d' ' -f1)"` → `$(cat `.
- **Greedy with a backreferenced quote** keeps nanopct6-lts broken, because its comment quotes another `.dtb` path.

Cutting the trailing comment *before* the regex runs leaves both cases alone: the first `#` that starts a word and is not inside quotes. A `#` inside a value survives, and a line whose only `#` is quoted is untouched.

## Verification

Ran the real parser against the one on `main` over every file in `config/boards/`:

- **14 values change, 0 suspicious**
- every change is a strict prefix of the old value (only trailing junk removed)
- no board gains or loses a variable

`khadas-vim1s` `BOARD_NAME` now parses as `'Khadas VIM1S'`.

## Note

`image-info.json` is published from CI, so consumers only see the correction once a run regenerates it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved parsing of board configuration files when lines contain trailing comments.
  * Prevented quoted text and apostrophes in comments from being incorrectly included in configuration values.
  * Increased reliability when extracting static board information from configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->