### PR TITLE
rtl8852bs: bump commit hash to include 7.3 compat and drop the lt 7.3 gate

### DIFF
--- a/lib/functions/compilation/patch/drivers_network.sh
+++ b/lib/functions/compilation/patch/drivers_network.sh
@@ -406,10 +406,10 @@ driver_rtw88() {
 
 driver_rtl8852bs() {
 	# Wireless driver for Realtek 8852BS SDIO Wireless driver used in BananaPi F3 and Armsom Sige5
-	if linux-version compare "${version}" ge 6.1 && linux-version compare "${version}" lt 7.3 && [[ "${LINUXFAMILY}" == spacemit || "${LINUXFAMILY}" == rk35xx || "${LINUXFAMILY}" == rockchip64 ]]; then
+	if linux-version compare "${version}" ge 6.1 && [[ "${LINUXFAMILY}" == spacemit || "${LINUXFAMILY}" == rk35xx || "${LINUXFAMILY}" == rockchip64 ]]; then
 
 		# Attach to specific commit
-		local rtl8852bs_ver='commit:58840d11af91d0b72bc830980b4aff740a37b5e3' # Commit date: Aug 18, 2026 (please update when updating commit ref)
+		local rtl8852bs_ver='commit:9dc6d671bc64127efee60937701f73691c8fdda8' # Commit date: Sep 4, 2026 (please update when updating commit ref)
 
 		display_alert "Adding" "Wireless drivers for Realtek 8852BS SDIO chipset ${rtl8852bs_ver}" "info"
 


### PR DESCRIPTION
# Description

Pin moves 58840d11 → 9dc6d671, delta is one commit: armbian/wifi-rtl8852bs#26 (cookie by value on Linux 7.3). The `lt 7.3` gate goes away, so rockchip64 bleedingedge builds the driver again.

# How Has This Been Tested?

- [x] odroidm1 BRANCH=bleedingedge (7.3-rc1): rtl8852bs builds and links, 0 errors, warnings unchanged from the current pin
- [x] Module builds with 0 errors against 7.3-rc1, 7.2.3 and 6.18 headers (driver PR)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the RTL8852BS driver source to a pinned revision for improved consistency.
  - Expanded driver compatibility across supported SpacemiT and Rockchip kernels starting with version 6.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->