### PR TITLE
rockchip: rk3506: cap bootm_size to maintain CMA alignment

### DIFF
--- a/patch/u-boot/v2026.07-rk3506/rockchip-rk3506-bootm-size-keep-CMA-PMD-aligned.patch
+++ b/patch/u-boot/v2026.07-rk3506/rockchip-rk3506-bootm-size-keep-CMA-PMD-aligned.patch
@@ -1,0 +1,34 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Austin Lane <vidplace7@gmail.com>
+Date: Wed, 3 Sep 2026 17:30:00 +0000
+Subject: rockchip: rk3506: Cap bootm_size to keep the kernel CMA PMD aligned
+
+Without bootm_size, the FDT and initrd are relocated to the top of RAM at
+4 KiB granularity. Linux then allocates CMA just below them with only
+1 MiB alignment, so the base is rarely PMD aligned - dma_contiguous_remap()
+leaves a partial PMD as a section and trips BUG_ON(pmd_bad()) in
+paging_init(), before any exception vectors exist. The board hangs silently.
+
+Cap bootm_size at 64 MiB so the FDT and initrd stay low and CMA lands at
+end_of_DRAM - cma_size, PMD aligned by construction.
+
+Signed-off-by: Austin Lane <vidplace7@gmail.com>
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
+---
+ include/configs/rk3506_common.h | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/include/configs/rk3506_common.h b/include/configs/rk3506_common.h
+index 111111111111..222222222222 100644
+--- a/include/configs/rk3506_common.h
++++ b/include/configs/rk3506_common.h
+@@ -26,7 +26,8 @@
+ 	"kernel_addr_r=0x00400000\0"		\
+ 	"fdt_addr_r=0x00200000\0"		\
+ 	"fdtoverlay_addr_r=0x00300000\0"	\
+-	"ramdisk_addr_r=0x02400000\0"
++	"ramdisk_addr_r=0x02400000\0"		\
++	"bootm_size=0x04000000\0"
+ 
+ #define CFG_EXTRA_ENV_SETTINGS			\
+ 	"fdtfile=" CONFIG_DEFAULT_FDT_FILE "\0"	\


### PR DESCRIPTION
# Description

Fix boot issues on some RK3506 boards (depending on CMA allocation, ram size, etc) by explicitly setting `bootm_size` to force CMA memory allocations to align cleanly.

# How Has This Been Tested?

- [x] `luckfox-lyra-zero-w` trixie (broken before this change, now booting again)
- [x] `ebyte-ecb41-pge` trixie (working before this change, still working)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a boot issue on RK3506 boards that could cause the system to hang during kernel initialization.
  * Improved memory layout during boot so the device tree, initial ramdisk, and kernel memory regions are placed within supported boundaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->