### PR TITLE
firmware: move {ARMBIAN/MAINLINE}_FIRMWARE_{SOURCE/BRANCH} to main-config & pin to tag/sha1

### DIFF
--- a/lib/functions/artifacts/artifact-firmware.sh
+++ b/lib/functions/artifacts/artifact-firmware.sh
@@ -16,9 +16,6 @@ function artifact_firmware_prepare_version() {
 	artifact_version="undetermined"        # outer scope
 	artifact_version_reason="undetermined" # outer scope
 
-	local ARMBIAN_FIRMWARE_SOURCE="${ARMBIAN_FIRMWARE_GIT_SOURCE:-"https://github.com/armbian/firmware"}"
-	local ARMBIAN_FIRMWARE_BRANCH="branch:${ARMBIAN_FIRMWARE_GIT_BRANCH:-"master"}"
-
 	debug_var ARMBIAN_FIRMWARE_SOURCE
 	debug_var ARMBIAN_FIRMWARE_BRANCH
 

--- a/lib/functions/artifacts/artifact-full_firmware.sh
+++ b/lib/functions/artifacts/artifact-full_firmware.sh
@@ -16,12 +16,10 @@ function artifact_full_firmware_prepare_version() {
 	artifact_version="undetermined"        # outer scope
 	artifact_version_reason="undetermined" # outer scope
 
-	local ARMBIAN_FIRMWARE_SOURCE="${ARMBIAN_FIRMWARE_GIT_SOURCE:-"https://github.com/armbian/firmware"}"
-	local ARMBIAN_FIRMWARE_BRANCH="branch:${ARMBIAN_FIRMWARE_GIT_BRANCH:-"master"}"
-
 	debug_var ARMBIAN_FIRMWARE_SOURCE
 	debug_var ARMBIAN_FIRMWARE_BRANCH
 	debug_var MAINLINE_FIRMWARE_SOURCE
+	debug_var MAINLINE_FIRMWARE_BRANCH
 
 	declare short_hash_size=4
 
@@ -32,7 +30,7 @@ function artifact_full_firmware_prepare_version() {
 	# Sanity check, the SHA1 gotta be sane.
 	[[ "${GIT_INFO_ARMBIAN_FIRMWARE[SHA1]}" =~ ^[0-9a-f]{40}$ ]] || exit_with_error "SHA1 is not sane: '${GIT_INFO_ARMBIAN_FIRMWARE[SHA1]}'"
 
-	declare -A GIT_INFO_MAINLINE_FIRMWARE=([GIT_SOURCE]="${MAINLINE_FIRMWARE_SOURCE}" [GIT_REF]="branch:main")
+	declare -A GIT_INFO_MAINLINE_FIRMWARE=([GIT_SOURCE]="${MAINLINE_FIRMWARE_SOURCE}" [GIT_REF]="${MAINLINE_FIRMWARE_BRANCH}")
 	run_memoized GIT_INFO_MAINLINE_FIRMWARE "git2info" memoized_git_ref_to_info
 	debug_dict GIT_INFO_MAINLINE_FIRMWARE
 

--- a/lib/functions/compilation/packages/firmware-deb.sh
+++ b/lib/functions/compilation/packages/firmware-deb.sh
@@ -18,19 +18,16 @@ function compile_firmware() {
 	declare fw_dir="armbian-firmware${FULL}"
 	mkdir -p "${fw_temp_dir}/${fw_dir}/lib/firmware"
 
-	local ARMBIAN_FIRMWARE_GIT_SOURCE="${ARMBIAN_FIRMWARE_GIT_SOURCE:-"https://github.com/armbian/firmware"}"
-	local ARMBIAN_FIRMWARE_GIT_BRANCH="${ARMBIAN_FIRMWARE_GIT_BRANCH:-"master"}"
-
 	# Fetch Armbian firmware from git.
 	declare fetched_revision
-	do_checkout="no" fetch_from_repo "${ARMBIAN_FIRMWARE_GIT_SOURCE}" "armbian-firmware-git" "branch:${ARMBIAN_FIRMWARE_GIT_BRANCH}"
+	do_checkout="no" fetch_from_repo "${ARMBIAN_FIRMWARE_SOURCE}" "armbian-firmware-git" "${ARMBIAN_FIRMWARE_BRANCH}"
 	declare -r armbian_firmware_git_sha1="${fetched_revision}"
 
 	declare extra_conflicts_comma=""
 	if [[ -n $FULL ]]; then
 		# Fetch kernel firmware from git. This is large, but we don't have two copies of it anymore. So more manageable.
 		declare fetched_revision
-		fetch_from_repo "$MAINLINE_FIRMWARE_SOURCE" "linux-firmware-git" "branch:main"
+		fetch_from_repo "${MAINLINE_FIRMWARE_SOURCE}" "linux-firmware-git" "${MAINLINE_FIRMWARE_BRANCH}"
 		declare -r mainline_firmware_git_sha1="${fetched_revision}"
 
 		# Usage of make install ensures proper symlink creation

--- a/lib/functions/configuration/main-config.sh
+++ b/lib/functions/configuration/main-config.sh
@@ -245,6 +245,15 @@ function do_main_configuration() {
 			;;
 	esac
 
+	# Mainline firmware git version
+	# used to be 'branch:master', but that caused a lot of churn. Bump this when needed. Use the latest published tag's SHA1.
+	# Important: use the tag's ref commit, not the the sha1 for the signed tag itself.
+	declare -g -r MAINLINE_FIRMWARE_BRANCH="${MAINLINE_FIRMWARE_BRANCH:-"commit:2135b2f7714a3a514c989b9728f51f36144cab6f"}" # ref: 'tag:20260810'
+
+	# Armbian firmware
+	declare -g -r ARMBIAN_FIRMWARE_SOURCE="${ARMBIAN_FIRMWARE_SOURCE:-"https://github.com/armbian/firmware"}"
+	declare -g -r ARMBIAN_FIRMWARE_BRANCH="${ARMBIAN_FIRMWARE_BRANCH:-"branch:master"}"
+
 	[[ $USE_GITHUB_UBOOT_MIRROR == yes ]] && UBOOT_MIRROR=github # legacy compatibility?
 
 	# A CI runner that advertises a pass-through git proxy (GITPROXY_ADDRESS,


### PR DESCRIPTION
- 🌿 single spot to set where to source firmware
- 🌴 armbian's still does a branch:master lookup everytime (so it auto-bumps)
- 🌱 mainline is now pinned to specific release (tag)'s sha1, for faster lookups
- 🐸 if needed new firmware lands upstream, bump the tag/sha1 manually
  - this should avoid the multiple terabytes of armbian-firmware-full churn

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Firmware builds now use centrally configured Armbian firmware sources and branches.
  * Mainline firmware is fetched from a pinned revision for more consistent build results.
  * Firmware packaging supports configurable source and branch references instead of relying on fixed defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->