### PR TITLE
rockchip64-7.3: fix whitespace in orangepi-5 es8388 mclk patch

### DIFF
--- a/patch/kernel/archive/rockchip64-7.3/board-orangepi-5-es8388-route-mclk-to-io.patch
+++ b/patch/kernel/archive/rockchip64-7.3/board-orangepi-5-es8388-route-mclk-to-io.patch
@@ -34,7 +34,7 @@ overrides it (codec on I2S2) and is unaffected.
 
 Signed-off-by: defcom5-rockchip <defcom5rockchip@proton.me>
 ---
- arch/arm64/boot/dts/rockchip/rk3588s-orangepi-5.dtsi | 2 +-
+ arch/arm64/boot/dts/rockchip/rk3588s-orangepi-5-5b.dtsi | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/arch/arm64/boot/dts/rockchip/rk3588s-orangepi-5-5b.dtsi b/arch/arm64/boot/dts/rockchip/rk3588s-orangepi-5-5b.dtsi
@@ -42,13 +42,13 @@ index 6e081bc06cfe..5ac3e0d9d373 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3588s-orangepi-5-5b.dtsi
 +++ b/arch/arm64/boot/dts/rockchip/rk3588s-orangepi-5-5b.dtsi
 @@ -87,7 +87,7 @@ &i2c6 {
-        es8388: audio-codec@10 {
-                compatible = "everest,es8388", "everest,es8328";
-                reg = <0x10>;
--               clocks = <&cru I2S1_8CH_MCLKOUT>;
-+               clocks = <&cru I2S1_8CH_MCLKOUT_TO_IO>;
-                AVDD-supply = <&vcca_3v3_s0>;
-                DVDD-supply = <&vcca_1v8_s0>;
-                HPVDD-supply = <&vcca_3v3_s0>;
+ 	es8388: audio-codec@10 {
+ 		compatible = "everest,es8388", "everest,es8328";
+ 		reg = <0x10>;
+-		clocks = <&cru I2S1_8CH_MCLKOUT>;
++		clocks = <&cru I2S1_8CH_MCLKOUT_TO_IO>;
+ 		AVDD-supply = <&vcca_3v3_s0>;
+ 		DVDD-supply = <&vcca_1v8_s0>;
+ 		HPVDD-supply = <&vcca_3v3_s0>;
 -- 
 Armbian


### PR DESCRIPTION
# Description

978a64cd8 re-typed the hunk context with spaces instead of tabs, so `patch` rejects it on v7.3-rc1 and every rockchip64 bleedingedge build stops at kernel patching (`Hunk #1 FAILED at 87`). Hunk regenerated from the kernel tree, diffstat names the right file.

# How Has This Been Tested?

- [x] `git apply --check` against v7.3-rc1: applies
- [x] odroidm1 BRANCH=bleedingedge: kernel patching passes (216/216), build proceeds to compilation

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed silent analog audio output on Orange Pi 5 and 5B boards by correctly routing the audio codec’s master clock.
  * Preserved the expected 12.288 MHz audio clock rate.
  * Orange Pi 5 Pro audio behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->