### PR TITLE
sunxi-7.2: add sun8i-r40-emmc compatible, fixes eMMC boot hang (Banana Pi M2 Ultra)

### DIFF
--- a/patch/kernel/archive/sunxi-7.2/patches.armbian/drv-mmc-sunxi-add-r40-emmc-compatible.patch
+++ b/patch/kernel/archive/sunxi-7.2/patches.armbian/drv-mmc-sunxi-add-r40-emmc-compatible.patch
@@ -1,0 +1,52 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: ell <guardwire2@gmail.com>
+Date: Tue, 9 Sep 2026 00:00:00 +0000
+Subject: mmc: sunxi: add sun8i-r40-emmc compatible, fixes eMMC boot hang
+
+drivers/mmc/host/sunxi-mmc.c has no of_device_id entry for
+"allwinner,sun8i-r40-emmc". On boards using this compatible (e.g.
+Banana Pi M2 Ultra), the config falls through to sun50i_a64_emmc_cfg,
+which enables autocalibration (can_calibrate + needs_new_timings).
+That autocalibration routine never converges for at least one
+in-the-wild eMMC chip (8GTF4R, as fitted to Banana Pi M2 Ultra),
+hanging the probe and therefore the whole boot.
+
+Add a dedicated static (non-calibrating) config for this compatible
+instead. This DDR/calibration mode was never exercised on this board
+even under older (pre-6.x) kernels, so a static config carries no
+real performance cost here.
+
+No numeric series prefix (unlike sibling 0501/0502/0503 patches in
+this same file) since this doesn't have a real ordering dependency on
+them individually - it only needs to land somewhere after the group,
+which series.conf's list order already guarantees. Insertion points
+and context were deliberately chosen/minimized to land outside the
+regions 0501/0502/0503 touch, and to survive their h5/h6-emmc entries
+being inserted between sun50i-a100-emmc and sun50i-h616-mmc - verified
+by applying all three plus this patch in series order against a real
+checkout, not just eyeballed.
+
+Tested on two physical Banana Pi M2 Ultra boards, kernels 6.18.35 and
+6.18.44, both running stable for several weeks in production
+(eMMC/f2fs root, full docker workload) since applying this fix.
+---
+ drivers/mmc/host/sunxi-mmc.c | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+--- a/drivers/mmc/host/sunxi-mmc.c
++++ b/drivers/mmc/host/sunxi-mmc.c
+@@ -1208,2 +1208,8 @@
+ 
++static const struct sunxi_mmc_cfg sun8i_r40_emmc_cfg = {
++	.idma_des_size_bits = 13,
++	.clk_delays = NULL,
++	.can_calibrate = false,
++};
++
+ static const struct of_device_id sunxi_mmc_of_match[] = {
+@@ -1217,2 +1223,3 @@
+ 	{ .compatible = "allwinner,sun50i-a64-emmc", .data = &sun50i_a64_emmc_cfg },
++	{ .compatible = "allwinner,sun8i-r40-emmc", .data = &sun8i_r40_emmc_cfg },
+ 	{ .compatible = "allwinner,sun50i-a100-mmc", .data = &sun20i_d1_cfg },
+--
+Armbian

--- a/patch/kernel/archive/sunxi-7.2/series.conf
+++ b/patch/kernel/archive/sunxi-7.2/series.conf
@@ -663,6 +663,7 @@
 	patches.armbian/drv-mfd-ac200-add-ephy-syscon.patch
 	patches.armbian/drv-mfd-axp20x-add-sysfs.patch
 	patches.armbian/drv-misc-sunxi-add-addr-mgt-driver-uwe5622.patch
+	patches.armbian/drv-mmc-sunxi-add-r40-emmc-compatible.patch
 	patches.armbian/drv-mmc-sunxi-pin-runtime-pm.patch
 	patches.armbian/drv-mtd-nand-add-h27ubg8t2btr-nand.patch
     patches.armbian/drv-net-bluetooth-hci-ignore-def-link-policy-error.patch


### PR DESCRIPTION
Companion to #10635 — @EvilOlaf asked there whether sunxi-7.2 is affected too: yes, `patches.armbian/` for sunxi-7.2 doesn't have this compatible string either (checked — only goes up to `0503-drv-mmc-sunxi-fix-h6-emmc.patch`), and the underlying mainline driver still lacks it. Same fix, ported forward (only the hunk line offsets differ, by a constant -7 lines throughout — the `0503` h6 patch is otherwise byte-identical between the two branches, so the surrounding table/function is unchanged).

See #10633 and #10635 for full root-cause/testing details.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Allwinner R40 eMMC devices.
  * Improved compatibility with systems using the `sun8i-r40-emmc` controller configuration.
  * Enabled reliable eMMC operation without requiring hardware autocalibration.
  * Improved eMMC initialization and data transfer compatibility on supported R40-based hardware.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->