### PR TITLE
bootscripts: rk35xx: fall back to PARTUUID instead of hardcoded rootdev

### DIFF
--- a/config/bootscripts/boot-rk35xx.cmd
+++ b/config/bootscripts/boot-rk35xx.cmd
@@ -6,7 +6,7 @@
 setenv load_addr "0x9000000"
 setenv overlay_error "false"
 # default values
-setenv rootdev "/dev/mmcblk0p1"
+setenv rootdev ""
 setenv verbosity "1"
 setenv console "both"
 setenv bootlogo "false"
@@ -36,6 +36,19 @@ fi
 
 # get PARTUUID of first partition on SD/eMMC the boot script was loaded from
 if test "${devtype}" = "mmc"; then part uuid mmc ${devnum}:${distro_bootpart} partuuid; fi
+
+# armbianEnv.txt normally sets rootdev explicitly (e.g. a UUID= override). If it
+# didn't - missing file, or an environment that doesn't set it - fall back to the
+# PARTUUID we already computed above instead of a hardcoded /dev/mmcblk0p1: U-Boot
+# and the kernel can number mmc controllers differently on some rk35xx boards, so a
+# fixed device name can silently point at the wrong (or a nonexistent) device.
+if test -z "${rootdev}"; then
+	if test -n "${partuuid}"; then
+		setenv rootdev "PARTUUID=${partuuid}"
+	else
+		setenv rootdev "/dev/mmcblk0p1"
+	fi
+fi
 
 setenv bootargs "root=${rootdev} rootwait rootfstype=${rootfstype} ${consoleargs} consoleblank=0 loglevel=${verbosity} ubootpart=${partuuid} usb-storage.quirks=${usbstoragequirks} ${extraargs} ${extraboardargs}"
 

--- a/config/bootscripts/boot-rk35xx.cmd
+++ b/config/bootscripts/boot-rk35xx.cmd
@@ -34,7 +34,11 @@ else
 	setenv consoleargs "splash=verbose ${consoleargs}"
 fi
 
-# get PARTUUID of first partition on SD/eMMC the boot script was loaded from
+# get PARTUUID of first partition on SD/eMMC the boot script was loaded from. Clear
+# it first: on a non-mmc devtype, or if the lookup itself fails, U-Boot leaves the
+# variable untouched rather than clearing it, so a stale PARTUUID from an earlier
+# successful lookup could otherwise be reused below.
+setenv partuuid
 if test "${devtype}" = "mmc"; then part uuid mmc ${devnum}:${distro_bootpart} partuuid; fi
 
 # armbianEnv.txt normally sets rootdev explicitly (e.g. a UUID= override). If it


### PR DESCRIPTION
# Description

`boot-rk35xx.cmd` defaults `rootdev` to a hardcoded `/dev/mmcblk0p1` and only overrides it if `armbianEnv.txt` is present and sets `rootdev` itself. U-Boot and the kernel can number mmc controllers differently on some rk35xx boards (this board: U-Boot's `mmc 0` = eMMC, but the kernel calls eMMC `mmcblk1`), so when `armbianEnv.txt` is missing or doesn't set `rootdev`, the hardcoded default points at the wrong (empty) device and boot drops to the initramfs shell with `ALERT! /dev/mmcblk0p1 does not exist.`

The script already computes `PARTUUID` for the boot partition a few lines above (used for the `ubootpart=` kernel arg), so this reuses that value: if `rootdev` wasn't already set by `armbianEnv.txt`, fall back to `PARTUUID=${partuuid}` instead of the hardcoded device path. PARTUUID is numbering-independent, so it works regardless of how U-Boot vs. the kernel enumerate the mmc controllers. The old hardcoded path is kept as a last-resort fallback only if the PARTUUID lookup itself comes back empty.

I intentionally left `boot-generic.cmd.template` alone even though it has the same `setenv rootdev "/dev/mmcblk${devnum}p${distro_bootpart}"` pattern (flagged in the issue as a possible instance of the same bug class) — that template is shared across many board families, and I didn't want to change shared boot behavior for boards I have no way to test, in the same PR as a board-specific fix. Happy to open a separate PR for that if maintainers agree it needs the same treatment.

# Documentation summary for feature / change

Not applicable — internal boot script logic change, no user-facing config surface.

# How Has This Been Tested?

- [x] `mkimage -C none -A arm -T script -d config/bootscripts/boot-rk35xx.cmd out.scr` compiles cleanly (sanity check only — `mkimage` doesn't parse hush script semantics, it just wraps the text)
- [ ] Actual boot test on hardware

I don't have the affected hardware (LCKFB Taishan Pi RK3566) or any rk35xx board to boot-test this against. I'd appreciate it if @Tearran or another maintainer/the original reporter could confirm this boots correctly on real hardware before merge — happy to iterate on the approach if there's a reason to prefer a different fallback (e.g. the `armbian.bootdev`/`armbian.bootdevnum` token approach used in `boot-seeed-rk35xx.cmd`'s newer fallback logic, which I considered but didn't find an initramfs consumer for, so didn't want to introduce a dependency that isn't wired up).

Fixes #10617

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved boot-device detection by automatically using the computed partition identifier when available.
  * Prevented stale partition identifiers from being reused after an unsuccessful lookup.
  * Preserved the existing storage-device fallback when no partition identifier is found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->