### PR TITLE
patching.py: render the failed-patches table at the terminal width

### DIFF
--- a/lib/tools/common/patching_utils.py
+++ b/lib/tools/common/patching_utils.py
@@ -435,7 +435,8 @@ class PatchInPatchFile:
 		# log.debug(f"Rejects file is going to be '{rejects_file}'...")
 
 		proc = subprocess.run(
-			["patch", "--batch", "-p1", "-N", f"--reject-file={rejects_file}", "--quoting-style=c"],
+			# Unified rejects regardless of the input patch format: rich_rejects() styles lines by their +/-/@@ prefix.
+			["patch", "--batch", "-p1", "-N", "--reject-format=unified", f"--reject-file={rejects_file}", "--quoting-style=c"],
 			cwd=working_dir,
 			input=real_input,
 			stdout=subprocess.PIPE,

--- a/lib/tools/common/patching_utils.py
+++ b/lib/tools/common/patching_utils.py
@@ -20,6 +20,7 @@ import tempfile
 import git  # GitPython
 from unidecode import unidecode
 from unidiff import PatchSet
+from rich.text import Text
 
 from common.patching_config import PatchingConfig
 from common.term_colors import background_dark_or_light
@@ -740,6 +741,18 @@ class PatchInPatchFile:
 			for tag in color_tags[color]:
 				ret = ret.replace(tag, f"[{bold} {color}]{tag}[/{bold} {color}]")
 		return ret
+
+	def rich_rejects(self) -> Text:
+		"""Reject hunks as foldable Text, coloured per line like a diff pager."""
+		line_styles = {"+": "green", "-": "red", "@": "cyan"}
+		text = Text()
+		for line in self.rejects.splitlines(keepends=True):
+			text.append(line, style=line_styles.get(line[:1], ""))
+		# Expand on the Text, not the str: rich counts terminal cells, so wide
+		# characters before a tab keep the columns aligned. 4 instead of rich's
+		# default 8 keeps diff indentation readable in a narrow cell.
+		text.expand_tabs(4)
+		return text
 
 	def apply_patch_date_to_files(self, working_dir, options):
 		# The date applied to the patched files is:

--- a/lib/tools/patching.py
+++ b/lib/tools/patching.py
@@ -568,7 +568,7 @@ if apply_patches_to_git and readme_markdown is not None and git_repo is not None
 # Use Rich.
 from rich.console import Console
 from rich.table import Table
-from rich.syntax import Syntax
+from rich.text import Text
 
 CONSOLE_FALLBACK_WIDTH = 160   # no terminal to measure (CI logs, piped output)
 CONSOLE_WIDTH_MARGIN = 12      # columns reserved for table borders and cell padding
@@ -616,26 +616,26 @@ if True:
 # Use Rich to print a summary of the failed patches and their rejects
 if any_failed_to_apply:
 	summary_table = Table(title="Summary of failed patches", show_header=True, show_lines=True, box=rich.box.ROUNDED)
+	# Small minima so the three columns still fit (and fold) down to
+	# CONSOLE_MIN_WIDTH; with min_width=20 on the output column rich crops the
+	# Rejects column on terminals narrower than ~75 columns instead of folding.
 	summary_table.add_column("Patch", overflow="fold", min_width=5, max_width=20)
-	summary_table.add_column("Patching output", overflow="fold", min_width=20, max_width=40)
-	summary_table.add_column("Rejects")
+	summary_table.add_column("Patching output", overflow="fold", min_width=10, max_width=40)
+	# Rejects are full of long unbroken tokens (paths, dts identifiers); folding
+	# keeps every character on screen at any terminal width, where word-wrapping
+	# would elide them with an ellipsis.
+	summary_table.add_column("Rejects", overflow="fold")
 	for one_patch in failed_to_apply_list:
 		reject_compo = "No rejects"
 		if one_patch.rejects is not None:
-			reject_compo = Syntax(one_patch.rejects, "diff", line_numbers=False, word_wrap=True)
+			reject_compo = Text(one_patch.rejects)  # Text, not markup: rejects carry literal brackets
 
 		summary_table.add_row(
 			one_patch.rich_name_status(),
 			one_patch.rich_patch_output(),
 			reject_compo
 		)
-	# Reject diagnostics need room regardless of the reader's terminal: rich's
-	# Syntax word-wrap elides long unbroken diff lines with an ellipsis when the
-	# column is narrow. Give this table at least the fallback width (so a narrow
-	# terminal still gets room), but the full adaptive width when it is wider, so
-	# a wide terminal keeps every reject line it could show before.
-	console_failed = Console(color_system="standard", width=max(console_width, CONSOLE_FALLBACK_WIDTH), highlight=False)
-	console_failed.print(summary_table)
+	console.print(summary_table)
 
 if exit_with_exception is not None:
 	raise exit_with_exception

--- a/lib/tools/patching.py
+++ b/lib/tools/patching.py
@@ -568,7 +568,6 @@ if apply_patches_to_git and readme_markdown is not None and git_repo is not None
 # Use Rich.
 from rich.console import Console
 from rich.table import Table
-from rich.text import Text
 
 CONSOLE_FALLBACK_WIDTH = 160   # no terminal to measure (CI logs, piped output)
 CONSOLE_WIDTH_MARGIN = 12      # columns reserved for table borders and cell padding
@@ -628,7 +627,7 @@ if any_failed_to_apply:
 	for one_patch in failed_to_apply_list:
 		reject_compo = "No rejects"
 		if one_patch.rejects is not None:
-			reject_compo = Text(one_patch.rejects)  # Text, not markup: rejects carry literal brackets
+			reject_compo = one_patch.rich_rejects()
 
 		summary_table.add_row(
 			one_patch.rich_name_status(),


### PR DESCRIPTION
# Description

The "Summary of failed patches" table prints through a console at least 160 columns wide, so on any terminal narrower than 172 columns (160 plus the 12-column logger prefix margin) every row wraps and the frame falls apart. The 160 floor guarded the Rejects column against `Syntax(word_wrap=True)`, which elides long unbroken tokens with an ellipsis in a narrow column.

1. Print the table with the same adaptive console as the summary table and give Rejects `overflow="fold"`: every character stays on screen at any width. Rejects go in as `Text`, not markup: hunks carry literal brackets that rich would parse as tags.
2. Colour rejects per line: `+` green, `-` red, `@@` cyan, tabs expanded to 4 columns.

Follow-up to #9734 / ad6cf6ef2a.

# How Has This Been Tested?

Synthetic render of the table with a real reject (180-char dts line), rich 15.0.0:

| tty | current (`max(cw,160)` + Syntax) | `cw` + Syntax | `cw` + fold / coloured Text |
|---|---|---|---|
| 80 | 160-col rows, wraps | fits, elides with … | fits, complete |
| 99 | 160-col rows, wraps | fits, elides with … | fits, complete |
| 160 | 160-col rows, wraps | fits, complete | fits, complete |
| 172, 220 | fits | fits | fits |

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved failed patch displays with clearer coloring for additions, deletions, and hunk headers.
  - Long rejected patch lines now fold more cleanly for easier review.
  - Failure summaries adapt more reliably to the available terminal width.
  - Rejected sections preserve readable spacing, including content containing tabs.
  - Rejected patch details now use a consistent unified format across patch types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->