### PR TITLE
extensions: skip DKMS modules on kernels built with clang

### DIFF
--- a/extensions/bcmdhd-spacemit.sh
+++ b/extensions/bcmdhd-spacemit.sh
@@ -4,6 +4,10 @@
 
 function extension_finish_config__install_kernel_headers_for_bcmdhd_spacemit_dkms() {
 
+	if [[ "${KERNEL_DKMS_BUILDABLE}" != "yes" ]]; then
+		display_alert "Kernel cannot build DKMS modules" "skipping ${EXTENSION}: ${KERNEL_DKMS_UNBUILDABLE_REASON}" "warn"
+		return 0
+	fi
 	if [[ "${KERNEL_HAS_WORKING_HEADERS}" != "yes" ]]; then
 		display_alert "Kernel version has no working headers package" "skipping bcmdhd-spacemit dkms for kernel v${KERNEL_MAJOR_MINOR}" "warn"
 		return 0
@@ -14,7 +18,7 @@ function extension_finish_config__install_kernel_headers_for_bcmdhd_spacemit_dkm
 
 function post_install_kernel_debs__install_bcmdhd_spacemit_dkms_package() {
 
-	[[ "${INSTALL_HEADERS}" != "yes" ]] || [[ "${KERNEL_HAS_WORKING_HEADERS}" != "yes" ]] && return 0
+	[[ "${INSTALL_HEADERS}" != "yes" ]] || [[ "${KERNEL_HAS_WORKING_HEADERS}" != "yes" ]] || [[ "${KERNEL_DKMS_BUILDABLE}" != "yes" ]] && return 0
 	[[ -z ${BCMDHD_SPACEMIT_TAG} ]] && return 0
 	[[ -z ${BCMDHD_SPACEMIT_TYPE} ]] && return 0
 

--- a/extensions/bcmdhd.sh
+++ b/extensions/bcmdhd.sh
@@ -1,7 +1,11 @@
-# @description Installs the Broadcom `bcmdhd` WiFi driver as a DKMS module. Downloads the latest `pcie`, `sdio`, or `usb` variant `.deb` (selected by `BCMDHD_TYPE`) from the `armbian/bcmdhd-dkms` GitHub releases and builds it in the chroot. Forces `INSTALL_HEADERS=yes`; skips when `BCMDHD_TYPE` is unset or the kernel lacks working headers.
+# @description Installs the Broadcom `bcmdhd` WiFi driver as a DKMS module. Downloads the latest `pcie`, `sdio`, or `usb` variant `.deb` (selected by `BCMDHD_TYPE`) from the `armbian/bcmdhd-dkms` GitHub releases and builds it in the chroot. Forces `INSTALL_HEADERS=yes`; skips when `BCMDHD_TYPE` is unset or the kernel lacks working headers. Also skipped on kernels built with clang/LLVM, where DKMS cannot build modules.
 
 function extension_finish_config__install_kernel_headers_for_bcmdhd_dkms() {
 
+	if [[ "${KERNEL_DKMS_BUILDABLE}" != "yes" ]]; then
+		display_alert "Kernel cannot build DKMS modules" "skipping ${EXTENSION}: ${KERNEL_DKMS_UNBUILDABLE_REASON}" "warn"
+		return 0
+	fi
 	if [[ "${KERNEL_HAS_WORKING_HEADERS}" != "yes" ]]; then
 		display_alert "Kernel version has no working headers package" "skipping bcmdhd dkms for kernel v${KERNEL_MAJOR_MINOR}" "warn"
 		return 0
@@ -12,7 +16,7 @@ function extension_finish_config__install_kernel_headers_for_bcmdhd_dkms() {
 
 function post_install_kernel_debs__install_bcmdhd_dkms_package() {
 
-	[[ "${INSTALL_HEADERS}" != "yes" ]] || [[ "${KERNEL_HAS_WORKING_HEADERS}" != "yes" ]] && return 0
+	[[ "${INSTALL_HEADERS}" != "yes" ]] || [[ "${KERNEL_HAS_WORKING_HEADERS}" != "yes" ]] || [[ "${KERNEL_DKMS_BUILDABLE}" != "yes" ]] && return 0
 	[[ -z $BCMDHD_TYPE ]] && return 0
 	api_url="https://api.github.com/repos/armbian/bcmdhd-dkms/releases/latest"
 	latest_version=$(curl -s "${api_url}" | jq -r '.tag_name')

--- a/extensions/brostrend-aic8800-dkms.sh
+++ b/extensions/brostrend-aic8800-dkms.sh
@@ -2,6 +2,10 @@
 
 function extension_finish_config__install_kernel_headers_for_aic8800_dkms() {
 
+	if [[ "${KERNEL_DKMS_BUILDABLE}" != "yes" ]]; then
+		display_alert "Kernel cannot build DKMS modules" "skipping ${EXTENSION}: ${KERNEL_DKMS_UNBUILDABLE_REASON}" "warn"
+		return 0
+	fi
 	if [[ "${KERNEL_HAS_WORKING_HEADERS}" != "yes" ]]; then
 		display_alert "Kernel version has no working headers package" "skipping aic8800 dkms for kernel v${KERNEL_MAJOR_MINOR}" "warn"
 		return 0
@@ -11,7 +15,7 @@ function extension_finish_config__install_kernel_headers_for_aic8800_dkms() {
 }
 
 function post_install_kernel_debs__install_aic8800_dkms_package() {
-	if [[ "${INSTALL_HEADERS}" != "yes" || "${KERNEL_HAS_WORKING_HEADERS}" != "yes" ]]; then
+	if [[ "${INSTALL_HEADERS}" != "yes" || "${KERNEL_HAS_WORKING_HEADERS}" != "yes" || "${KERNEL_DKMS_BUILDABLE}" != "yes" ]]; then
 		return 0
 	fi
 

--- a/extensions/nvidia.sh
+++ b/extensions/nvidia.sh
@@ -8,6 +8,10 @@ function extension_finish_config__build_nvidia_kernel_module() {
 		return 0
 	fi
 
+	if [[ "${KERNEL_DKMS_BUILDABLE}" != "yes" ]]; then
+		display_alert "Kernel cannot build DKMS modules" "skipping ${EXTENSION}: ${KERNEL_DKMS_UNBUILDABLE_REASON}" "warn"
+		return 0
+	fi
 	if [[ "${KERNEL_HAS_WORKING_HEADERS}" != "yes" ]]; then
 		display_alert "Kernel version has no working headers package" "skipping nVidia for kernel v${KERNEL_MAJOR_MINOR}" "warn"
 		return 0
@@ -31,7 +35,7 @@ function extension_finish_config__build_nvidia_kernel_module() {
 }
 
 function post_install_kernel_debs__build_nvidia_kernel_module() {
-	[[ "${INSTALL_HEADERS}" != "yes" ]] || [[ "${KERNEL_HAS_WORKING_HEADERS}" != "yes" ]] && return 0
+	[[ "${INSTALL_HEADERS}" != "yes" ]] || [[ "${KERNEL_HAS_WORKING_HEADERS}" != "yes" ]] || [[ "${KERNEL_DKMS_BUILDABLE}" != "yes" ]] && return 0
 
 	# Pre-ship the modprobe blacklist BEFORE installing nvidia packages.
 	# nvidia-dkms postinst triggers update-initramfs; with the file already
@@ -136,7 +140,7 @@ function post_install_kernel_debs__build_nvidia_kernel_module() {
 # this is the right hook for writing extension-owned auxiliary files
 # into the chroot's final filesystem.
 function post_family_tweaks__build_nvidia_kernel_module_autodetect() {
-	[[ "${INSTALL_HEADERS}" != "yes" ]] || [[ "${KERNEL_HAS_WORKING_HEADERS}" != "yes" ]] && return 0
+	[[ "${INSTALL_HEADERS}" != "yes" ]] || [[ "${KERNEL_HAS_WORKING_HEADERS}" != "yes" ]] || [[ "${KERNEL_DKMS_BUILDABLE}" != "yes" ]] && return 0
 	install_armbian_nvidia_autodetect_helper
 }
 

--- a/extensions/photonicat-pm.sh
+++ b/extensions/photonicat-pm.sh
@@ -1,7 +1,11 @@
-# @description Installs the `photonicat-pm` DKMS power-management driver for the Ariaboard Photonicat router. Fetches the latest `HackingGate/photonicat-pm` release deb and builds the kernel module in the chroot, forcing `INSTALL_HEADERS=yes`. Requires a kernel with a working headers package and is skipped on kernels ≥ 6.20.
+# @description Installs the `photonicat-pm` DKMS power-management driver for the Ariaboard Photonicat router. Fetches the latest `HackingGate/photonicat-pm` release deb and builds the kernel module in the chroot, forcing `INSTALL_HEADERS=yes`. Requires a kernel with a working headers package and is skipped on kernels ≥ 6.20. Also skipped on kernels built with clang/LLVM, where DKMS cannot build modules.
 
 function extension_finish_config__install_kernel_headers_for_photonicat_pm_dkms() {
 
+	if [[ "${KERNEL_DKMS_BUILDABLE}" != "yes" ]]; then
+		display_alert "Kernel cannot build DKMS modules" "skipping ${EXTENSION}: ${KERNEL_DKMS_UNBUILDABLE_REASON}" "warn"
+		return 0
+	fi
 	if [[ "${KERNEL_HAS_WORKING_HEADERS}" != "yes" ]]; then
 		display_alert "Kernel version has no working headers package" "skipping photonicat-pm dkms for kernel v${KERNEL_MAJOR_MINOR}" "warn"
 		return 0
@@ -16,7 +20,7 @@ function post_install_kernel_debs__install_photonicat_pm_dkms_package() {
 		display_alert "Kernel version is too recent" "skipping photonicat-pm dkms for kernel v${KERNEL_MAJOR_MINOR}" "warn"
 		return 0
 	fi
-	[[ "${INSTALL_HEADERS}" != "yes" ]] || [[ "${KERNEL_HAS_WORKING_HEADERS}" != "yes" ]] && return 0
+	[[ "${INSTALL_HEADERS}" != "yes" ]] || [[ "${KERNEL_HAS_WORKING_HEADERS}" != "yes" ]] || [[ "${KERNEL_DKMS_BUILDABLE}" != "yes" ]] && return 0
 	api_url="https://api.github.com/repos/HackingGate/photonicat-pm/releases/latest"
 	latest_version=$(curl -s "${api_url}" | jq -r '.tag_name')
 	# Get the Debian version from changelog

--- a/extensions/r8125-dkms.sh
+++ b/extensions/r8125-dkms.sh
@@ -13,6 +13,10 @@
 # Only enabled for the vendor branch on easepi-a2 board.
 
 function extension_finish_config__install_r8125_dkms() {
+	if [[ "${KERNEL_DKMS_BUILDABLE}" != "yes" ]]; then
+		display_alert "Kernel cannot build DKMS modules" "skipping ${EXTENSION}: ${KERNEL_DKMS_UNBUILDABLE_REASON}" "warn"
+		return 0
+	fi
 	if [[ "${KERNEL_HAS_WORKING_HEADERS}" != "yes" ]]; then
 		display_alert "Kernel version has no working headers package" "skipping r8125 dkms for kernel v${KERNEL_MAJOR_MINOR}" "warn"
 		return 0
@@ -33,7 +37,7 @@ function extension_finish_config__install_r8125_dkms() {
 }
 
 function post_install_kernel_debs__install_r8125_dkms_package() {
-	[[ "${INSTALL_HEADERS}" != "yes" ]] || [[ "${KERNEL_HAS_WORKING_HEADERS}" != "yes" ]] && return 0
+	[[ "${INSTALL_HEADERS}" != "yes" ]] || [[ "${KERNEL_HAS_WORKING_HEADERS}" != "yes" ]] || [[ "${KERNEL_DKMS_BUILDABLE}" != "yes" ]] && return 0
 
 	display_alert "Installing Realtek r8125 DKMS driver for RTL8125B" "${EXTENSION}" "info"
 

--- a/extensions/radxa-aic8800.sh
+++ b/extensions/radxa-aic8800.sh
@@ -1,7 +1,11 @@
-# @description Installs the AIC8800 WiFi DKMS driver and firmware for Radxa boards. Downloads the `aic8800-<type>-dkms` and firmware debs (`pcie`/`sdio`/`usb` per `AIC8800_TYPE`) from the latest `radxa-pkg/aic8800` release and builds the module in the chroot. Forces `INSTALL_HEADERS=yes`, needs working kernel headers, and skips kernels ≥ 7.3.
+# @description Installs the AIC8800 WiFi DKMS driver and firmware for Radxa boards. Downloads the `aic8800-<type>-dkms` and firmware debs (`pcie`/`sdio`/`usb` per `AIC8800_TYPE`) from the latest `radxa-pkg/aic8800` release and builds the module in the chroot. Forces `INSTALL_HEADERS=yes`, needs working kernel headers, and skips kernels ≥ 7.3. Also skipped on kernels built with clang/LLVM, where DKMS cannot build modules.
 
 function extension_finish_config__install_kernel_headers_for_aic8800_dkms() {
 
+	if [[ "${KERNEL_DKMS_BUILDABLE}" != "yes" ]]; then
+		display_alert "Kernel cannot build DKMS modules" "skipping ${EXTENSION}: ${KERNEL_DKMS_UNBUILDABLE_REASON}" "warn"
+		return 0
+	fi
 	if [[ "${KERNEL_HAS_WORKING_HEADERS}" != "yes" ]]; then
 		display_alert "Kernel version has no working headers package" "skipping aic8800 dkms for kernel v${KERNEL_MAJOR_MINOR}" "warn"
 		return 0
@@ -16,7 +20,7 @@ function post_install_kernel_debs__install_aic8800_dkms_package() {
 		display_alert "Kernel version is too recent" "skipping aic8800 dkms for kernel v${KERNEL_MAJOR_MINOR}" "warn"
 		return 0
 	fi
-	[[ "${INSTALL_HEADERS}" != "yes" ]] || [[ "${KERNEL_HAS_WORKING_HEADERS}" != "yes" ]] && return 0
+	[[ "${INSTALL_HEADERS}" != "yes" ]] || [[ "${KERNEL_HAS_WORKING_HEADERS}" != "yes" ]] || [[ "${KERNEL_DKMS_BUILDABLE}" != "yes" ]] && return 0
 	[[ -z $AIC8800_TYPE ]] && return 0
 	api_url="https://api.github.com/repos/radxa-pkg/aic8800/releases/latest"
 	latest_version=$(curl -s "${api_url}" | jq -r '.tag_name')

--- a/extensions/v4l2loopback-dkms.sh
+++ b/extensions/v4l2loopback-dkms.sh
@@ -1,9 +1,13 @@
-# @description Builds the `v4l2loopback` virtual-camera kernel module via DKMS in the chroot, installing `v4l2loopback-dkms`, `v4l2loopback-utils`, and `v4l-utils`. Forces `INSTALL_HEADERS=yes` and requires a kernel with a working headers package. Skipped on minimal CLI images and on kernels 7.2 or newer, where the module no longer builds.
+# @description Builds the `v4l2loopback` virtual-camera kernel module via DKMS in the chroot, installing `v4l2loopback-dkms`, `v4l2loopback-utils`, and `v4l-utils`. Forces `INSTALL_HEADERS=yes` and requires a kernel with a working headers package. Skipped on minimal CLI images and on kernels 7.2 or newer, where the module no longer builds. Also skipped on kernels built with clang/LLVM, where DKMS cannot build modules.
 
 function extension_finish_config__build_v4l2loopback_dkms_kernel_module() {
 	# Deny on minimal CLI images
 	if [[ "${BUILD_MINIMAL}" == "yes" ]]; then
 		display_alert "Extension: ${EXTENSION}" "skip installation in minimal images" "warn"
+		return 0
+	fi
+	if [[ "${KERNEL_DKMS_BUILDABLE}" != "yes" ]]; then
+		display_alert "Kernel cannot build DKMS modules" "skipping ${EXTENSION}: ${KERNEL_DKMS_UNBUILDABLE_REASON}" "warn"
 		return 0
 	fi
 	if [[ "${KERNEL_HAS_WORKING_HEADERS}" != "yes" ]]; then
@@ -19,7 +23,7 @@ function post_install_kernel_debs__build_v4l2loopback_dkms_kernel_module() {
 		display_alert "Kernel version is too recent" "skipping v4l2loopback-dkms for kernel v${KERNEL_MAJOR_MINOR}" "warn"
 		return 0
 	fi
-	[[ "${INSTALL_HEADERS}" != "yes" ]] || [[ "${KERNEL_HAS_WORKING_HEADERS}" != "yes" ]] && return 0
+	[[ "${INSTALL_HEADERS}" != "yes" ]] || [[ "${KERNEL_HAS_WORKING_HEADERS}" != "yes" ]] || [[ "${KERNEL_DKMS_BUILDABLE}" != "yes" ]] && return 0
 
 	# v4l2loopback only builds against current kernels from 0.15.3 onwards. Earlier releases
 	# call v4l2_fh_add() with the pre-signature-change argument count and fail the DKMS build

--- a/extensions/yt6801.sh
+++ b/extensions/yt6801.sh
@@ -2,6 +2,10 @@
 
 function extension_finish_config__install_kernel_headers_for_yt6801_dkms() {
 
+	if [[ "${KERNEL_DKMS_BUILDABLE}" != "yes" ]]; then
+		display_alert "Kernel cannot build DKMS modules" "skipping ${EXTENSION}: ${KERNEL_DKMS_UNBUILDABLE_REASON}" "warn"
+		return 0
+	fi
 	if [[ "${KERNEL_HAS_WORKING_HEADERS}" != "yes" ]]; then
 		display_alert "Kernel version has no working headers package" "skipping yt6801 dkms for kernel v${KERNEL_MAJOR_MINOR}" "warn"
 		return 0
@@ -12,7 +16,7 @@ function extension_finish_config__install_kernel_headers_for_yt6801_dkms() {
 
 function post_install_kernel_debs__install_yt6801_dkms_package() {
 
-	[[ "${INSTALL_HEADERS}" != "yes" ]] || [[ "${KERNEL_HAS_WORKING_HEADERS}" != "yes" ]] && return 0
+	[[ "${INSTALL_HEADERS}" != "yes" ]] || [[ "${KERNEL_HAS_WORKING_HEADERS}" != "yes" ]] || [[ "${KERNEL_DKMS_BUILDABLE}" != "yes" ]] && return 0
 	api_url="https://api.github.com/repos/amazingfate/yt6801-dkms/releases/latest"
 	latest_version=$(curl -s "${api_url}" | jq -r '.tag_name')
 	yt6801_dkms_url="https://github.com/amazingfate/yt6801-dkms/releases/download/${latest_version}/yt6801-dkms_${latest_version}_all.deb"

--- a/extensions/zfs.sh
+++ b/extensions/zfs.sh
@@ -1,6 +1,10 @@
-# @description Installs OpenZFS on the image by building the `zfs` kernel module through DKMS. Installs the `zfs-dkms` and `zfsutils-linux` packages in the chroot, forcing `INSTALL_HEADERS=yes` so the module can compile against the kernel headers. Skips itself when `KERNEL_HAS_WORKING_HEADERS` is not `yes`.
+# @description Installs OpenZFS on the image by building the `zfs` kernel module through DKMS. Installs the `zfs-dkms` and `zfsutils-linux` packages in the chroot, forcing `INSTALL_HEADERS=yes` so the module can compile against the kernel headers. Skips itself when `KERNEL_HAS_WORKING_HEADERS` is not `yes`. Also skipped on kernels built with clang/LLVM, where DKMS cannot build modules.
 
 function extension_finish_config__build_zfs_kernel_module() {
+	if [[ "${KERNEL_DKMS_BUILDABLE}" != "yes" ]]; then
+		display_alert "Kernel cannot build DKMS modules" "skipping ${EXTENSION}: ${KERNEL_DKMS_UNBUILDABLE_REASON}" "warn"
+		return 0
+	fi
 	if [[ "${KERNEL_HAS_WORKING_HEADERS}" != "yes" ]]; then
 		display_alert "Kernel version has no working headers package" "skipping ZFS for kernel v${KERNEL_MAJOR_MINOR}" "warn"
 		return 0
@@ -10,7 +14,7 @@ function extension_finish_config__build_zfs_kernel_module() {
 }
 
 function post_install_kernel_debs__build_zfs_kernel_module() {
-	[[ "${INSTALL_HEADERS}" != "yes" ]] || [[ "${KERNEL_HAS_WORKING_HEADERS}" != "yes" ]] && return 0
+	[[ "${INSTALL_HEADERS}" != "yes" ]] || [[ "${KERNEL_HAS_WORKING_HEADERS}" != "yes" ]] || [[ "${KERNEL_DKMS_BUILDABLE}" != "yes" ]] && return 0
 	display_alert "Install ZFS packages, will build kernel module in chroot" "${EXTENSION}" "info"
 	declare -ag if_error_find_files_sdcard=("/var/lib/dkms/zfs/*/build/*.log")
 	# See https://github.com/zfsonlinux/pkg-zfs/issues/69 for a bug with leaking env vars.

--- a/lib/functions/main/config-prepare.sh
+++ b/lib/functions/main/config-prepare.sh
@@ -212,6 +212,31 @@ function config_post_main() {
 	fi
 	track_general_config_variables "at beginning of config_post_main"
 
+	# Can DKMS build out-of-tree modules against this kernel inside the image?
+	#
+	# Distinct from KERNEL_HAS_WORKING_HEADERS, which asks whether the headers
+	# package itself is usable: on a clang-built kernel the headers are fine (see
+	# the sidecar tarball in kernel-debs.sh, which deliberately preserves
+	# CONFIG_CC_IS_CLANG so they describe the kernel as actually compiled), but no
+	# DKMS module can be built from them. The headers advertise clang, DKMS then
+	# invokes it with LLVM=1, and clang is not installed in any Armbian rootfs:
+	#
+	#     The kernel was built by: Debian clang version 19.1.7
+	#     /bin/sh: 1: clang: not found
+	#     make[4]: *** [v4l2loopback.o] Error 127
+	#
+	# Falling back to gcc is not an option either: these kernels set
+	# CONFIG_LTO_CLANG/CONFIG_LTO_CLANG_THIN, and gcc-built modules cannot link
+	# against a ThinLTO kernel. Shipping the toolchain in the image would cost
+	# ~270MB and would still have to keep matching the kernel's clang major on
+	# every future kernel upgrade, so DKMS extensions skip themselves instead.
+	declare -g KERNEL_DKMS_BUILDABLE="yes"
+	declare -g KERNEL_DKMS_UNBUILDABLE_REASON=""
+	if [[ "${KERNEL_COMPILER}" == "clang" ]]; then
+		declare -g KERNEL_DKMS_BUILDABLE="no"
+		declare -g KERNEL_DKMS_UNBUILDABLE_REASON="kernel is built with clang/LLVM, which is not available in the image"
+	fi
+
 	# So for kernel full cached rebuilds.
 	# We wanna be able to rebuild kernels very fast. so it only makes sense to use a dir for each built kernel.
 	# That is the "default" layout; there will be as many source dirs as there are built kernel debs.


### PR DESCRIPTION
> **TL;DR** — Xiaomi-sheng images fail because DKMS can't build against a clang/ThinLTO kernel: the headers correctly advertise clang, DKMS invokes it, and clang isn't in the rootfs. Gate DKMS extensions on a new `KERNEL_DKMS_BUILDABLE` instead of failing the build.

## The failure

[armbian/ci run 33517020634](https://github.com/armbian/ci/actions/runs/33517020634), Xiaomi-sheng gnome + kde:

```
DKMS make.log for v4l2loopback/0.15.3 for kernel 7.1.8-edge-sm8550-sheng
# command: make ... v4l2loopback LLVM=1
The kernel was built by: Debian clang version 19.1.7
You are using:
/bin/sh: 1: clang: not found
make[4]: *** [v4l2loopback.o] Error 127
```

## Cause

`sm8550-sheng.conf` sets `KERNEL_COMPILER="clang"`, and `kernel-debs.sh` deliberately preserves `CONFIG_CC_IS_CLANG` in the headers package (the sidecar tarball added for #9425) so the headers describe the kernel *as actually compiled*. Both are correct — and together they mean DKMS selects `LLVM=1`, while clang is installed in no Armbian rootfs.

Note this is **not** the same bug as the one fixed in `3c077ad35`. That scoped `LLVM=1` to the kernel make so it stopped leaking into the linux-headers postinst. DKMS reaches the identical wall by a different route: it reads the shipped headers rather than inheriting the environment.

And nothing about it is specific to v4l2loopback — any of the ten DKMS extensions hits it on such a kernel.

## Change

A gate, `KERNEL_DKMS_BUILDABLE`, computed once in `config_post_main` and consulted by all ten DKMS extensions next to the `KERNEL_HAS_WORKING_HEADERS` check they already share.

**Why a separate variable.** The headers package here is genuinely fine. Folding this into `KERNEL_HAS_WORKING_HEADERS` would also stop the `linux-headers` deb being built and change the kernel artifact package map — hence the artifact hash — invalidating caches and removing headers from users who might install clang themselves.

**Why skip rather than ship the toolchain.** gcc is not a fallback: these kernels set `CONFIG_LTO_CLANG`/`CONFIG_LTO_CLANG_THIN`, and gcc-built modules cannot link against a ThinLTO kernel. Installing the toolchain would cost ~270 MB (`libllvm19` 122, `llvm-19` 69, `libclang-cpp19` 66, `lld-19` 5) and would still have to keep matching the kernel's clang major on every future kernel upgrade. Skipping mirrors the kernel ≥ 7.2 cutoff `v4l2loopback-dkms` already carries.

The visible effect is that sheng images lose v4l2loopback (virtual camera). They currently build no image at all.

## Verification

`compile.sh configdump` against real boards:

| Board | Branch | `KERNEL_COMPILER` | `KERNEL_DKMS_BUILDABLE` | `KERNEL_HAS_WORKING_HEADERS` |
|---|---|---|---|---|
| xiaomi-sheng | edge 7.1 | `clang` | **no** | `yes` (unchanged) |
| orangepi5-max | edge 7.2 | `aarch64-linux-gnu-` | `yes` | `yes` (unchanged) |

So gcc-built boards are untouched and the headers deb still ships on sheng. `bash -n` clean across all extensions.

## Related

The other failures in that run are Orange Pi 5 Max / bcmdhd on 7.2, fixed separately and released as [bcmdhd-dkms 101.10.591.52.27-8](https://github.com/armbian/bcmdhd-dkms/releases/tag/101.10.591.52.27-8), which `extensions/bcmdhd.sh` picks up automatically.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * DKMS-based driver and module extensions now detect kernels that cannot build DKMS modules and skip incompatible installation steps.
  * Added clear warnings explaining why DKMS components were not installed.
  * Prevented failed driver builds and related package installation attempts on clang/LLVM-built kernels.
  * Existing header and kernel capability checks continue to be honored across supported extensions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->