### PR TITLE
Handle initrd compression method during U-Boot image generation

### DIFF
--- a/packages/bsp/common/etc/initramfs/post-update.d/99-uboot
+++ b/packages/bsp/common/etc/initramfs/post-update.d/99-uboot
@@ -9,11 +9,23 @@
 # Special case: the lzo method is referred to as "lzop" in initramfs.conf, after the
 # compressor software, but U-Boot requires "lzo" as the compression method
 [ "$COMPRESS" = "lzop" ] && COMPRESS="lzo"
+# "xz" uses the LZMA compression algorithm. Although its file format differs from that
+# produced by "lzma" software, both should be accepted as "lzma" compression method
+# by U-Boot
+[ "$COMPRESS" = "xz" ] && COMPRESS="lzma"
 # Warn if $COMPRESS specifies a compression method not supported by U-Boot
 [ "$COMPRESS" = "gzip" ] || [ "$COMPRESS" = "bzip2" ] || [ "$COMPRESS" = "zstd" ] || \
 [ "$COMPRESS" = "lzo"  ] || [ "$COMPRESS" = "lz4"   ] || [ "$COMPRESS" = "lzma" ] || \
 echo "update-initramfs: Armbian: Warning: unsupported compression method \"$COMPRESS\"" \
-	"configured in /etc/initramfs-tools/initramfs.conf"
+	"configured in initramfs.conf"
+# Check if mkinitramfs falled back to gzip when other method was specified
+if [ "$COMPRESS" != "gzip" ] && [ -x $( command -v gzip ) ]; then
+	if gzip -ql $2 >/dev/null 2>&1; then
+		echo "update-initramfs: Armbian: Warning: $2 is gzip, but \"$COMPRESS\"" \
+			"configured in initramfs.conf"
+		COMPRESS="gzip"
+	fi
+fi
 
 tempname="/boot/uInitrd-$1"
 echo "update-initramfs: Armbian: Converting to u-boot format: ${tempname}" >&2

--- a/packages/bsp/common/etc/initramfs/post-update.d/99-uboot
+++ b/packages/bsp/common/etc/initramfs/post-update.d/99-uboot
@@ -2,9 +2,22 @@
 
 . /etc/armbian-release
 
+# Source initramfs.conf to determine the initrd compression method
+[ -f /etc/initramfs-tools/initramfs.conf ] && . /etc/initramfs-tools/initramfs.conf
+# Default to "gzip" if unset
+[ -z "$COMPRESS" ] && COMPRESS="gzip"
+# Special case: the lzo method is referred to as "lzop" in initramfs.conf, after the
+# compressor software, but U-Boot requires "lzo" as the compression method
+[ "$COMPRESS" = "lzop" ] && COMPRESS="lzo"
+# Warn if $COMPRESS specifies a compression method not supported by U-Boot
+[ "$COMPRESS" = "gzip" ] || [ "$COMPRESS" = "bzip2" ] || [ "$COMPRESS" = "zstd" ] || \
+[ "$COMPRESS" = "lzo"  ] || [ "$COMPRESS" = "lz4"   ] || [ "$COMPRESS" = "lzma" ] || \
+echo "update-initramfs: Armbian: Warning: unsupported compression method \"$COMPRESS\"" \
+	"configured in /etc/initramfs-tools/initramfs.conf"
+
 tempname="/boot/uInitrd-$1"
 echo "update-initramfs: Armbian: Converting to u-boot format: ${tempname}" >&2
-mkimage -A $INITRD_ARCH -O linux -T ramdisk -C gzip -n uInitrd -d $2 $tempname
+mkimage -A $INITRD_ARCH -O linux -T ramdisk -C "$COMPRESS" -n uInitrd -d $2 $tempname
 
 echo "update-initramfs: Armbian: Symlinking ${tempname} to /boot/uInitrd" >&2
 ln -sfv $(basename $tempname) /boot/uInitrd || {


### PR DESCRIPTION
# Description

The `/etc/initramfs/post-update.d/99-uboot` hook, which is used to convert an initramfs-tools-generated initrd into a U-Boot `uInitrd`, currently passes a hardcoded `gzip` compression method to `mkimage`. However, `mkimage` only uses this argument as metadata and does not compress the image itself.

If another compression method is configured in `/etc/initramfs-tools/initramfs.conf`, initramfs-tools generates an initrd compressed with that algorithm, while `mkimage` is still instructed to treat it as a gzip-compressed image. U-Boot supports most compression methods that can be specified in `initramfs.conf` (with special cases for the `lzop`/`lzo` and `xz`/`lzma` naming difference), so there is no reason to keep `gzip` hardcoded here.

This PR makes `99-uboot` source the variables from `/etc/initramfs-tools/initramfs.conf`, perform the necessary validation and handling of the `$COMPRESS` value, and pass it as the compression method (`-C` argument) to `mkimage` instead of the fixed `gzip` value.

# How Has This Been Tested?

1. Change `COMPRESS` in `/etc/initramfs-tools/initramfs.conf`.
2. Run `update-initramfs -u -k all` and verify that both the initrd and uInitrd images are generated using the configured compression algorithm.
3. Repeat steps 1-2 for all valid `COMPRESS` values supported by `initramfs.conf`.
4. Repeat steps 1-2 with `COMPRESS` unset (commented out), with an invalid compression method specified, and with `initramfs.conf` missing.

I've also tested building and booting a zstd-compressed initrd/uInitrd image on my Orange Pi One running the up-to-date `Armbian_26.8.1_Orangepione_trixie_current_6.18.44_minimal.img.xz` image. Everything works as expected without issues, and rebuilding the initrd with zstd compression is considerably faster on this relatively old board. This is partly because zstd uses multiple threads by default and is significantly faster than gzip even without multithreading.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings (although they add one new warning for an invalid configuration)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

* Improved U-Boot initramfs image creation for configured compression methods.
* Added support for mapping `xz` compression to U-Boot’s `lzma` format.
* Detects when initramfs generation falls back to gzip and uses the effective compression format when creating the image.
* Displays a warning when the configured compression method differs from the generated payload.
* Updated unsupported-compression warnings to reference `initramfs.conf`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->