### PR TITLE
Extension Brostrend-AIC8800: skip for kernel > 7.2

### DIFF
--- a/extensions/brostrend-aic8800-dkms.sh
+++ b/extensions/brostrend-aic8800-dkms.sh
@@ -14,6 +14,10 @@ function post_install_kernel_debs__install_aic8800_dkms_package() {
 	if [[ "${INSTALL_HEADERS}" != "yes" || "${KERNEL_HAS_WORKING_HEADERS}" != "yes" ]]; then
 		return 0
 	fi
+	if linux-version compare "${KERNEL_MAJOR_MINOR}" ge 7.2; then
+		display_alert "Kernel version is too recent" "skipping aic8800 dkms for kernel v${KERNEL_MAJOR_MINOR}" "warn"
+		return 0
+	fi
 
 	local api_url="https://api.github.com/repos/Shadowrom2020/aic8800-dkms/releases/latest"
 	local latest_version

--- a/extensions/brostrend-aic8800-dkms.sh
+++ b/extensions/brostrend-aic8800-dkms.sh
@@ -14,7 +14,7 @@ function post_install_kernel_debs__install_aic8800_dkms_package() {
 	if [[ "${INSTALL_HEADERS}" != "yes" || "${KERNEL_HAS_WORKING_HEADERS}" != "yes" ]]; then
 		return 0
 	fi
-	if linux-version compare "${KERNEL_MAJOR_MINOR}" ge 7.2; then
+	if linux-version compare "${KERNEL_MAJOR_MINOR}" gt 7.2; then
 		display_alert "Kernel version is too recent" "skipping aic8800 dkms for kernel v${KERNEL_MAJOR_MINOR}" "warn"
 		return 0
 	fi


### PR DESCRIPTION
# Description

_Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change._

Skip installation of brostrend aic8800 driver if Kernel is newer than 7.2 until compilation is fixed.

# How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration._

- [x] build with kernel=edge for Qidi X-6 

# Checklist:

_Please delete options that are not relevant._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Updated AIC8800 DKMS package installation compatibility so kernel version 7.2 remains eligible, while newer kernel versions are skipped.
  - Displays a warning and exits before attempting to download an incompatible package.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->