### PR TITLE
recomputer-rk3588-devkit: drop duplicate common.inc sourcing

### DIFF
--- a/config/boards/recomputer-rk3588-devkit.conf
+++ b/config/boards/recomputer-rk3588-devkit.conf
@@ -19,9 +19,6 @@ OTA_ENABLE="yes"
 BT_UART="/dev/ttyS6"
 AIC8800_TYPE="sdio"
 RECOMPUTER_GPU_STACK="panthor"
-enable_extension "radxa-aic8800"
-
-source "${SRC}/config/sources/vendors/seeed-studio/recomputer-rk35xx-common.inc"
 
 # select case for BRANCH=vendor to source the Seeed Studio recomputer-rk35xx-common.inc
 case "${BRANCH}" in


### PR DESCRIPTION
# Description

The board conf sourced `recomputer-rk35xx-common.inc` and enabled `radxa-aic8800` unconditionally **before** the `BRANCH` case, which does both again for `BRANCH=vendor` — so `common.inc` was sourced twice. Each sourcing runs `enable_extension "seeed_armbian_extension"`, and with the OTA extension enabled the second pass aborts the build at config stage:

```
extensions/seeed_armbian_extension/armbian-ota/ota-support.sh: line 9: OTA_COMMON_ROOTFS: readonly variable
```

The `BRANCH` case already covers both branches, so the pre-case lines are simply removed.

GitHub issue reference: N/A
Jira reference: N/A

# How Has This Been Tested?

- [x] Building `recomputer-rk3588-devkit` with `BRANCH=vendor` previously aborted at `config_source_board_file` with the error above; with the duplicate `source` removed, the extension chain is enabled exactly once and the build proceeds.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added branch-specific configuration for the ReComputer RK3588 DevKit.
  * Mainline builds now use the updated device tree and Panthor GPU stack.
  * Vendor builds retain the vendor extension and shared board configuration.
* **Bug Fixes**
  * Improved board package selection for non-vendor builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->