### PR TITLE
RK3506: Update DDR, TEE, ROCKUSB blobs

### DIFF
--- a/config/sources/families/rockchip.conf
+++ b/config/sources/families/rockchip.conf
@@ -51,17 +51,10 @@ elif [[ "$BOOT_SOC" == "rk3506" || "$BOOT_SOC" == "rk3506b" ]]; then
 	BOOTENV_FILE='rk3506.txt'
 	OVERLAY_PREFIX='rockchip'
 	OFFSET=16
-	# RK3506 / RK3506B use different DDR init and ROCKUSB blobs, but the same TEE blob.
-	# We set the defaults here, but allow overriding in board config if needed.
+	DDR_BLOB="${DDR_BLOB:-"rk35/rk3506_ddr_750MHz_v1.09.bin"}"
 	# ROCKUSB_BLOB is used to flash a board with rkdeveloptool (Linux, can use 'rkdevflash' extension) or RKDevTool (Windows) in MASKROM mode
-	if [[ "$BOOT_SOC" == "rk3506" ]]; then
-		DDR_BLOB="${DDR_BLOB:-"rk35/rk3506_ddr_750MHz_v1.06.bin"}"
-		ROCKUSB_BLOB="${ROCKUSB_BLOB:-"rk35/rk3506_spl_loader_v1.06.112.bin"}"
-	elif [[ "$BOOT_SOC" == "rk3506b" ]]; then
-		DDR_BLOB="${DDR_BLOB:-"rk35/rk3506b_ddr_750MHz_v1.06.bin"}"
-		ROCKUSB_BLOB="${ROCKUSB_BLOB:-"rk35/rk3506b_spl_loader_v1.06.112.bin"}"
-	fi
-	TEE_BLOB="${TEE_BLOB:-"rk35/rk3506_tee_v2.10.bin"}"
+	ROCKUSB_BLOB="${ROCKUSB_BLOB:-"rk35/rk3506_loader_v1.09.112.bin"}"
+	TEE_BLOB="${TEE_BLOB:-"rk35/rk3506_tee_v2.50.bin"}"
 	UBOOT_TARGET_MAP="ROCKCHIP_TPL=${RKBIN_DIR}/${DDR_BLOB} TEE=${RKBIN_DIR}/${TEE_BLOB};;u-boot-rockchip.bin"
 
 	BOOTBRANCH='tag:v2026.07'


### PR DESCRIPTION
# Description

Update boot blobs for RK3506 family per @Kwiboo's recommendation in https://github.com/armbian/build/pull/10470.
These blobs are now generic for RK3506G, RK3506B and RK3506J :heart:.

Depends on:
- https://github.com/armbian/rkbin/pull/51

# How Has This Been Tested?

Boot tested:
- [x] `luckfox-lyra-zero-w` trixie (RK3506B)
- [x] `ebyte-ecb41-pge` trixie (RK3506G)

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated rk3506 and rk3506b boot components to use the latest shared DDR, loader, and trusted execution environment binaries.
  * Standardized boot component selection across both SoC variants.
  * Improved compatibility and consistency for supported rk3506-series hardware.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->