### PR TITLE
rtl88x2cs: bump driver to f4263fc6 (2026-09-01)

### DIFF
--- a/lib/functions/compilation/patch/drivers_network.sh
+++ b/lib/functions/compilation/patch/drivers_network.sh
@@ -466,7 +466,7 @@ driver_rtl88x2cs() {
 	if linux-version compare "${version}" ge 5.9 && [[ "$LINUXFAMILY" == meson64 ]]; then
 
 		# Attach to specific commit (track branch:tune_for_jethub)
-		local rtl88x2csver='commit:a206673937708aa5d2fb8c42b6b12f2fb96dd9b3' # Commit date: Aug 20, 2026 (please update when updating commit ref)
+		local rtl88x2csver='commit:f4263fc6ecd11465bf60ce142aa76e2e85e2cbf3' # Commit date: Sep 1, 2026 (please update when updating commit ref)
 
 		display_alert "Adding" "Wireless drivers for Realtek 88x2cs chipsets ${rtl88x2csver}" "info"
 


### PR DESCRIPTION
# Description

Picks up the two fixes merged in jethome-iot/rtl88x2cs since a2066739:
ae2cc93 makes the rx_ampdu sz_limit init handle an unexpected nss index
instead of indexing past the table, and a2e3fed makes remain_on_channel
and mgmt_tx report the cookie cfg80211 hands them, gated at
KERNEL_VERSION(7, 3, 0) so the 6.12/6.18/7.1/7.2 builds are unchanged.
    
for #10579

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the RTL88x2CS wireless driver source to a newer revision, improving compatibility and reliability for supported Wi‑Fi hardware.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->