### PR TITLE
rockchip64: firefly-rk3399: fix RK808 LDO mapping (analog audio is dead)

### DIFF
--- a/patch/kernel/archive/rockchip64-6.12/board-firefly-rk3399-dts.patch
+++ b/patch/kernel/archive/rockchip64-6.12/board-firefly-rk3399-dts.patch
@@ -30,13 +30,13 @@ Subject: [ARCHEOLOGY] firefly-rk3399: move to rockchip64 family
 > X-Git-Archeology:
 ---
  arch/arm64/boot/dts/rockchip/rk3399-firefly.dts | 133 +++++++---
- 1 file changed, 103 insertions(+), 30 deletions(-)
+ 1 file changed, 91 insertions(+), 20 deletions(-)
 
 diff --git a/arch/arm64/boot/dts/rockchip/rk3399-firefly.dts b/arch/arm64/boot/dts/rockchip/rk3399-firefly.dts
 index 111111111111..222222222222 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3399-firefly.dts
 +++ b/arch/arm64/boot/dts/rockchip/rk3399-firefly.dts
-@@ -216,7 +216,7 @@ vcc5v0_host: vcc5v0-host-regulator {
+@@ -216,7 +216,7 @@
  		enable-active-high;
  		gpio = <&gpio1 RK_PA0 GPIO_ACTIVE_HIGH>;
  		pinctrl-names = "default";
@@ -45,7 +45,7 @@ index 111111111111..222222222222 100644
  		regulator-name = "vcc5v0_host";
  		regulator-always-on;
  		vin-supply = <&vcc_sys>;
-@@ -235,8 +235,11 @@ vcc5v0_typec: vcc5v0-typec-regulator {
+@@ -235,8 +235,11 @@
  
  	vcc_sys: vcc-sys {
  		compatible = "regulator-fixed";
@@ -58,7 +58,7 @@ index 111111111111..222222222222 100644
  		regulator-boot-on;
  		regulator-min-microvolt = <5000000>;
  		regulator-max-microvolt = <5000000>;
-@@ -253,6 +256,27 @@ vdd_log: vdd-log {
+@@ -253,6 +256,27 @@
  		regulator-min-microvolt = <430000>;
  		regulator-max-microvolt = <1400000>;
  	};
@@ -86,16 +86,7 @@ index 111111111111..222222222222 100644
  };
  
  &cpu_l0 {
-@@ -305,6 +329,8 @@ &gpu {
- };
- 
- &hdmi {
-+	avdd-0v9-supply = <&vcca0v9_hdmi>;
-+	avdd-1v8-supply = <&vcca1v8_hdmi>;
- 	ddc-i2c-bus = <&i2c3>;
- 	pinctrl-names = "default";
- 	pinctrl-0 = <&hdmi_cec>;
-@@ -329,18 +355,18 @@ rk808: pmic@1b {
+@@ -329,18 +353,18 @@
  		rockchip,system-power-controller;
  		wakeup-source;
  
@@ -124,52 +115,7 @@ index 111111111111..222222222222 100644
  
  		regulators {
  			vdd_center: DCDC_REG1 {
-@@ -388,8 +414,8 @@ regulator-state-mem {
- 				};
- 			};
- 
--			vcc1v8_dvp: LDO_REG1 {
--				regulator-name = "vcc1v8_dvp";
-+			vcca1v8_codec: LDO_REG1 {
-+				regulator-name = "vcca1v8_codec";
- 				regulator-always-on;
- 				regulator-boot-on;
- 				regulator-min-microvolt = <1800000>;
-@@ -399,12 +425,12 @@ regulator-state-mem {
- 				};
- 			};
- 
--			vcc2v8_dvp: LDO_REG2 {
--				regulator-name = "vcc2v8_dvp";
-+			vcca1v8_hdmi: LDO_REG2 {
-+				regulator-name = "vcca1v8_hdmi";
- 				regulator-always-on;
- 				regulator-boot-on;
--				regulator-min-microvolt = <2800000>;
--				regulator-max-microvolt = <2800000>;
-+				regulator-min-microvolt = <1800000>;
-+				regulator-max-microvolt = <1800000>;
- 				regulator-state-mem {
- 					regulator-off-in-suspend;
- 				};
-@@ -457,12 +483,12 @@ regulator-state-mem {
- 				};
- 			};
- 
--			vcca1v8_codec: LDO_REG7 {
--				regulator-name = "vcca1v8_codec";
-+			vcca0v9_hdmi: LDO_REG7 {
-+				regulator-name = "vcca0v9_hdmi";
- 				regulator-always-on;
- 				regulator-boot-on;
--				regulator-min-microvolt = <1800000>;
--				regulator-max-microvolt = <1800000>;
-+				regulator-min-microvolt = <900000>;
-+				regulator-max-microvolt = <900000>;
- 				regulator-state-mem {
- 					regulator-off-in-suspend;
- 				};
-@@ -503,14 +529,16 @@ regulator-state-mem {
+@@ -503,14 +527,16 @@
  	vdd_cpu_b: regulator@40 {
  		compatible = "silergy,syr827";
  		reg = <0x40>;
@@ -188,7 +134,7 @@ index 111111111111..222222222222 100644
  
  		regulator-state-mem {
  			regulator-off-in-suspend;
-@@ -521,13 +549,15 @@ vdd_gpu: regulator@41 {
+@@ -521,13 +547,15 @@
  		compatible = "silergy,syr828";
  		reg = <0x41>;
  		fcs,suspend-voltage-selector = <1>;
@@ -205,7 +151,7 @@ index 111111111111..222222222222 100644
  
  		regulator-state-mem {
  			regulator-off-in-suspend;
-@@ -564,7 +594,7 @@ &i2c4 {
+@@ -564,7 +592,7 @@
  	status = "okay";
  
  	fusb0: typec-portc@22 {
@@ -214,7 +160,7 @@ index 111111111111..222222222222 100644
  		reg = <0x22>;
  		interrupt-parent = <&gpio1>;
  		interrupts = <RK_PA2 IRQ_TYPE_LEVEL_LOW>;
-@@ -637,7 +667,7 @@ &i2s2 {
+@@ -637,7 +665,7 @@
  &io_domains {
  	status = "okay";
  
@@ -223,7 +169,7 @@ index 111111111111..222222222222 100644
  	audio-supply = <&vcca1v8_codec>;
  	sdmmc-supply = <&vcc_sdio>;
  	gpio1830-supply = <&vcc_3v0>;
-@@ -651,7 +681,10 @@ &pcie0 {
+@@ -651,7 +679,10 @@
  	ep-gpios = <&gpio4 RK_PD1 GPIO_ACTIVE_HIGH>;
  	num-lanes = <4>;
  	pinctrl-names = "default";
@@ -235,7 +181,7 @@ index 111111111111..222222222222 100644
  	status = "okay";
  };
  
-@@ -703,6 +736,10 @@ pcie_pwr_en: pcie-pwr-en {
+@@ -703,6 +734,10 @@
  		pcie_3g_drv: pcie-3g-drv {
  			rockchip,pins = <0 RK_PA2 RK_FUNC_GPIO &pcfg_pull_up>;
  		};
@@ -246,7 +192,7 @@ index 111111111111..222222222222 100644
  	};
  
  	pmic {
-@@ -741,6 +778,14 @@ usb2 {
+@@ -741,6 +776,14 @@
  		vcc5v0_host_en: vcc5v0-host-en {
  			rockchip,pins = <1 RK_PA0 RK_FUNC_GPIO &pcfg_pull_none>;
  		};
@@ -261,7 +207,7 @@ index 111111111111..222222222222 100644
  	};
  
  	wifi {
-@@ -748,6 +793,20 @@ wifi_host_wake_l: wifi-host-wake-l {
+@@ -748,6 +791,20 @@
  			rockchip,pins = <0 RK_PA3 RK_FUNC_GPIO &pcfg_pull_none>;
  		};
  	};
@@ -282,7 +228,7 @@ index 111111111111..222222222222 100644
  };
  
  &pwm0 {
-@@ -787,7 +846,7 @@ brcmf: wifi@1 {
+@@ -787,7 +844,7 @@
  		reg = <1>;
  		compatible = "brcm,bcm4329-fmac";
  		interrupt-parent = <&gpio0>;
@@ -291,7 +237,7 @@ index 111111111111..222222222222 100644
  		interrupt-names = "host-wake";
  		brcm,drive-strength = <5>;
  		pinctrl-names = "default";
-@@ -884,8 +943,22 @@ u2phy1_host: host-port {
+@@ -884,8 +941,22 @@
  
  &uart0 {
  	pinctrl-names = "default";
@@ -315,6 +261,3 @@ index 111111111111..222222222222 100644
  };
  
  &uart2 {
--- 
-Armbian
-

--- a/patch/kernel/archive/rockchip64-6.18/board-firefly-rk3399-dts.patch
+++ b/patch/kernel/archive/rockchip64-6.18/board-firefly-rk3399-dts.patch
@@ -30,7 +30,7 @@ Subject: [ARCHEOLOGY] firefly-rk3399: move to rockchip64 family
 > X-Git-Archeology:
 ---
  arch/arm64/boot/dts/rockchip/rk3399-firefly.dts | 133 +++++++---
- 1 file changed, 103 insertions(+), 30 deletions(-)
+ 1 file changed, 91 insertions(+), 20 deletions(-)
 
 diff --git a/arch/arm64/boot/dts/rockchip/rk3399-firefly.dts b/arch/arm64/boot/dts/rockchip/rk3399-firefly.dts
 index 111111111111..222222222222 100644
@@ -86,16 +86,7 @@ index 111111111111..222222222222 100644
  };
  
  &cpu_l0 {
-@@ -305,6 +329,8 @@ &gpu {
- };
- 
- &hdmi {
-+	avdd-0v9-supply = <&vcca0v9_hdmi>;
-+	avdd-1v8-supply = <&vcca1v8_hdmi>;
- 	ddc-i2c-bus = <&i2c3>;
- 	pinctrl-names = "default";
- 	pinctrl-0 = <&hdmi_cec>;
-@@ -329,18 +355,18 @@ rk808: pmic@1b {
+@@ -329,18 +353,18 @@ rk808: pmic@1b {
  		system-power-controller;
  		wakeup-source;
  
@@ -124,52 +115,7 @@ index 111111111111..222222222222 100644
  
  		regulators {
  			vdd_center: DCDC_REG1 {
-@@ -388,8 +414,8 @@ regulator-state-mem {
- 				};
- 			};
- 
--			vcc1v8_dvp: LDO_REG1 {
--				regulator-name = "vcc1v8_dvp";
-+			vcca1v8_codec: LDO_REG1 {
-+				regulator-name = "vcca1v8_codec";
- 				regulator-always-on;
- 				regulator-boot-on;
- 				regulator-min-microvolt = <1800000>;
-@@ -399,12 +425,12 @@ regulator-state-mem {
- 				};
- 			};
- 
--			vcc2v8_dvp: LDO_REG2 {
--				regulator-name = "vcc2v8_dvp";
-+			vcca1v8_hdmi: LDO_REG2 {
-+				regulator-name = "vcca1v8_hdmi";
- 				regulator-always-on;
- 				regulator-boot-on;
--				regulator-min-microvolt = <2800000>;
--				regulator-max-microvolt = <2800000>;
-+				regulator-min-microvolt = <1800000>;
-+				regulator-max-microvolt = <1800000>;
- 				regulator-state-mem {
- 					regulator-off-in-suspend;
- 				};
-@@ -457,12 +483,12 @@ regulator-state-mem {
- 				};
- 			};
- 
--			vcca1v8_codec: LDO_REG7 {
--				regulator-name = "vcca1v8_codec";
-+			vcca0v9_hdmi: LDO_REG7 {
-+				regulator-name = "vcca0v9_hdmi";
- 				regulator-always-on;
- 				regulator-boot-on;
--				regulator-min-microvolt = <1800000>;
--				regulator-max-microvolt = <1800000>;
-+				regulator-min-microvolt = <900000>;
-+				regulator-max-microvolt = <900000>;
- 				regulator-state-mem {
- 					regulator-off-in-suspend;
- 				};
-@@ -503,14 +529,16 @@ regulator-state-mem {
+@@ -503,14 +527,16 @@ regulator-state-mem {
  	vdd_cpu_b: regulator@40 {
  		compatible = "silergy,syr827";
  		reg = <0x40>;
@@ -188,7 +134,7 @@ index 111111111111..222222222222 100644
  
  		regulator-state-mem {
  			regulator-off-in-suspend;
-@@ -521,13 +549,15 @@ vdd_gpu: regulator@41 {
+@@ -521,13 +547,15 @@ vdd_gpu: regulator@41 {
  		compatible = "silergy,syr828";
  		reg = <0x41>;
  		fcs,suspend-voltage-selector = <1>;
@@ -205,7 +151,7 @@ index 111111111111..222222222222 100644
  
  		regulator-state-mem {
  			regulator-off-in-suspend;
-@@ -564,7 +594,7 @@ &i2c4 {
+@@ -564,7 +592,7 @@ &i2c4 {
  	status = "okay";
  
  	fusb0: typec-portc@22 {
@@ -214,7 +160,7 @@ index 111111111111..222222222222 100644
  		reg = <0x22>;
  		interrupt-parent = <&gpio1>;
  		interrupts = <RK_PA2 IRQ_TYPE_LEVEL_LOW>;
-@@ -637,7 +667,7 @@ &i2s2 {
+@@ -637,7 +665,7 @@ &i2s2 {
  &io_domains {
  	status = "okay";
  
@@ -223,7 +169,7 @@ index 111111111111..222222222222 100644
  	audio-supply = <&vcca1v8_codec>;
  	sdmmc-supply = <&vcc_sdio>;
  	gpio1830-supply = <&vcc_3v0>;
-@@ -651,7 +681,10 @@ &pcie0 {
+@@ -651,7 +679,10 @@ &pcie0 {
  	ep-gpios = <&gpio4 RK_PD1 GPIO_ACTIVE_HIGH>;
  	num-lanes = <4>;
  	pinctrl-names = "default";
@@ -235,7 +181,7 @@ index 111111111111..222222222222 100644
  	status = "okay";
  };
  
-@@ -703,6 +736,10 @@ pcie_pwr_en: pcie-pwr-en {
+@@ -703,6 +734,10 @@ pcie_pwr_en: pcie-pwr-en {
  		pcie_3g_drv: pcie-3g-drv {
  			rockchip,pins = <0 RK_PA2 RK_FUNC_GPIO &pcfg_pull_up>;
  		};
@@ -246,7 +192,7 @@ index 111111111111..222222222222 100644
  	};
  
  	pmic {
-@@ -741,6 +778,14 @@ usb2 {
+@@ -741,6 +776,14 @@ usb2 {
  		vcc5v0_host_en: vcc5v0-host-en {
  			rockchip,pins = <1 RK_PA0 RK_FUNC_GPIO &pcfg_pull_none>;
  		};
@@ -261,7 +207,7 @@ index 111111111111..222222222222 100644
  	};
  
  	wifi {
-@@ -748,6 +793,20 @@ wifi_host_wake_l: wifi-host-wake-l {
+@@ -748,6 +791,20 @@ wifi_host_wake_l: wifi-host-wake-l {
  			rockchip,pins = <0 RK_PA3 RK_FUNC_GPIO &pcfg_pull_none>;
  		};
  	};
@@ -282,7 +228,7 @@ index 111111111111..222222222222 100644
  };
  
  &pwm0 {
-@@ -787,7 +846,7 @@ brcmf: wifi@1 {
+@@ -787,7 +844,7 @@ brcmf: wifi@1 {
  		reg = <1>;
  		compatible = "brcm,bcm4329-fmac";
  		interrupt-parent = <&gpio0>;
@@ -291,7 +237,7 @@ index 111111111111..222222222222 100644
  		interrupt-names = "host-wake";
  		brcm,drive-strength = <5>;
  		pinctrl-names = "default";
-@@ -884,8 +943,22 @@ u2phy1_host: host-port {
+@@ -884,8 +941,22 @@ u2phy1_host: host-port {
  
  &uart0 {
  	pinctrl-names = "default";
@@ -315,6 +261,3 @@ index 111111111111..222222222222 100644
  };
  
  &uart2 {
--- 
-Armbian
-

--- a/patch/kernel/archive/rockchip64-7.2/board-firefly-rk3399-dts.patch
+++ b/patch/kernel/archive/rockchip64-7.2/board-firefly-rk3399-dts.patch
@@ -30,7 +30,7 @@ Subject: [ARCHEOLOGY] firefly-rk3399: move to rockchip64 family
 > X-Git-Archeology:
 ---
  arch/arm64/boot/dts/rockchip/rk3399-firefly.dts | 133 +++++++---
- 1 file changed, 103 insertions(+), 30 deletions(-)
+ 1 file changed, 91 insertions(+), 20 deletions(-)
 
 diff --git a/arch/arm64/boot/dts/rockchip/rk3399-firefly.dts b/arch/arm64/boot/dts/rockchip/rk3399-firefly.dts
 index 111111111111..222222222222 100644
@@ -86,16 +86,7 @@ index 111111111111..222222222222 100644
  };
  
  &cpu_l0 {
-@@ -305,6 +329,8 @@ &gpu {
- };
- 
- &hdmi {
-+	avdd-0v9-supply = <&vcca0v9_hdmi>;
-+	avdd-1v8-supply = <&vcca1v8_hdmi>;
- 	ddc-i2c-bus = <&i2c3>;
- 	pinctrl-names = "default";
- 	pinctrl-0 = <&hdmi_cec>;
-@@ -329,18 +355,18 @@ rk808: pmic@1b {
+@@ -329,18 +353,18 @@ rk808: pmic@1b {
  		system-power-controller;
  		wakeup-source;
  
@@ -124,52 +115,7 @@ index 111111111111..222222222222 100644
  
  		regulators {
  			vdd_center: DCDC_REG1 {
-@@ -388,8 +414,8 @@ regulator-state-mem {
- 				};
- 			};
- 
--			vcc1v8_dvp: LDO_REG1 {
--				regulator-name = "vcc1v8_dvp";
-+			vcca1v8_codec: LDO_REG1 {
-+				regulator-name = "vcca1v8_codec";
- 				regulator-always-on;
- 				regulator-boot-on;
- 				regulator-min-microvolt = <1800000>;
-@@ -399,12 +425,12 @@ regulator-state-mem {
- 				};
- 			};
- 
--			vcc2v8_dvp: LDO_REG2 {
--				regulator-name = "vcc2v8_dvp";
-+			vcca1v8_hdmi: LDO_REG2 {
-+				regulator-name = "vcca1v8_hdmi";
- 				regulator-always-on;
- 				regulator-boot-on;
--				regulator-min-microvolt = <2800000>;
--				regulator-max-microvolt = <2800000>;
-+				regulator-min-microvolt = <1800000>;
-+				regulator-max-microvolt = <1800000>;
- 				regulator-state-mem {
- 					regulator-off-in-suspend;
- 				};
-@@ -457,12 +483,12 @@ regulator-state-mem {
- 				};
- 			};
- 
--			vcca1v8_codec: LDO_REG7 {
--				regulator-name = "vcca1v8_codec";
-+			vcca0v9_hdmi: LDO_REG7 {
-+				regulator-name = "vcca0v9_hdmi";
- 				regulator-always-on;
- 				regulator-boot-on;
--				regulator-min-microvolt = <1800000>;
--				regulator-max-microvolt = <1800000>;
-+				regulator-min-microvolt = <900000>;
-+				regulator-max-microvolt = <900000>;
- 				regulator-state-mem {
- 					regulator-off-in-suspend;
- 				};
-@@ -503,14 +529,16 @@ regulator-state-mem {
+@@ -503,14 +527,16 @@ regulator-state-mem {
  	vdd_cpu_b: regulator@40 {
  		compatible = "silergy,syr827";
  		reg = <0x40>;
@@ -188,7 +134,7 @@ index 111111111111..222222222222 100644
  
  		regulator-state-mem {
  			regulator-off-in-suspend;
-@@ -521,13 +549,15 @@ vdd_gpu: regulator@41 {
+@@ -521,13 +547,15 @@ vdd_gpu: regulator@41 {
  		compatible = "silergy,syr828";
  		reg = <0x41>;
  		fcs,suspend-voltage-selector = <1>;
@@ -205,7 +151,7 @@ index 111111111111..222222222222 100644
  
  		regulator-state-mem {
  			regulator-off-in-suspend;
-@@ -564,7 +594,7 @@ &i2c4 {
+@@ -564,7 +592,7 @@ &i2c4 {
  	status = "okay";
  
  	fusb0: typec-portc@22 {
@@ -214,7 +160,7 @@ index 111111111111..222222222222 100644
  		reg = <0x22>;
  		interrupt-parent = <&gpio1>;
  		interrupts = <RK_PA2 IRQ_TYPE_LEVEL_LOW>;
-@@ -637,7 +667,7 @@ &i2s2 {
+@@ -637,7 +665,7 @@ &i2s2 {
  &io_domains {
  	status = "okay";
  
@@ -223,7 +169,7 @@ index 111111111111..222222222222 100644
  	audio-supply = <&vcca1v8_codec>;
  	sdmmc-supply = <&vcc_sdio>;
  	gpio1830-supply = <&vcc_3v0>;
-@@ -651,7 +681,10 @@ &pcie0 {
+@@ -651,7 +679,10 @@ &pcie0 {
  	ep-gpios = <&gpio4 RK_PD1 GPIO_ACTIVE_HIGH>;
  	num-lanes = <4>;
  	pinctrl-names = "default";
@@ -235,7 +181,7 @@ index 111111111111..222222222222 100644
  	status = "okay";
  };
  
-@@ -703,6 +736,10 @@ pcie_pwr_en: pcie-pwr-en {
+@@ -703,6 +734,10 @@ pcie_pwr_en: pcie-pwr-en {
  		pcie_3g_drv: pcie-3g-drv {
  			rockchip,pins = <0 RK_PA2 RK_FUNC_GPIO &pcfg_pull_up>;
  		};
@@ -246,7 +192,7 @@ index 111111111111..222222222222 100644
  	};
  
  	pmic {
-@@ -741,6 +778,14 @@ usb2 {
+@@ -741,6 +776,14 @@ usb2 {
  		vcc5v0_host_en: vcc5v0-host-en {
  			rockchip,pins = <1 RK_PA0 RK_FUNC_GPIO &pcfg_pull_none>;
  		};
@@ -261,7 +207,7 @@ index 111111111111..222222222222 100644
  	};
  
  	wifi {
-@@ -748,6 +793,20 @@ wifi_host_wake_l: wifi-host-wake-l {
+@@ -748,6 +791,20 @@ wifi_host_wake_l: wifi-host-wake-l {
  			rockchip,pins = <0 RK_PA3 RK_FUNC_GPIO &pcfg_pull_none>;
  		};
  	};
@@ -282,7 +228,7 @@ index 111111111111..222222222222 100644
  };
  
  &pwm0 {
-@@ -787,7 +846,7 @@ brcmf: wifi@1 {
+@@ -787,7 +844,7 @@ brcmf: wifi@1 {
  		reg = <1>;
  		compatible = "brcm,bcm4329-fmac";
  		interrupt-parent = <&gpio0>;
@@ -291,7 +237,7 @@ index 111111111111..222222222222 100644
  		interrupt-names = "host-wake";
  		brcm,drive-strength = <5>;
  		pinctrl-names = "default";
-@@ -884,8 +943,22 @@ u2phy1_host: host-port {
+@@ -884,8 +941,22 @@ u2phy1_host: host-port {
  
  &uart0 {
  	pinctrl-names = "default";
@@ -315,6 +261,3 @@ index 111111111111..222222222222 100644
  };
  
  &uart2 {
--- 
-Armbian
-

--- a/patch/kernel/archive/rockchip64-7.3/board-firefly-rk3399-dts.patch
+++ b/patch/kernel/archive/rockchip64-7.3/board-firefly-rk3399-dts.patch
@@ -30,7 +30,7 @@ Subject: [ARCHEOLOGY] firefly-rk3399: move to rockchip64 family
 > X-Git-Archeology:
 ---
  arch/arm64/boot/dts/rockchip/rk3399-firefly.dts | 133 +++++++---
- 1 file changed, 103 insertions(+), 30 deletions(-)
+ 1 file changed, 91 insertions(+), 20 deletions(-)
 
 diff --git a/arch/arm64/boot/dts/rockchip/rk3399-firefly.dts b/arch/arm64/boot/dts/rockchip/rk3399-firefly.dts
 index 111111111111..222222222222 100644
@@ -86,16 +86,7 @@ index 111111111111..222222222222 100644
  };
  
  &cpu_l0 {
-@@ -305,6 +329,8 @@ &gpu {
- };
- 
- &hdmi {
-+	avdd-0v9-supply = <&vcca0v9_hdmi>;
-+	avdd-1v8-supply = <&vcca1v8_hdmi>;
- 	ddc-i2c-bus = <&i2c3>;
- 	pinctrl-names = "default";
- 	pinctrl-0 = <&hdmi_cec>;
-@@ -329,18 +355,18 @@ rk808: pmic@1b {
+@@ -329,18 +353,18 @@ rk808: pmic@1b {
  		system-power-controller;
  		wakeup-source;
  
@@ -124,52 +115,7 @@ index 111111111111..222222222222 100644
  
  		regulators {
  			vdd_center: DCDC_REG1 {
-@@ -388,8 +414,8 @@ regulator-state-mem {
- 				};
- 			};
- 
--			vcc1v8_dvp: LDO_REG1 {
--				regulator-name = "vcc1v8_dvp";
-+			vcca1v8_codec: LDO_REG1 {
-+				regulator-name = "vcca1v8_codec";
- 				regulator-always-on;
- 				regulator-boot-on;
- 				regulator-min-microvolt = <1800000>;
-@@ -399,12 +425,12 @@ regulator-state-mem {
- 				};
- 			};
- 
--			vcc2v8_dvp: LDO_REG2 {
--				regulator-name = "vcc2v8_dvp";
-+			vcca1v8_hdmi: LDO_REG2 {
-+				regulator-name = "vcca1v8_hdmi";
- 				regulator-always-on;
- 				regulator-boot-on;
--				regulator-min-microvolt = <2800000>;
--				regulator-max-microvolt = <2800000>;
-+				regulator-min-microvolt = <1800000>;
-+				regulator-max-microvolt = <1800000>;
- 				regulator-state-mem {
- 					regulator-off-in-suspend;
- 				};
-@@ -457,12 +483,12 @@ regulator-state-mem {
- 				};
- 			};
- 
--			vcca1v8_codec: LDO_REG7 {
--				regulator-name = "vcca1v8_codec";
-+			vcca0v9_hdmi: LDO_REG7 {
-+				regulator-name = "vcca0v9_hdmi";
- 				regulator-always-on;
- 				regulator-boot-on;
--				regulator-min-microvolt = <1800000>;
--				regulator-max-microvolt = <1800000>;
-+				regulator-min-microvolt = <900000>;
-+				regulator-max-microvolt = <900000>;
- 				regulator-state-mem {
- 					regulator-off-in-suspend;
- 				};
-@@ -503,14 +529,16 @@ regulator-state-mem {
+@@ -503,14 +527,16 @@ regulator-state-mem {
  	vdd_cpu_b: regulator@40 {
  		compatible = "silergy,syr827";
  		reg = <0x40>;
@@ -188,7 +134,7 @@ index 111111111111..222222222222 100644
  
  		regulator-state-mem {
  			regulator-off-in-suspend;
-@@ -521,13 +549,15 @@ vdd_gpu: regulator@41 {
+@@ -521,13 +547,15 @@ vdd_gpu: regulator@41 {
  		compatible = "silergy,syr828";
  		reg = <0x41>;
  		fcs,suspend-voltage-selector = <1>;
@@ -205,7 +151,7 @@ index 111111111111..222222222222 100644
  
  		regulator-state-mem {
  			regulator-off-in-suspend;
-@@ -564,7 +594,7 @@ &i2c4 {
+@@ -564,7 +592,7 @@ &i2c4 {
  	status = "okay";
  
  	fusb0: typec-portc@22 {
@@ -214,7 +160,7 @@ index 111111111111..222222222222 100644
  		reg = <0x22>;
  		interrupt-parent = <&gpio1>;
  		interrupts = <RK_PA2 IRQ_TYPE_LEVEL_LOW>;
-@@ -637,7 +667,7 @@ &i2s2 {
+@@ -637,7 +665,7 @@ &i2s2 {
  &io_domains {
  	status = "okay";
  
@@ -223,7 +169,7 @@ index 111111111111..222222222222 100644
  	audio-supply = <&vcca1v8_codec>;
  	sdmmc-supply = <&vcc_sdio>;
  	gpio1830-supply = <&vcc_3v0>;
-@@ -651,7 +681,10 @@ &pcie0 {
+@@ -651,7 +679,10 @@ &pcie0 {
  	ep-gpios = <&gpio4 RK_PD1 GPIO_ACTIVE_HIGH>;
  	num-lanes = <4>;
  	pinctrl-names = "default";
@@ -235,7 +181,7 @@ index 111111111111..222222222222 100644
  	status = "okay";
  };
  
-@@ -703,6 +736,10 @@ pcie_pwr_en: pcie-pwr-en {
+@@ -703,6 +734,10 @@ pcie_pwr_en: pcie-pwr-en {
  		pcie_3g_drv: pcie-3g-drv {
  			rockchip,pins = <0 RK_PA2 RK_FUNC_GPIO &pcfg_pull_up>;
  		};
@@ -246,7 +192,7 @@ index 111111111111..222222222222 100644
  	};
  
  	pmic {
-@@ -741,6 +778,14 @@ usb2 {
+@@ -741,6 +776,14 @@ usb2 {
  		vcc5v0_host_en: vcc5v0-host-en {
  			rockchip,pins = <1 RK_PA0 RK_FUNC_GPIO &pcfg_pull_none>;
  		};
@@ -261,7 +207,7 @@ index 111111111111..222222222222 100644
  	};
  
  	wifi {
-@@ -748,6 +793,20 @@ wifi_host_wake_l: wifi-host-wake-l {
+@@ -748,6 +791,20 @@ wifi_host_wake_l: wifi-host-wake-l {
  			rockchip,pins = <0 RK_PA3 RK_FUNC_GPIO &pcfg_pull_none>;
  		};
  	};
@@ -282,7 +228,7 @@ index 111111111111..222222222222 100644
  };
  
  &pwm0 {
-@@ -787,7 +846,7 @@ brcmf: wifi@1 {
+@@ -787,7 +844,7 @@ brcmf: wifi@1 {
  		reg = <1>;
  		compatible = "brcm,bcm4329-fmac";
  		interrupt-parent = <&gpio0>;
@@ -291,7 +237,7 @@ index 111111111111..222222222222 100644
  		interrupt-names = "host-wake";
  		brcm,drive-strength = <5>;
  		pinctrl-names = "default";
-@@ -884,8 +943,22 @@ u2phy1_host: host-port {
+@@ -884,8 +941,22 @@ u2phy1_host: host-port {
  
  &uart0 {
  	pinctrl-names = "default";
@@ -315,6 +261,3 @@ index 111111111111..222222222222 100644
  };
  
  &uart2 {
--- 
-Armbian
-


### PR DESCRIPTION
# Description

`board-firefly-rk3399-dts.patch` re-assigns three RK808 LDOs away from what
upstream `rk3399-firefly.dts` has:

| LDO | upstream | this patch |
|-----|----------|------------|
| LDO_REG1 | vcc1v8_dvp 1.8V | vcca1v8_codec 1.8V |
| LDO_REG2 | vcc2v8_dvp 2.8V | vcca1v8_hdmi 1.8V |
| **LDO_REG7** | **vcca1v8_codec 1.8V** | **vcca0v9_hdmi 0.9V** |

That is the layout of `rk3399-roc-pc` / `rock-pi-4` / `rock960`, not of the
Firefly-RK3399. On this board LDO7 is the analog 1.8V supply of the on-board
Realtek ALC5640 (rt5640) codec.

At 0.9V the codec never powers up:

```
rt5640 1-001c: Device with ID register 0x0 is not rt5640/39
```

`i2cdetect -y -r 1` shows nothing at all on the bus, no analog sound card is
registered, and the headphone / microphone jacks are dead.

Affects `rockchip64-6.12`, `-6.18`, `-7.2` and `-7.3` (the hunks are identical
in all four).

This PR restores the upstream mapping and drops the two `&hdmi` avdd supplies
that were pointing at the now-misnamed regulators — upstream does not set them
on this board. No other hunk of the patch is touched.

# How Has This Been Tested?

Hardware: Firefly-RK3399 (4 GB), Armbian 6.18.45-current-rockchip64.

- [x] **Cross-checked against the vendor device tree.** Extracted the DTB from
      Firefly's official Ubuntu image (BSP 4.4 kernel) and compared it node by
      node. The vendor maps LDO7 to `vcca1v8_codec` at 1.8V, has no
      `vcca0v9_hdmi` regulator at all, and booting that image on the same board
      gives working headphone audio. Upstream `rk3399-firefly.dts` agrees with
      the vendor (checked v6.12 through v7.3).

- [x] **Before / after on the board:**

  | | before | after |
  |---|---|---|
  | `i2cdetect -y -r 1` | all `--` | `0x1c` = `UU` |
  | `dmesg \| grep -c 'Device with ID register'` | 6+ | 0 |
  | `/proc/asound/cards` | no analog card | `rockchiprt5640c` |
  | `amixer` controls | 0 | 120 |
  | playback | — | OK at 44.1 kHz and 48 kHz |

- [x] **Patch application:** all four corrected patch files verified to apply
      cleanly to their respective kernel trees, and the resulting DTS checked to
      have LDO_REG7 back at 1800000 uV.

- [x] Verified across a cold boot, not just a soft reboot.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved power and voltage configuration for the Firefly RK3399 board.
  - Updated HDMI, codec, PCIe, USB-C, and peripheral regulator handling.
  - Corrected USB-C controller compatibility and PCIe reset configuration.
  - Updated Wi-Fi interrupt handling and Bluetooth support over UART.
  - Removed obsolete HDMI supply definitions from the board configuration.

- **Hardware Support**
  - Added board controls for system power, USB hubs, PCIe reset, and Bluetooth connectivity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->