### PR TITLE
rtl8723ds: re-enable, bump commit hash for add 7.3 compat

### DIFF
--- a/lib/functions/compilation/patch/drivers_network.sh
+++ b/lib/functions/compilation/patch/drivers_network.sh
@@ -646,10 +646,10 @@ driver_rtl8723DS() {
 
 	# Wireless drivers for Realtek 8723DS chipsets
 
-	if linux-version compare "${version}" ge 5.0 && linux-version compare "${version}" lt 7.3 && [[ "$LINUXFAMILY" == rockchip64 ]]; then
+	if linux-version compare "${version}" ge 5.0 && [[ "$LINUXFAMILY" == rockchip64 ]]; then
 
 		# Attach to specific commit (was "branch:master")
-		local rtl8723dsver='commit:2e63716ff6357fe188f0118d6f4c9f4694912f71' # Commit date: Aug 06, 2026 (please update when updating commit ref)
+		local rtl8723dsver='commit:13c56416cb9dea2ccf9d351390ad0e9b064ac6a3' # Commit date: Sep 2nd 2026 (please update when updating commit ref)
 
 		display_alert "Adding" "Wireless drivers for Realtek 8723DS chipsets ${rtl8723dsver}" "info"
 


### PR DESCRIPTION
# Description

**depends on https://github.com/armbian/rtl8723ds/pull/19 !!** 

# How Has This Been Tested?

- [x] build rockchip64-7.3

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved RTL8723DS wireless driver compatibility on Rockchip64 systems running kernel version 5.0 or later, including newer kernel releases.
  * Updated the bundled RTL8723DS driver source to a newer revision, providing updated hardware support and compatibility improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->