### PR TITLE
be nicer to git upstreams; use ORAS gitball for u-boot as well as kernel

### DIFF
--- a/lib/functions/compilation/kernel-git-oras.sh
+++ b/lib/functions/compilation/kernel-git-oras.sh
@@ -135,7 +135,10 @@ function kernel_prepare_bare_repo_decide_shallow_or_full() {
 
 	display_alert "Using ${decision} Kernel bare tree for ${KERNEL_MAJOR_MINOR}" "${decision_why}" "info"
 
-	declare base_oras_ref="${GHCR_SOURCE}/armbian/shallow" # @TODO allow changing this
+	# GIT_ORAS_TARBALLS_SHALLOW_BASE_REF points the premade-git-tree pulls at a different registry/namespace;
+	# the same variable serves u-boot. It selects a mirror, not content, so it is deliberately
+	# NOT part of any artifact version hash.
+	declare base_oras_ref="${GIT_ORAS_TARBALLS_SHALLOW_BASE_REF:-"${GHCR_SOURCE}/armbian/shallow"}"
 	declare estimated_dl_size_mib=0 benefits="" cons=""
 	case "${decision}" in
 		shallow)
@@ -183,8 +186,7 @@ function kernel_prepare_bare_repo_decide_shallow_or_full() {
 
 # This is run under the logging section, so, no interactive parts -- please.
 function kernel_prepare_bare_repo_from_oras_gitball() {
-
-	# validate kernel_git_bare_tree and bare_tree_done_marker_file are set
+	# These are set by kernel_prepare_bare_repo_decide_shallow_or_full(); assert it actually ran.
 	if [[ -z "${kernel_git_bare_tree}" ]]; then
 		exit_with_error "kernel_git_bare_tree is not set"
 	fi
@@ -192,79 +194,10 @@ function kernel_prepare_bare_repo_from_oras_gitball() {
 		exit_with_error "bare_tree_done_marker_file is not set"
 	fi
 
-	declare kernel_git_bare_tree_done_marker="${kernel_git_bare_tree}/${bare_tree_done_marker_file}"
-
-	if [[ ! -d "${kernel_git_bare_tree}" || ! -f "${kernel_git_bare_tree_done_marker}" ]]; then
-		display_alert "Preparing bare kernel git tree" "this might take a long time" "info"
-
-		if [[ -d "${kernel_git_bare_tree}" ]]; then
-			display_alert "Removing old kernel bare tree" "${kernel_git_bare_tree}" "info"
-			run_host_command_logged rm -rf "${kernel_git_bare_tree}"
-		fi
-
-		wait_for_disk_sync "before Kernel git tree download"
-
-		# now, make sure we've the bundle downloaded correctly...
-		# this defines linux_kernel_clone_bundle_file
-		declare linux_kernel_clone_tar_file
-		download_git_kernel_gitball_via_oras # sets linux_kernel_clone_tar_file or dies
-
-		wait_for_disk_sync "before Kernel git extraction"
-
-		# Just extract the tar_file into the "${kernel_git_bare_tree}" directory, no further work needed.
-		run_host_command_logged mkdir -p "${kernel_git_bare_tree}"
-		# @TODO chance of a pv thingy here?
-		run_host_command_logged tar -xf "${linux_kernel_clone_tar_file}" -C "${kernel_git_bare_tree}"
-
-		wait_for_disk_sync "after Kernel git extraction"
-
-		# sanity check
-		if [[ ! -d "${kernel_git_bare_tree}/.git" ]]; then
-			exit_with_error "Kernel bare tree is missing .git directory ${kernel_git_bare_tree}"
-		fi
-
-		# write the marker file
-		touch "${kernel_git_bare_tree_done_marker}"
-	else
-		display_alert "Kernel bare tree already exists" "${kernel_git_bare_tree}" "cachehit"
-	fi
-
-	git_ensure_safe_directory "${kernel_git_bare_tree}"
+	git_oras_tree_prepare_from_gitball \
+		"Kernel" "${kernel_git_bare_tree}" "${bare_tree_done_marker_file}" \
+		"${git_kernel_oras_ref}" "${git_bundles_dir}" "${git_kernel_ball_fn}" \
+		"${SRC}/cache/sources/linux-kernel-worktree"
 
 	return 0
-}
-
-function download_git_kernel_gitball_via_oras() {
-	# validate git_bundles_dir, git_kernel_ball_fn, and git_kernel_oras_ref are set
-	if [[ -z "${git_bundles_dir}" ]]; then
-		exit_with_error "git_bundles_dir is not set"
-	fi
-	if [[ -z "${git_kernel_ball_fn}" ]]; then
-		exit_with_error "git_kernel_ball_fn is not set"
-	fi
-	if [[ -z "${git_kernel_oras_ref}" ]]; then
-		exit_with_error "git_kernel_oras_ref is not set"
-	fi
-
-	run_host_command_logged mkdir -p "${git_bundles_dir}" # this is later cleaned up by kernel_cleanup_bundle_artifacts()
-
-	# defines outer scope value
-	linux_kernel_clone_tar_file="${git_bundles_dir}/${git_kernel_ball_fn}"
-
-	# if the file already exists, do nothing; it will only exist if successfully downloaded by ORAS
-	if [[ -f "${linux_kernel_clone_tar_file}" ]]; then
-		display_alert "Kernel git-tarball already exists" "${git_kernel_ball_fn}" "cachehit"
-		return 0
-	fi
-
-	# do_with_retries 5 xxx ? -- no -- oras_pull_artifact_file should do it's own retries.
-	oras_pull_artifact_file "${git_kernel_oras_ref}" "${git_bundles_dir}" "${git_kernel_ball_fn}"
-
-	# sanity check
-	if [[ ! -f "${linux_kernel_clone_tar_file}" ]]; then
-		exit_with_error "Kernel git-tarball download failed ${linux_kernel_clone_tar_file}"
-	fi
-
-	return 0
-
 }

--- a/lib/functions/compilation/kernel-git.sh
+++ b/lib/functions/compilation/kernel-git.sh
@@ -27,10 +27,5 @@ function kernel_prepare_git() {
 function kernel_cleanup_bundle_artifacts() {
 	[[ -z "${git_bundles_dir}" ]] && exit_with_error "git_bundles_dir is not set"
 
-	if [[ -d "${git_bundles_dir}" ]]; then
-		display_alert "Cleaning up Kernel git bundle artifacts" "no longer needed" "info"
-		run_host_command_logged rm -rf "${git_bundles_dir}"
-	fi
-
-	return 0
+	git_oras_tree_cleanup_bundles "Kernel" "${git_bundles_dir}"
 }

--- a/lib/functions/compilation/uboot-git-oras.sh
+++ b/lib/functions/compilation/uboot-git-oras.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+#
+# SPDX-License-Identifier: GPL-2.0
+#
+# Copyright (c) 2013-2026 Igor Pecovnik, igor@armbian.com
+#
+# This file is a part of the Armbian Build Framework
+# https://github.com/armbian/build/
+
+# The u-boot bare tree is a premade git tree pulled from an OCI artifact, the same way the Kernel
+# one is. Unlike the Kernel there is no shallow/full decision to make: the artifact is ~390MiB,
+# so one complete tree serves every board.
+#
+# The tree seeds mainline u-boot ('master' plus every tag -- most boards pin BOOTBRANCH to a
+# 'tag:vYYYY.MM') and the Radxa vendor branches under 'radxa/*', which the rk35xx,
+# rockchip-rk3588 and rockchip-rv1106 families build from. Every *other* u-boot fork Armbian
+# builds fetches into this same tree; they are not seeded, but they land on top of mainline's
+# history, so their fetches stay small.
+
+# Sets outer scope: uboot_git_bare_tree, uboot_git_bundles_dir
+function uboot_prepare_bare_repo() {
+	# Path is unchanged from when this was a git clone; cli-patch.sh pushes from it by name.
+	uboot_git_bare_tree="${SRC}/cache/git-bare/u-boot"      # outer scope
+	uboot_git_bundles_dir="${SRC}/cache/git-bundles/u-boot" # outer scope
+
+	# Deliberately not the Kernel's ".git/armbian-bare-tree-done". A tree carrying that older
+	# marker was produced by the old `git clone` of mainline: it has no Radxa branches, plus an
+	# origin remote, hooks and multiple packfiles. Accepting it would mean warm-cache users and
+	# long-lived self-hosted runners silently never get the vendor branches, while fresh CI
+	# runners do -- and it would not even save bandwidth, since the first rk35xx build on such a
+	# tree fetches all of Radxa anyway. Treat the marker name as the artifact's version number.
+	declare marker_rel=".git/armbian-bare-tree-done-oras"
+
+	# Offline builds can't pull, and hard-failing a user who already has a working tree would be
+	# a regression over the old behaviour. Accept either marker, and say what might be missing.
+	if [[ "${OFFLINE_WORK}" == "yes" && -d "${uboot_git_bare_tree}" ]]; then
+		if [[ -f "${uboot_git_bare_tree}/${marker_rel}" || -f "${uboot_git_bare_tree}/.git/armbian-bare-tree-done" ]]; then
+			display_alert "OFFLINE_WORK: using the existing u-boot bare tree as-is" "vendor branches may be missing" "warn"
+			git_ensure_safe_directory "${uboot_git_bare_tree}"
+			return 0
+		fi
+	fi
+
+	# GIT_ORAS_TARBALLS_SHALLOW_BASE_REF also drives the Kernel gitball; see kernel-git-oras.sh.
+	declare base_oras_ref="${GIT_ORAS_TARBALLS_SHALLOW_BASE_REF:-"${GHCR_SOURCE}/armbian/shallow"}"
+
+	# There is no shallow/full prompt for u-boot, so this alert is the only warning a first-time
+	# user on a slow link gets before a few hundred MiB starts moving.
+	display_alert "Preparing u-boot bare git tree" "~390 MiB download, first use only" "info"
+
+	git_oras_tree_prepare_from_gitball \
+		"u-boot" "${uboot_git_bare_tree}" "${marker_rel}" \
+		"${base_oras_ref}/u-boot-git:latest" \
+		"${uboot_git_bundles_dir}" "u-boot-complete.git.tar" \
+		"${SRC}/cache/sources/u-boot-worktree"
+
+	return 0
+}
+
+function uboot_cleanup_bundle_artifacts() {
+	[[ -z "${uboot_git_bundles_dir}" ]] && exit_with_error "uboot_git_bundles_dir is not set"
+
+	git_oras_tree_cleanup_bundles "u-boot" "${uboot_git_bundles_dir}"
+}

--- a/lib/functions/compilation/uboot-git.sh
+++ b/lib/functions/compilation/uboot-git.sh
@@ -7,35 +7,12 @@
 # This file is a part of the Armbian Build Framework
 # https://github.com/armbian/build/
 
-function uboot_prepare_bare_repo() {
-	uboot_git_bare_tree="${SRC}/cache/git-bare/u-boot" # sets the outer scope variable
-	declare uboot_git_bare_tree_done_marker="${uboot_git_bare_tree}/.git/armbian-bare-tree-done"
-
-	if [[ ! -d "${uboot_git_bare_tree}" || ! -f "${uboot_git_bare_tree_done_marker}" ]]; then
-		if [[ -d "${uboot_git_bare_tree}" ]]; then
-			display_alert "Removing old u-boot bare tree" "${uboot_git_bare_tree}" "info"
-			rm -rf "${uboot_git_bare_tree}"
-		fi
-
-		# get the mainline u-boot repo completely; use clone, not fetch.
-		display_alert "Cloning u-boot from mainline into bare tree" "this might take a somewhat-long time" "info"
-		declare -a verbose_params=() && if_user_on_terminal_and_not_logging_add verbose_params "--verbose" "--progress"
-		run_host_command_logged git clone "${verbose_params[@]}" --tags --no-checkout \
-			"${MAINLINE_UBOOT_SOURCE}" "${uboot_git_bare_tree}"
-
-		# write the marker file
-		touch "${uboot_git_bare_tree_done_marker}"
-	fi
-
-	return 0
-}
-
 function uboot_prepare_git() {
 	display_alert "Preparing git for u-boot" "BOOTSOURCE: ${BOOTSOURCE}" "debug"
 	if [[ -n $BOOTSOURCE ]] && [[ "${BOOTSOURCE}" != "none" ]]; then
-		# Prepare the git bare repo for u-boot.
-		declare uboot_git_bare_tree
-		uboot_prepare_bare_repo # this sets uboot_git_bare_tree
+		# Prepare the git bare repo for u-boot; shared between all u-boot builds.
+		declare uboot_git_bare_tree uboot_git_bundles_dir
+		uboot_prepare_bare_repo # sets uboot_git_bare_tree and uboot_git_bundles_dir
 		git_ensure_safe_directory "${uboot_git_bare_tree}"
 
 		display_alert "Downloading sources" "u-boot; BOOTSOURCEDIR=${BOOTSOURCEDIR}" "git"
@@ -52,6 +29,14 @@ function uboot_prepare_git() {
 		# Sets the outer scope variable
 		uboot_git_revision="${checked_out_revision}"
 		display_alert "Using u-boot revision SHA1" "${uboot_git_revision}"
+
+		# fetch_from_repo() has now created a worktree off the extracted tree, resolved a
+		# revision, checked it out and cleaned it -- so it has read real objects out of the
+		# extracted pack and the downloaded tarball has served its purpose. The Kernel defers
+		# this until after patching (compile_kernel), but u-boot has no single orchestrator:
+		# uboot_prepare_git has two callers that patch in different places, and doing it here
+		# covers both.
+		uboot_cleanup_bundle_artifacts
 	fi
 	return 0
 }

--- a/lib/functions/configuration/main-config.sh
+++ b/lib/functions/configuration/main-config.sh
@@ -271,6 +271,10 @@ function do_main_configuration() {
 			;;
 	esac
 
+	# Note: this selects the mirror for BOOTSOURCE on boards that use mainline u-boot. It no
+	# longer has anything to do with the shared u-boot bare tree, which since the move to
+	# premade ORAS git trees always comes from ${GHCR_SOURCE} -- see uboot-git-oras.sh, and
+	# GHCR_MIRROR / GIT_ORAS_TARBALLS_SHALLOW_BASE_REF for redirecting that.
 	case $UBOOT_MIRROR in
 		gitee)
 			declare -g -r MAINLINE_UBOOT_SOURCE='https://gitee.com/mirrors/u-boot.git'

--- a/lib/functions/general/git-oras-tree.sh
+++ b/lib/functions/general/git-oras-tree.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+#
+# SPDX-License-Identifier: GPL-2.0
+#
+# Copyright (c) 2013-2026 Igor Pecovnik, igor@armbian.com
+#
+# This file is a part of the Armbian Build Framework
+# https://github.com/armbian/build/
+
+# Obtaining a premade git tree from an OCI artifact, shared by the Kernel and u-boot paths.
+#
+# The producer (https://github.com/armbian/shallow) builds a git tree, tars its .git directory,
+# and pushes that tar to ghcr.io. Here we pull the tar and extract it into a "bare tree" -- which
+# despite the name is a normal non-bare repo with an empty working copy; fetch_from_repo() hangs
+# `git worktree`s off it. A marker file inside records that the extraction completed, so a
+# half-finished download is never mistaken for a usable tree.
+#
+# Everything is passed in explicitly: the callers own wildly different config vars, and outer-scope
+# coupling is what kept this from being reusable in the first place.
+
+# <what> <tree_dir> <marker_rel> <oci_ref> <bundles_dir> <ball_fn> [<stale_worktrees_dir>]
+#   what                human-readable subject for log lines, e.g. "Kernel" or "u-boot"
+#   tree_dir            where the tree lives, e.g. ${SRC}/cache/git-bare/u-boot
+#   marker_rel          done-marker, relative to tree_dir, e.g. ".git/armbian-bare-tree-done"
+#   oci_ref             full OCI reference including the tag
+#   bundles_dir         scratch directory for the download
+#   ball_fn             file name inside the artifact, e.g. "u-boot-complete.git.tar"
+#   stale_worktrees_dir optional; its *contents* are purged if the tree is (re-)extracted
+#
+# Idempotent, hard-fails via exit_with_error. Must run under a logging section; nothing here
+# is interactive.
+function git_oras_tree_prepare_from_gitball() {
+	declare what="${1:?what is required}"
+	declare tree_dir="${2:?tree_dir is required}"
+	declare marker_rel="${3:?marker_rel is required}"
+	declare oci_ref="${4:?oci_ref is required}"
+	declare bundles_dir="${5:?bundles_dir is required}"
+	declare ball_fn="${6:?ball_fn is required}"
+	declare stale_worktrees_dir="${7:-""}"
+
+	declare done_marker="${tree_dir}/${marker_rel}"
+
+	if [[ ! -d "${tree_dir}" || ! -f "${done_marker}" ]]; then
+		display_alert "Preparing bare ${what} git tree" "this might take a long time" "info"
+
+		if [[ -d "${tree_dir}" ]]; then
+			display_alert "Removing old ${what} bare tree" "${tree_dir}" "info"
+			run_host_command_logged rm -rf "${tree_dir}"
+		fi
+
+		# Worktrees are registered on both ends: the worktree's .git file points into
+		# ${tree_dir}/.git/worktrees/<name>, and fetch_from_repo() hard-fails (see
+		# lib/functions/general/git.sh, "Bare repo worktree gitdir not found") when it finds a
+		# worktree whose registry entry has gone. Replacing the tree orphans every one of them,
+		# so they have to go with it. Contents only -- these directories are Docker mountpoints
+		# and removing the directory itself is EBUSY inside the container.
+		if [[ -n "${stale_worktrees_dir}" && -d "${stale_worktrees_dir}" ]]; then
+			display_alert "Purging ${what} worktrees orphaned by bare tree removal" "${stale_worktrees_dir}" "warn"
+			run_host_command_logged rm -rf "${stale_worktrees_dir:?}/"*
+		fi
+
+		wait_for_disk_sync "before ${what} git tree download"
+
+		declare git_oras_tree_tar_file
+		git_oras_tree_download_gitball "${what}" "${oci_ref}" "${bundles_dir}" "${ball_fn}" # sets git_oras_tree_tar_file or dies
+
+		wait_for_disk_sync "before ${what} git extraction"
+
+		# Just extract the tar_file into the "${tree_dir}" directory, no further work needed.
+		run_host_command_logged mkdir -p "${tree_dir}"
+		# @TODO chance of a pv thingy here?
+		run_host_command_logged tar -xf "${git_oras_tree_tar_file}" -C "${tree_dir}"
+
+		wait_for_disk_sync "after ${what} git extraction"
+
+		# sanity check
+		if [[ ! -d "${tree_dir}/.git" ]]; then
+			exit_with_error "${what} bare tree is missing .git directory ${tree_dir}"
+		fi
+
+		# write the marker file
+		touch "${done_marker}"
+	else
+		display_alert "${what} bare tree already exists" "${tree_dir}" "cachehit"
+	fi
+
+	git_ensure_safe_directory "${tree_dir}"
+
+	return 0
+}
+
+# <what> <oci_ref> <bundles_dir> <ball_fn>
+# Sets outer-scope 'git_oras_tree_tar_file' to the downloaded file, or dies trying.
+function git_oras_tree_download_gitball() {
+	declare what="${1:?what is required}"
+	declare oci_ref="${2:?oci_ref is required}"
+	declare bundles_dir="${3:?bundles_dir is required}"
+	declare ball_fn="${4:?ball_fn is required}"
+
+	run_host_command_logged mkdir -p "${bundles_dir}" # cleaned up later by git_oras_tree_cleanup_bundles()
+
+	# defines outer scope value
+	git_oras_tree_tar_file="${bundles_dir}/${ball_fn}"
+
+	# if the file already exists, do nothing; it will only exist if successfully downloaded by ORAS
+	if [[ -f "${git_oras_tree_tar_file}" ]]; then
+		display_alert "${what} git-tarball already exists" "${ball_fn}" "cachehit"
+		return 0
+	fi
+
+	# do_with_retries 5 xxx ? -- no -- oras_pull_artifact_file should do it's own retries.
+	oras_pull_artifact_file "${oci_ref}" "${bundles_dir}" "${ball_fn}"
+
+	# sanity check
+	if [[ ! -f "${git_oras_tree_tar_file}" ]]; then
+		exit_with_error "${what} git-tarball download failed ${git_oras_tree_tar_file}"
+	fi
+
+	return 0
+}
+
+# <what> <bundles_dir>
+# Drop the downloaded tar once the extracted tree has proven itself; it is dead weight afterwards.
+function git_oras_tree_cleanup_bundles() {
+	declare what="${1:?what is required}"
+	declare bundles_dir="${2:?bundles_dir is required}"
+
+	if [[ -d "${bundles_dir}" ]]; then
+		display_alert "Cleaning up ${what} git bundle artifacts" "no longer needed" "info"
+		run_host_command_logged rm -rf "${bundles_dir}"
+	fi
+
+	return 0
+}

--- a/lib/functions/general/git-ref2info.sh
+++ b/lib/functions/general/git-ref2info.sh
@@ -21,6 +21,19 @@ function _git_sources_pinned_sha1() {
 		'[.[] | select(.source == $s and .branch == $b) | .sha1] | first // empty' "${json}"
 }
 
+# The URL to actually contact for a given git source, honoring GITHUB_MIRROR=ghproxy.
+# Same reasoning as _git_sources_pinned_sha1() above re: file scope and the memoize cache hash:
+# keep it trivial and stable.
+# <source_url>
+function git_remote_url_for_mirror() {
+	declare source_url="${1}"
+	if [[ "${GITHUB_MIRROR}" == "ghproxy" && "${source_url}" == "https://github.com/"* ]]; then
+		echo -n "https://${GHPROXY_ADDRESS}/${source_url}"
+	else
+		echo -n "${source_url}"
+	fi
+}
+
 # This works under memoize-cached.sh::run_memoized() -- which is full of tricks.
 # Nested functions are used because the source of the momoized function is used as part of the cache hash.
 function memoized_git_ref_to_info() {
@@ -32,13 +45,13 @@ function memoized_git_ref_to_info() {
 	MEMO_DICT+=(["REF_TYPE"]="${ref_type}")
 	MEMO_DICT+=(["REF_NAME"]="${ref_name}")
 
-	# Small detour here; if it's a tag, ask for the dereferenced commit, to avoid the annotated tag's sha1, instead get the commit tag points to.
-	# Also, try 'refs/heads/xxx' first. Some repos have Gerrit-style "refs/for/xxx" refs, which are not what we want.
-	if [[ "${ref_type}" == "tag" ]]; then
-		refs_to_try+=("refs/heads/${ref_name}^{}" "refs/heads/${ref_name}" "${ref_name}^{}" "${ref_name}") # try first with a tag dereference, then just the tag. for annotated tags support.
-	elif [[ "${ref_type}" == "branch" ]]; then
+	# Tags are resolved further down, in a single hit to the remote, by git_ls_remote_tag_commit_sha1();
+	# they don't go through the try-list at all. Asking for 'refs/heads/xxx' for a tag, as this used to,
+	# is two guaranteed-dead round-trips: a tag is never in the branch namespace.
+	# For the rest: try 'refs/heads/xxx' first. Some repos have Gerrit-style "refs/for/xxx" refs, which are not what we want.
+	if [[ "${ref_type}" == "branch" ]]; then
 		refs_to_try+=("refs/heads/${ref_name}" "${ref_name}")
-	else
+	elif [[ "${ref_type}" != "tag" ]]; then
 		refs_to_try+=("${ref_name}")
 	fi
 
@@ -60,6 +73,13 @@ function memoized_git_ref_to_info() {
 		fi
 	fi
 
+	# Tags: one ls-remote resolves annotated and lightweight tags alike; no try-list, no wasted round-trips.
+	# Guarded on the sha1 not being valid yet, so the OFFLINE_WORK pinned-sha1 above still wins.
+	if [[ "${ref_type}" == "tag" && ! "${sha1}" =~ ^[0-9a-f]{40}$ ]]; then
+		sha1="$(git_ls_remote_tag_commit_sha1 "$(git_remote_url_for_mirror "${MEMO_DICT[GIT_SOURCE]}")" "${ref_name}")"
+		display_alert "SHA1 of tag ${ref_name}" "'${sha1}'" "info"
+	fi
+
 	# Enter loop. The first that resolves to a valid sha1 wins.
 	declare to_try
 	for to_try in "${refs_to_try[@]}"; do
@@ -69,21 +89,7 @@ function memoized_git_ref_to_info() {
 				sha1="${to_try}"
 				;;
 			*)
-				case "${GITHUB_MIRROR}" in
-					"ghproxy")
-						case "${MEMO_DICT[GIT_SOURCE]}" in
-							"https://github.com/"*)
-								sha1="$(git ls-remote --exit-code "https://${GHPROXY_ADDRESS}/${MEMO_DICT[GIT_SOURCE]}" "${to_try}" | cut -f1)"
-								;;
-							*)
-								sha1="$(git ls-remote --exit-code "${MEMO_DICT[GIT_SOURCE]}" "${to_try}" | cut -f1)"
-								;;
-						esac
-						;;
-					*)
-						sha1="$(git ls-remote --exit-code "${MEMO_DICT[GIT_SOURCE]}" "${to_try}" | cut -f1)"
-						;;
-				esac
+				sha1="$(git_ls_remote_logged "${ref_type} '${to_try}'" --exit-code "$(git_remote_url_for_mirror "${MEMO_DICT[GIT_SOURCE]}")" "${to_try}" | cut -f1)"
 				;;
 		esac
 

--- a/lib/functions/general/git.sh
+++ b/lib/functions/general/git.sh
@@ -59,6 +59,28 @@ function git_ls_remote_logged() {
 	git ls-remote "$@"
 }
 
+# Resolve a tag to the COMMIT it points at, in a single hit to the remote.
+# Annotated tags advertise both 'refs/tags/X' (the tag object) and 'refs/tags/X^{}' (the commit);
+# lightweight tags advertise only 'refs/tags/X', which already is the commit. ls-remote takes more
+# than one pattern at a time, so ask for both and prefer the peeled one -- one round-trip, correct
+# for either kind of tag. Echoes the sha1, or nothing if the remote does not have the tag.
+# <url> <tag_name>
+function git_ls_remote_tag_commit_sha1() {
+	declare url="${1}" tag_name="${2}"
+	declare ls_remote_output peeled="" plain="" one_sha1 one_ref
+	# '|| true': not finding the tag is a normal answer here, not an error; the caller decides what to do.
+	ls_remote_output="$(git_ls_remote_logged "tag '${tag_name}' (annotated or not)" --tags "${url}" "${tag_name}" "${tag_name}^{}" || true)"
+	# Match the full ref name: ls-remote patterns match the tail on a slash boundary, so asking for
+	# 'v2026.07' also matches a 'refs/tags/vendor/v2026.07', which is not the tag we asked for.
+	while read -r one_sha1 one_ref; do
+		case "${one_ref}" in
+			"refs/tags/${tag_name}^{}") peeled="${one_sha1}" ;;
+			"refs/tags/${tag_name}") plain="${one_sha1}" ;;
+		esac
+	done <<< "${ls_remote_output}"
+	echo -n "${peeled:-${plain}}"
+}
+
 # workaround new limitations imposed by CVE-2022-24765 fix in git, otherwise  "fatal: unsafe repository"
 function git_ensure_safe_directory() {
 	if [[ -n "$(command -v git)" ]]; then
@@ -212,14 +234,12 @@ function fetch_from_repo() {
 				changed=true
 				;;
 			tag)
-				remote_hash=$(git_ls_remote_logged "the tag" -t "${url}" "$ref_name" | cut -f1)
-				if [[ -z $local_hash || "${local_hash}" != "${remote_hash}" ]]; then
-					remote_hash=$(git_ls_remote_logged "the annotated tag commit" -t "${url}" "$ref_name^{}" | cut -f1) # peel the annotated tag down to the commit it points at
-					if [[ -z $remote_hash || "${local_hash}" != "${remote_hash}" ]]; then
-						changed=true
-					else
-						display_alert "Git annotated tag already checked out" "$dir tag:${ref_name} @ ${local_hash}" "cachehit"
-					fi
+				# One hit resolves both annotated and lightweight tags, and always yields a commit, so it is
+				# directly comparable to local_hash (which is 'git rev-parse @', also a commit). Comparing
+				# against the annotated tag's own sha1 could never match, and thus never cache-hit.
+				remote_hash="$(git_ls_remote_tag_commit_sha1 "${url}" "${ref_name}")"
+				if [[ -z $local_hash || -z $remote_hash || "${local_hash}" != "${remote_hash}" ]]; then
+					changed=true
 				else
 					display_alert "Git tag already checked out" "$dir tag:${ref_name} @ ${local_hash}" "cachehit"
 				fi
@@ -286,8 +306,11 @@ function fetch_from_repo() {
 	display_alert "git: Fetch from remote completed, rev-parsing..." "'$dir' '$ref_name' '${checkout_from}'" "info"
 
 	# should be declared in outer scope: fetched_revision fetched_revision_ts
-	fetched_revision="$(git rev-parse "${checkout_from}")"
-	fetched_revision_ts="$(git log -1 --pretty=%ct "${checkout_from}")" # unix timestamp of the commit date
+	# Peel to the commit: after fetching an annotated tag, FETCH_HEAD is the *tag object's* sha1, not the
+	# commit's. Without this, a cold build (fetch -> FETCH_HEAD) and a warm one (cachehit -> HEAD) would
+	# report different revisions for the exact same tree. It also matches what git-ref2info.sh resolves.
+	fetched_revision="$(git rev-parse "${checkout_from}^{commit}")"
+	fetched_revision_ts="$(git log -1 --pretty=%ct "${fetched_revision}")" # unix timestamp of the commit date
 	display_alert "Fetched revision: fetched_revision:" "${fetched_revision}" "git"
 	display_alert "Fetched revision: fetched_revision_ts:" "${fetched_revision_ts}" "git"
 

--- a/lib/functions/general/git.sh
+++ b/lib/functions/general/git.sh
@@ -51,6 +51,14 @@ function improved_git_fetch() {
 	improved_git fetch "${verbose_params[@]}" --recurse-submodules=no "$@"
 }
 
+# Every 'git ls-remote' is a hit to the remote: it is slow, and it might hang; let the user know before we do it.
+# <what: human description of what we are asking the remote> <ls-remote args...>
+function git_ls_remote_logged() {
+	declare what="${1}" && shift
+	display_alert "Querying git remote for ${what}" "${*}" "info" # display_alert writes to stderr, so this is safe inside $(...)
+	git ls-remote "$@"
+}
+
 # workaround new limitations imposed by CVE-2022-24765 fix in git, otherwise  "fatal: unsafe repository"
 function git_ensure_safe_directory() {
 	if [[ -n "$(command -v git)" ]]; then
@@ -198,55 +206,80 @@ function fetch_from_repo() {
 
 		case $ref_type in
 			branch)
-				# TODO: grep refs/heads/$name
-				remote_hash=$(git ls-remote -h "${url}" "$ref_name" | head -1 | cut -f1)
-				[[ -z $local_hash || "${local_hash}" != "a${remote_hash}" ]] && changed=true
+				# Branches are always fetched, because they are mutable; we don't want to be stuck on an old commit.
+				# No ls-remote here on purpose: its answer can't change the outcome, and it'd cost an extra remote round-trip.
+				remote_hash="(not queried)"
+				changed=true
 				;;
 			tag)
-				remote_hash=$(git ls-remote -t "${url}" "$ref_name" | cut -f1)
+				remote_hash=$(git_ls_remote_logged "the tag" -t "${url}" "$ref_name" | cut -f1)
 				if [[ -z $local_hash || "${local_hash}" != "${remote_hash}" ]]; then
-					remote_hash=$(git ls-remote -t "${url}" "$ref_name^{}" | cut -f1)
-					[[ -z $remote_hash || "${local_hash}" != "${remote_hash}" ]] && changed=true
+					remote_hash=$(git_ls_remote_logged "the annotated tag commit" -t "${url}" "$ref_name^{}" | cut -f1) # peel the annotated tag down to the commit it points at
+					if [[ -z $remote_hash || "${local_hash}" != "${remote_hash}" ]]; then
+						changed=true
+					else
+						display_alert "Git annotated tag already checked out" "$dir tag:${ref_name} @ ${local_hash}" "cachehit"
+					fi
+				else
+					display_alert "Git tag already checked out" "$dir tag:${ref_name} @ ${local_hash}" "cachehit"
 				fi
 				;;
 			head)
-				remote_hash=$(git ls-remote "${url}" HEAD | cut -f1)
-				[[ -z $local_hash || "${local_hash}" != "${remote_hash}" ]] && changed=true
+				remote_hash=$(git_ls_remote_logged "HEAD" "${url}" HEAD | cut -f1)
+				if [[ -z $local_hash || "${local_hash}" != "${remote_hash}" ]]; then
+					changed=true
+				else
+					display_alert "Git already at the remote HEAD" "$dir head @ ${local_hash}" "cachehit"
+				fi
 				;;
 			commit)
 				remote_hash="${ref_name}"
-				[[ -z $local_hash || $local_hash == "@" || "${local_hash}" != "${remote_hash}" ]] && changed=true
+				if [[ -z $local_hash || $local_hash == "@" || "${local_hash}" != "${remote_hash}" ]]; then
+					changed=true
+				else
+					display_alert "Git commit/sha1 already checked out" "$dir commit:${ref_name}" "cachehit"
+				fi
 				;;
 		esac
 
 		display_alert "Git local_hash vs remote_hash" "${local_hash} vs ${remote_hash}" "git"
 
+	else
+		display_alert "Git offline, not checking the remote at all" "$dir ${ref_type}:${ref_name}" "cachehit"
 	fi # offline
 
 	local checkout_from="HEAD" # Probably best to use the local revision?
 
 	if [[ "${changed}" == "true" ]]; then
 
-		# remote was updated, fetch and check out updates, but not tags; tags pull their respective commits too, making it a huge fetch.
-		display_alert "Fetching updates from remote repository" "$dir $ref_name"
-		case $ref_type in
-			branch)
-				improved_git_fetch --no-tags "${url}" "${ref_name}"
-				;;
-			tag)
-				improved_git_fetch --no-tags "${url}" tags/"${ref_name}"
-				;;
-			head)
-				improved_git_fetch --no-tags "${url}" HEAD
-				;;
-			commit)
-				# @TODO: if the local copy has the revision, skip the fetch -- would save us a lot of time
-				display_alert "Fetching a specific commit/sha1" "${ref_name}" "debug"
-				improved_git_fetch --no-tags "${url}" "${ref_name}"
-				;;
-		esac
+		# Important: we might have the commit locally, even if it is not the local_hash; sha1's are immutable, so
+		# if the object is already in the local copy there is nothing to fetch -- saves us a lot of time.
+		if [[ "${ref_type}" == "commit" ]] && git cat-file -e "${ref_name}^{commit}" &> /dev/null; then
+			display_alert "Commit/sha1 already in local copy, skipping git fetch" "$dir ${ref_name}" "cachehit"
+			checkout_from="${ref_name}"
+		else
+			# remote was updated, fetch and check out updates, but not tags; tags pull their respective commits too, making it a huge fetch.
+			display_alert "Fetching updates from remote repository" "$dir $ref_name"
+			case $ref_type in
+				branch)
+					improved_git_fetch --no-tags "${url}" "${ref_name}"
+					;;
+				tag)
+					improved_git_fetch --no-tags "${url}" tags/"${ref_name}"
+					;;
+				head)
+					improved_git_fetch --no-tags "${url}" HEAD
+					;;
+				commit)
+					display_alert "Fetching a specific commit/sha1" "${ref_name}" "debug"
+					improved_git_fetch --no-tags "${url}" "${ref_name}"
+					;;
+			esac
 
-		checkout_from="FETCH_HEAD"
+			checkout_from="FETCH_HEAD"
+		fi
+	else
+		display_alert "Local copy is up to date, skipping git fetch" "$dir ${ref_type}:${ref_name}" "cachehit"
 	fi
 
 	# if the tree is shallow and big, this first rev-parse takes a while; use info to inform about what is done

--- a/lib/library-functions.sh
+++ b/lib/library-functions.sh
@@ -87,6 +87,15 @@ source "${SRC}"/lib/functions/artifacts/artifact-rootfs.sh
 #set -o nounset   ## set -u : exit the script if you try to use an uninitialised variable - one day will be enabled
 set -o errtrace # trace ERR through - enabled
 set -o errexit  ## set -e : exit the script if any statement returns a non-true return value - enabled
+### lib/functions/artifacts/artifact-uboot.sh
+# shellcheck source=lib/functions/artifacts/artifact-uboot.sh
+source "${SRC}"/lib/functions/artifacts/artifact-uboot.sh
+
+# no errors tolerated. invoked before each sourced file to make sure.
+#set -o pipefail  # trace ERR through pipes - will be enabled "soon"
+#set -o nounset   ## set -u : exit the script if you try to use an uninitialised variable - one day will be enabled
+set -o errtrace # trace ERR through - enabled
+set -o errexit  ## set -e : exit the script if any statement returns a non-true return value - enabled
 ### lib/functions/artifacts/artifacts-obtain.sh
 # shellcheck source=lib/functions/artifacts/artifacts-obtain.sh
 source "${SRC}"/lib/functions/artifacts/artifacts-obtain.sh
@@ -108,15 +117,6 @@ set -o errexit  ## set -e : exit the script if any statement returns a non-true 
 ### lib/functions/artifacts/artifacts-reversion.sh
 # shellcheck source=lib/functions/artifacts/artifacts-reversion.sh
 source "${SRC}"/lib/functions/artifacts/artifacts-reversion.sh
-
-# no errors tolerated. invoked before each sourced file to make sure.
-#set -o pipefail  # trace ERR through pipes - will be enabled "soon"
-#set -o nounset   ## set -u : exit the script if you try to use an uninitialised variable - one day will be enabled
-set -o errtrace # trace ERR through - enabled
-set -o errexit  ## set -e : exit the script if any statement returns a non-true return value - enabled
-### lib/functions/artifacts/artifact-uboot.sh
-# shellcheck source=lib/functions/artifacts/artifact-uboot.sh
-source "${SRC}"/lib/functions/artifacts/artifact-uboot.sh
 
 # no errors tolerated. invoked before each sourced file to make sure.
 #set -o pipefail  # trace ERR through pipes - will be enabled "soon"
@@ -288,15 +288,6 @@ set -o errexit  ## set -e : exit the script if any statement returns a non-true 
 ### lib/functions/compilation/atf.sh
 # shellcheck source=lib/functions/compilation/atf.sh
 source "${SRC}"/lib/functions/compilation/atf.sh
-
-# no errors tolerated. invoked before each sourced file to make sure.
-#set -o pipefail  # trace ERR through pipes - will be enabled "soon"
-#set -o nounset   ## set -u : exit the script if you try to use an uninitialised variable - one day will be enabled
-set -o errtrace # trace ERR through - enabled
-set -o errexit  ## set -e : exit the script if any statement returns a non-true return value - enabled
-### lib/functions/compilation/stubble.sh
-# shellcheck source=lib/functions/compilation/stubble.sh
-source "${SRC}"/lib/functions/compilation/stubble.sh
 
 # no errors tolerated. invoked before each sourced file to make sure.
 #set -o pipefail  # trace ERR through pipes - will be enabled "soon"
@@ -483,6 +474,24 @@ source "${SRC}"/lib/functions/compilation/patch/patching.sh
 #set -o nounset   ## set -u : exit the script if you try to use an uninitialised variable - one day will be enabled
 set -o errtrace # trace ERR through - enabled
 set -o errexit  ## set -e : exit the script if any statement returns a non-true return value - enabled
+### lib/functions/compilation/stubble.sh
+# shellcheck source=lib/functions/compilation/stubble.sh
+source "${SRC}"/lib/functions/compilation/stubble.sh
+
+# no errors tolerated. invoked before each sourced file to make sure.
+#set -o pipefail  # trace ERR through pipes - will be enabled "soon"
+#set -o nounset   ## set -u : exit the script if you try to use an uninitialised variable - one day will be enabled
+set -o errtrace # trace ERR through - enabled
+set -o errexit  ## set -e : exit the script if any statement returns a non-true return value - enabled
+### lib/functions/compilation/uboot-git-oras.sh
+# shellcheck source=lib/functions/compilation/uboot-git-oras.sh
+source "${SRC}"/lib/functions/compilation/uboot-git-oras.sh
+
+# no errors tolerated. invoked before each sourced file to make sure.
+#set -o pipefail  # trace ERR through pipes - will be enabled "soon"
+#set -o nounset   ## set -u : exit the script if you try to use an uninitialised variable - one day will be enabled
+set -o errtrace # trace ERR through - enabled
+set -o errexit  ## set -e : exit the script if any statement returns a non-true return value - enabled
 ### lib/functions/compilation/uboot-git.sh
 # shellcheck source=lib/functions/compilation/uboot-git.sh
 source "${SRC}"/lib/functions/compilation/uboot-git.sh
@@ -654,9 +663,9 @@ source "${SRC}"/lib/functions/general/extensions.sh
 #set -o nounset   ## set -u : exit the script if you try to use an uninitialised variable - one day will be enabled
 set -o errtrace # trace ERR through - enabled
 set -o errexit  ## set -e : exit the script if any statement returns a non-true return value - enabled
-### lib/functions/general/github-actions.sh
-# shellcheck source=lib/functions/general/github-actions.sh
-source "${SRC}"/lib/functions/general/github-actions.sh
+### lib/functions/general/git-oras-tree.sh
+# shellcheck source=lib/functions/general/git-oras-tree.sh
+source "${SRC}"/lib/functions/general/git-oras-tree.sh
 
 # no errors tolerated. invoked before each sourced file to make sure.
 #set -o pipefail  # trace ERR through pipes - will be enabled "soon"
@@ -675,6 +684,15 @@ set -o errexit  ## set -e : exit the script if any statement returns a non-true 
 ### lib/functions/general/git.sh
 # shellcheck source=lib/functions/general/git.sh
 source "${SRC}"/lib/functions/general/git.sh
+
+# no errors tolerated. invoked before each sourced file to make sure.
+#set -o pipefail  # trace ERR through pipes - will be enabled "soon"
+#set -o nounset   ## set -u : exit the script if you try to use an uninitialised variable - one day will be enabled
+set -o errtrace # trace ERR through - enabled
+set -o errexit  ## set -e : exit the script if any statement returns a non-true return value - enabled
+### lib/functions/general/github-actions.sh
+# shellcheck source=lib/functions/general/github-actions.sh
+source "${SRC}"/lib/functions/general/github-actions.sh
 
 # no errors tolerated. invoked before each sourced file to make sure.
 #set -o pipefail  # trace ERR through pipes - will be enabled "soon"


### PR DESCRIPTION
#### be nicer to git upstreams; use ORAS gitball for u-boot as well as kernel

- 🍀 git: be much nicer to git upstreams; fetch less, log every remote hit
  - fetch_from_repo: avoid hitting remote for commit:xxx already present in local clone
  - fetch_from_repo() used to hit the remote more than it needed to, and did so mostly silently. Every ref, every build, every CI job -- that adds up to a lot of load on upstream git servers (kernel.org, GitHub, and friends) for answers we either already had or were going to ignore.
  - Fewer round-trips:
    - commit:<sha1> refs: if the object is already in the local copy, skip the fetch entirely and check out straight from the sha1. sha1's are immutable, so if we have it, there is nothing upstream could tell us. Note we might have the commit locally even when it is not the local_hash, so this hits far more often than the pre-existing local_hash comparison did.
    - branch refs: drop the ls-remote. Branches are mutable and thus always re-fetched; asking the remote for the tip first could not change that outcome, so it was a pure extra round-trip before the fetch that always followed. Halves the remote hits for every branch-based source.
  - Louder about the ones that remain:
    - new git_ls_remote_logged() wrapper: every single ls-remote now announces itself at info level before contacting the remote, naming what we're asking for and the URL. Remote queries are slow and can hang; the user should never be left wondering what the build is blocked on.
  - And celebrate the cache:
    - each arm of the ref-comparison now emits a cachehit alert when the local copy already has what we want: tag already checked out, annotated tag peeled to the same commit, already at remote HEAD, commit already checked out.
    - OFFLINE_WORK now says so explicitly instead of falling through to a message claiming the remote had been checked -- it never was.
  - No functional change to what ends up checked out.
  - Assisted-By: Claude Opus 5 <noreply@anthropic.com>
- 🌳 git: resolve tags in a single ls-remote; stop punishing upstreams for annotated tags
  - Annotated tags were the worst-handled ref type in the framework, and they're exactly what mainline u-boot and ATF use. `BOARD=nanopct6-lts BRANCH=edge uboot` uses BOOTBRANCH="tag:v2026.07" and ATFBRANCH='tag:v2.13.0', both annotated, and made 7 round-trips to github on a cold cache, 4 on a warm one. At least 4 of those could never have returned anything useful.
  - Two independent spots were at fault:
    - memoized_git_ref_to_info() asked for 'refs/heads/X^{}' and 'refs/heads/X' before trying the tag. A tag is never in the branch namespace, so those are two guaranteed-dead round-trips (three for a lightweight tag, where 'X^{}' misses too). The refs/heads-first idea is right for the branch arm; it had been copy-pasted into the tag arm.
    - fetch_from_repo() asked for the plain tag and compared it to local_hash. For an annotated tag the plain ref is the *tag object*, while local_hash is a *commit*, so the comparison could never be true and the '^{}' peel query always ran. Two round-trips on every single build -- and the "tag already checked out" cachehit was unreachable for annotated tags, so an unchanged tag also re-fetched, every time.
  - git ls-remote accepts several patterns and answers them all in one connection, which is the whole fix. New git_ls_remote_tag_commit_sha1() asks for both 'X' and 'X^{}' at once and prefers the peeled line, so annotated and lightweight tags both resolve to a commit in exactly one round-trip. Both call sites use it. Note it does NOT pipe to 'cut -f1': with two patterns that would glue two sha1s together with a newline. It matches on the full refname instead, which also rejects the 'refs/tags/vendor/X' that ls-remote's tail-matching would otherwise let through.
  - Measured on that command: 7 -> 3 round-trips cold, 4 -> 2 warm, and both annotated tags now cachehit instead of re-fetching.
  - Two more things while in here:
    - fetched_revision is now peeled with ^{commit}. After fetching an annotated tag, FETCH_HEAD is the tag object's sha1, not the commit's. That was self-consistent only because annotated tags always took the fetch path; now that they can cachehit (checkout_from=HEAD, a commit), a cold and a warm build would otherwise report different revisions for an identical tree. The peeled value also matches what git-ref2info.sh resolves.
    - git-ref2info.sh's three copy-pasted ls-remote calls (they differed only in GITHUB_MIRROR=ghproxy url handling) collapse into git_remote_url_for_mirror() plus git_ls_remote_logged(), so its remote queries are announced like every other one. It was the last silent caller.
  - worth knowing: tag resolution in git-ref2info.sh no longer prefers a branch named like the tag. That is what fetch_from_repo has always done (it queries with --tags), so this removes an A-vs-B divergence: 'tag:X' could previously resolve to *branch* X for the artifact version hash while the build checked out *tag* X. If some source repo does carry a branch named identically to a tag we use, its artifact_version moves once.
  - Assisted-By: Claude Opus 5 <noreply@anthropic.com>
- 🌱 u-boot: get the initial bare git tree from a premade ORAS gitball
  - compile_kernel has pulled a premade git tree from ghcr.io for a while; u-boot has the identical worktree architecture but was still cold-cloning mainline on every empty cache.
  - The producer side (armbian/shallow) now publishes a single tree seeded with mainline u-boot -- 'master' plus all 533 tags, which is what makes the 'tag:vYYYY.MM' boards a cache hit -- and Radxa's next-dev* branches under 'radxa/*'. Measured: 387 MiB, one packfile. This pulls it.
  - There is no shallow/full decision for u-boot and so no interactive prompt; one complete tree serves every board. Every *other* u-boot fork Armbian builds (TI, SolidRun, NXP, Xilinx, hardkernel, orangepi-xunlong, CoreELEC, ...) keeps fetching into this same shared tree -- not seeded, but landing on top of mainline's history, so those fetches stay small.
  - The download/extract/marker logic moves to general/git-oras-tree.sh, taking explicit arguments rather than the five outer-scope variables that kept it kernel-only. kernel_prepare_bare_repo_from_oras_gitball becomes a wrapper (keeping its guards, which assert the decide-function ran) and download_git_kernel_gitball_via_oras is gone, single caller.
  - The helper adds one thing the Kernel version did not have: replacing a bare tree orphans every worktree registered against it, and fetch_from_repo then dies at git.sh:201, "Bare repo worktree gitdir not found". So the worktree directory's *contents* are purged alongside. Contents only -- these are Docker mountpoints and removing the directory itself is EBUSY in-container. This also fixes the same latent failure on the Kernel path.
  - `GIT_ORAS_TARBALLS_SHALLOW_BASE_REF` (kernel and u-boot alike) resolves the long-standing "@TODO allow changing this" on base_oras_ref. It selects a mirror, not content. Use if you need to work on the tarballs themselves or use a separate source.
  - Assisted-by: Claude Opus 5 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Kernel and U-Boot sources can now be prepared from cached OCI git artifacts, improving repeatability and offline build support.
  - Configurable mirrors are supported for prebuilt source artifacts and GitHub lookups.
  - Shared artifact handling automatically manages extraction, validation, completion markers, and cleanup.

- **Bug Fixes**
  - Improved Git reference resolution for branches, tags, commits, and heads.
  - Existing local commit objects can now avoid unnecessary fetching.
  - Added clearer handling for missing artifacts and invalid source trees.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->