### PR TITLE
uefi-x86 (6.12 + 6.18): fix T2 magicmouse raw_event split ('nested' undeclared)

### DIFF
--- a/patch/kernel/archive/uefi-x86-6.12/4001-asahi-trackpad.patch
+++ b/patch/kernel/archive/uefi-x86-6.12/4001-asahi-trackpad.patch
@@ -478,10 +478,19 @@ index 111111111111..222222222222 100644
  };
  
  static int magicmouse_firm_touch(struct magicmouse_sc *msc)
-@@ -386,6 +395,14 @@ static int magicmouse_raw_event(struct hid_device *hdev,
- 		struct hid_report *report, u8 *data, int size)
+@@ -386,6 +395,23 @@ static int __magicmouse_raw_event(struct hid_device *hdev,
+ 		struct hid_report *report, u8 *data, int size, bool nested)
  {
  	struct magicmouse_sc *msc = hid_get_drvdata(hdev);
++
++	/*
++	 * A double report only ever wraps two normal reports, so it is never
++	 * nested. Refuse to recurse a second time; otherwise a malicious
++	 * device could chain DOUBLE_REPORT_ID packets to drive unbounded
++	 * recursion and overflow the kernel stack.
++	 */
++	if (nested && size >= 1 && data[0] == DOUBLE_REPORT_ID)
++		return 0;
 +
 +	return msc->input_ops.raw_event(hdev, report, data, size);
 +}
@@ -493,6 +502,20 @@ index 111111111111..222222222222 100644
  	struct input_dev *input = msc->input;
  	int x = 0, y = 0, ii, clicks = 0, npoints;
  
+@@ -493,13 +519,4 @@ static int __magicmouse_raw_event(struct hid_device *hdev,
+ 		 * packet.
+ 		 */
+ 
+-		/*
+-		 * A double report only ever wraps two normal reports, so it is
+-		 * never nested. Refuse to recurse a second time; otherwise a
+-		 * malicious device could chain DOUBLE_REPORT_ID packets to drive
+-		 * unbounded recursion and overflow the kernel stack.
+-		 */
+-		if (nested)
+-			return 0;
+-
+ 		/* Ensure that we have at least 2 elements (report type and size) */
 @@ -533,7 +550,17 @@ static int magicmouse_event(struct hid_device *hdev, struct hid_field *field,
  	return 0;
  }

--- a/patch/kernel/archive/uefi-x86-6.18/4001-asahi-trackpad.patch
+++ b/patch/kernel/archive/uefi-x86-6.18/4001-asahi-trackpad.patch
@@ -472,10 +472,19 @@ index 111111111111..222222222222 100644
  };
  
  static int magicmouse_firm_touch(struct magicmouse_sc *msc)
-@@ -389,6 +398,14 @@ static int magicmouse_raw_event(struct hid_device *hdev,
- 		struct hid_report *report, u8 *data, int size)
+@@ -389,6 +398,23 @@ static int __magicmouse_raw_event(struct hid_device *hdev,
+ 		struct hid_report *report, u8 *data, int size, bool nested)
  {
  	struct magicmouse_sc *msc = hid_get_drvdata(hdev);
++
++	/*
++	 * A double report only ever wraps two normal reports, so it is never
++	 * nested. Refuse to recurse a second time; otherwise a malicious
++	 * device could chain DOUBLE_REPORT_ID packets to drive unbounded
++	 * recursion and overflow the kernel stack.
++	 */
++	if (nested && size >= 1 && data[0] == DOUBLE_REPORT_ID)
++		return 0;
 +
 +	return msc->input_ops.raw_event(hdev, report, data, size);
 +}
@@ -487,7 +496,7 @@ index 111111111111..222222222222 100644
  	struct input_dev *input = msc->input;
  	int x = 0, y = 0, ii, clicks = 0, npoints;
  
-@@ -538,7 +555,17 @@ static int magicmouse_event(struct hid_device *hdev, struct hid_field *field,
+@@ -538,7 +564,17 @@ static int magicmouse_event(struct hid_device *hdev, struct hid_field *field,
  	return 0;
  }
  
@@ -506,7 +515,7 @@ index 111111111111..222222222222 100644
  {
  	int error;
  	int mt_flags = 0;
-@@ -865,6 +892,9 @@ static int magicmouse_probe(struct hid_device *hdev,
+@@ -865,6 +901,9 @@ static int magicmouse_probe(struct hid_device *hdev,
  		return -ENOMEM;
  	}
  
@@ -587,7 +596,21 @@ index 111111111111..222222222222 100644
  
  struct magicmouse_input_ops {
  	int (*raw_event)(struct hid_device *hdev,
-@@ -537,6 +550,154 @@ static int magicmouse_raw_event_usb(struct hid_device *hdev,
+@@ -496,13 +509,4 @@ static int __magicmouse_raw_event(struct hid_device *hdev,
+ 		 * packet.
+ 		 */
+ 
+-		/*
+-		 * A double report only ever wraps two normal reports, so it is
+-		 * never nested. Refuse to recurse a second time; otherwise a
+-		 * malicious device could chain DOUBLE_REPORT_ID packets to drive
+-		 * unbounded recursion and overflow the kernel stack.
+-		 */
+-		if (nested)
+-			return 0;
+-
+ 		/* Ensure that we have at least 2 elements (report type and size) */
+@@ -537,6 +541,154 @@ static int magicmouse_raw_event_usb(struct hid_device *hdev,
  	return 1;
  }
  
@@ -742,7 +765,7 @@ index 111111111111..222222222222 100644
  static int magicmouse_event(struct hid_device *hdev, struct hid_field *field,
  		struct hid_usage *usage, __s32 value)
  {
-@@ -727,6 +888,79 @@ static int magicmouse_setup_input_usb(struct input_dev *input,
+@@ -727,6 +879,79 @@ static int magicmouse_setup_input_usb(struct input_dev *input,
  	return 0;
  }
  
@@ -822,7 +845,7 @@ index 111111111111..222222222222 100644
  static int magicmouse_input_mapping(struct hid_device *hdev,
  		struct hid_input *hi, struct hid_field *field,
  		struct hid_usage *usage, unsigned long **bit, int *max)
-@@ -782,6 +1016,10 @@ static int magicmouse_enable_multitouch(struct hid_device *hdev)
+@@ -782,6 +1007,10 @@ static int magicmouse_enable_multitouch(struct hid_device *hdev)
  	int feature_size;
  
  	switch (hdev->product) {
@@ -833,7 +856,7 @@ index 111111111111..222222222222 100644
  	case USB_DEVICE_ID_APPLE_MAGICTRACKPAD2:
  	case USB_DEVICE_ID_APPLE_MAGICTRACKPAD2_USBC:
  		switch (hdev->vendor) {
-@@ -789,7 +1027,7 @@ static int magicmouse_enable_multitouch(struct hid_device *hdev)
+@@ -789,7 +1018,7 @@ static int magicmouse_enable_multitouch(struct hid_device *hdev)
  			feature_size = sizeof(feature_mt_trackpad2_bt);
  			feature = feature_mt_trackpad2_bt;
  			break;
@@ -842,7 +865,7 @@ index 111111111111..222222222222 100644
  			feature_size = sizeof(feature_mt_trackpad2_usb);
  			feature = feature_mt_trackpad2_usb;
  		}
-@@ -886,14 +1124,25 @@ static int magicmouse_probe(struct hid_device *hdev,
+@@ -886,14 +1115,25 @@ static int magicmouse_probe(struct hid_device *hdev,
  	struct hid_report *report;
  	int ret;
  
@@ -870,7 +893,7 @@ index 111111111111..222222222222 100644
  
  	msc->scroll_accel = SCROLL_ACCEL_DEFAULT;
  	msc->hdev = hdev;
-@@ -953,6 +1202,15 @@ static int magicmouse_probe(struct hid_device *hdev,
+@@ -953,6 +1193,15 @@ static int magicmouse_probe(struct hid_device *hdev,
  				TRACKPAD2_USB_REPORT_ID, 0);
  		}
  		break;
@@ -886,7 +909,7 @@ index 111111111111..222222222222 100644
  	default: /* USB_DEVICE_ID_APPLE_MAGICTRACKPAD */
  		report = hid_register_report(hdev, HID_INPUT_REPORT,
  			TRACKPAD_REPORT_ID, 0);
-@@ -1058,6 +1316,8 @@ static const struct hid_device_id magic_mice[] = {
+@@ -1058,6 +1307,8 @@ static const struct hid_device_id magic_mice[] = {
  		USB_DEVICE_ID_APPLE_MAGICTRACKPAD2_USBC), .driver_data = 0 },
  	{ HID_USB_DEVICE(USB_VENDOR_ID_APPLE,
  		USB_DEVICE_ID_APPLE_MAGICTRACKPAD2_USBC), .driver_data = 0 },


### PR DESCRIPTION
## Problem

`kernel-x86-legacy` (6.12.108) fails to build — e.g. [this scheduled CI run](https://github.com/armbian/ci/actions/runs/33713556655):

```
drivers/hid/hid-magicmouse.c:813:21: error: 'nested' undeclared (first use in this function)
make[4]: *** [drivers/hid/hid-magicmouse.o] Error 1
```

## Cause

Stable **6.12.108** backported the `DOUBLE_REPORT_ID` recursion hardening: the parser became `__magicmouse_raw_event(..., bool nested)` wrapped by a thin `magicmouse_raw_event()`, and the wrapped-report branch refuses to recurse twice.

The T2 series (`4001-asahi-trackpad.patch`) splits that parser into a per-bus handler + an `input_ops` dispatcher. Applied unchanged onto 6.12.108 it cuts the function in the wrong place: the `if (nested) return 0;` guard is left behind in the split-out body, which is now `magicmouse_raw_event_usb()` and has **no** `nested` parameter → the build error. Meanwhile `__magicmouse_raw_event()` keeps `nested` but silently discards it.

## Fix

Rebase the split so the recursion guard moves into the **dispatcher** — the single choke point every report passes through (entry `nested=false`, `DOUBLE_REPORT_ID` recursion `nested=true`) — checking `nested && data[0] == DOUBLE_REPORT_ID` with a size guard there (equivalent to upstream's check one frame deeper). Handlers keep the 4-arg `raw_event` signature that sub-patches 4004/4006 build on.

This is the **6.12 counterpart of the same fix already landed for uefi-x86-7.2 (#10575).**

**Verified** by replaying 4001/4004/4006 over upstream `hid-magicmouse.c` at `v6.12.108`: all apply with **no rejects**, `nested` survives only inside the dispatcher, the recursion guard remains functional, and `magicmouse_raw_event_usb` has no undefined symbol.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Apple Silicon keyboard and trackpad support for Asahi Linux.
  * Added support for SPI- and host-connected Apple HID devices, including MacBook keyboards, Touch Bars, Magic Mouse, and trackpads.
  * Added Apple SPI HID and DockChannel transport support.
  * Added suspend and resume support for Apple SPI HID devices.
  * Improved trackpad handling with touch-controller recovery and automatic device dimension detection.

* **Bug Fixes**
  * Improved RTKit crash reporting by preserving crash log details.
  * Improved reliability of SPI HID communication through status verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->