### PR TITLE
sunxi-6.18: add sun8i-r40-emmc compatible, fixes eMMC boot hang (Banana Pi M2 Ultra)

### DIFF
--- a/patch/kernel/archive/sunxi-6.18/patches.armbian/drv-mmc-sunxi-add-r40-emmc-compatible.patch
+++ b/patch/kernel/archive/sunxi-6.18/patches.armbian/drv-mmc-sunxi-add-r40-emmc-compatible.patch
@@ -1,0 +1,52 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: ell <guardwire2@gmail.com>
+Date: Tue, 9 Sep 2026 00:00:00 +0000
+Subject: mmc: sunxi: add sun8i-r40-emmc compatible, fixes eMMC boot hang
+
+drivers/mmc/host/sunxi-mmc.c has no of_device_id entry for
+"allwinner,sun8i-r40-emmc". On boards using this compatible (e.g.
+Banana Pi M2 Ultra), the config falls through to sun50i_a64_emmc_cfg,
+which enables autocalibration (can_calibrate + needs_new_timings).
+That autocalibration routine never converges for at least one
+in-the-wild eMMC chip (8GTF4R, as fitted to Banana Pi M2 Ultra),
+hanging the probe and therefore the whole boot.
+
+Add a dedicated static (non-calibrating) config for this compatible
+instead. This DDR/calibration mode was never exercised on this board
+even under older (pre-6.x) kernels, so a static config carries no
+real performance cost here.
+
+No numeric series prefix (unlike sibling 0501/0502/0503 patches in
+this same file) since this doesn't have a real ordering dependency on
+them individually - it only needs to land somewhere after the group,
+which series.conf's list order already guarantees. Insertion points
+and context were deliberately chosen/minimized to land outside the
+regions 0501/0502/0503 touch, and to survive their h5/h6-emmc entries
+being inserted between sun50i-a100-emmc and sun50i-h616-mmc - verified
+by applying all three plus this patch in series order against a real
+checkout, not just eyeballed.
+
+Tested on two physical Banana Pi M2 Ultra boards, kernels 6.18.35 and
+6.18.44, both running stable for several weeks in production
+(eMMC/f2fs root, full docker workload) since applying this fix.
+---
+ drivers/mmc/host/sunxi-mmc.c | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+--- a/drivers/mmc/host/sunxi-mmc.c
++++ b/drivers/mmc/host/sunxi-mmc.c
+@@ -1208,2 +1208,8 @@
+ 
++static const struct sunxi_mmc_cfg sun8i_r40_emmc_cfg = {
++	.idma_des_size_bits = 13,
++	.clk_delays = NULL,
++	.can_calibrate = false,
++};
++
+ static const struct of_device_id sunxi_mmc_of_match[] = {
+@@ -1217,2 +1223,3 @@
+ 	{ .compatible = "allwinner,sun50i-a64-emmc", .data = &sun50i_a64_emmc_cfg },
++	{ .compatible = "allwinner,sun8i-r40-emmc", .data = &sun8i_r40_emmc_cfg },
+ 	{ .compatible = "allwinner,sun50i-a100-mmc", .data = &sun20i_d1_cfg },
+--
+Armbian

--- a/patch/kernel/archive/sunxi-6.18/series.conf
+++ b/patch/kernel/archive/sunxi-6.18/series.conf
@@ -548,6 +548,7 @@
 	patches.armbian/drv-mfd-ac200-add-ephy-syscon.patch
 	patches.armbian/drv-mfd-axp20x-add-sysfs.patch
 	patches.armbian/drv-misc-sunxi-add-addr-mgt-driver-uwe5622.patch
+	patches.armbian/drv-mmc-sunxi-add-r40-emmc-compatible.patch
 	patches.armbian/drv-mtd-nand-add-h27ubg8t2btr-nand.patch
 	patches.armbian/drv-net-stmmac-dwmac-sun8i-add-second-emac-clock.patch
 	patches.armbian/drv-net-phy-ac300-phy-add.patch


### PR DESCRIPTION
Fixes #10633

`drivers/mmc/host/sunxi-mmc.c` has no `of_device_id` entry for `allwinner,sun8i-r40-emmc`, so it falls through to `sun50i_a64_emmc_cfg`'s autocalibration, which never converges for at least one in-the-wild eMMC chip (8GTF4R, Banana Pi M2 Ultra) — hangs the boot. Adds a dedicated static (non-calibrating) config instead.

Tested on two physical Banana Pi M2 Ultra boards, kernels 6.18.35 and 6.18.44, stable in production for several weeks (eMMC/f2fs root, full docker workload) since applying.

Full context/root-cause writeup in the linked issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved eMMC compatibility on Allwinner R40-based boards.
  * Prevented certain eMMC devices from hanging during hardware detection, which could otherwise interrupt system startup.
  * Added dedicated handling for the Banana Pi M2 Ultra and similar R40-based devices.
  * Improved reliability when booting with supported eMMC chips that previously experienced detection issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->