### PR TITLE
helios64: fix stray /thermal_zone0 symlink

### DIFF
--- a/packages/bsp/helios64/90-helios64-hwmon.rules
+++ b/packages/bsp/helios64/90-helios64-hwmon.rules
@@ -19,7 +19,7 @@ ENV{IS_HELIOS64_HWMON}=="1", ATTR{name}=="lm75", ENV{HELIOS64_SYMLINK}="/dev/the
 ENV{_IS_HELIOS64_FAN_}=="1", ENV{HELIOS64_SYMLINK}="/dev/fan-$env{_HELIOS64_FAN_}"
 
 #
-ENV{IS_HELIOS64_HWMON}=="1", RUN+="/bin/ln -sf $env{HWMON_PATH} $env{HELIOS64_SYMLINK}"
+ENV{IS_HELIOS64_HWMON}=="1", ENV{HELIOS64_SYMLINK}!="", RUN+="/bin/ln -sf $env{HWMON_PATH} $env{HELIOS64_SYMLINK}"
 
 LABEL="helios64_hwmon_end"
 


### PR DESCRIPTION
# Description

`90-helios64-hwmon.rules` runs `ln -sf $HWMON_PATH $HELIOS64_SYMLINK` for every device with `IS_HELIOS64_HWMON=1`. The `thermal_zone0` device itself matches, but on current kernels its type is `cpu-thermal`, so no target is assigned; udev drops the empty argument and single-operand `ln` creates `/thermal_zone0` in the root directory on every boot. Guard the RUN on a non-empty target.

The `packages/bsp/${BOARD}` hashing from the first revision of this PR is in main since 1b7133975; that commit is dropped.

# How Has This Been Tested?

Tested on helios64, 6.18.43-current-rockchip64: no `/thermal_zone0`, `/dev/thermal-cpu`, `/dev/thermal-board`, `/dev/fan-p6`, `/dev/fan-p7` still created, fancontrol active.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
