### PR TITLE
rockchip64-7.2: Mixtile Blade 3: fix pwm-fan tacho & regulator; levels

### DIFF
--- a/patch/kernel/archive/rockchip64-7.2/dt/rk3588-mixtile-blade3.dts
+++ b/patch/kernel/archive/rockchip64-7.2/dt/rk3588-mixtile-blade3.dts
@@ -31,9 +31,11 @@
 	fan: pwm-fan {
 		compatible = "pwm-fan";
 		#cooling-cells = <2>;
-		cooling-levels = <0 50 100 150 200 255>;
-		pwms = <&pwm8 0 250000 0>; /* aka GPIO3_D0 / PWM8_M2 On 4-pin fan header */
-		fan-supply = <&vcc5v0_sys>;
+		cooling-levels = <0 35 70 100 125 150>; /* vendor values; capped at ~59% duty, tuned for Noctua noise */
+		pwms = <&pwm8 0 40000 0>; /* aka GPIO3_D0 / PWM8_M2 On 4-pin fan header; 40000 meant for Noctua  */
+		fan-supply = <&vcc5v0_fan>;
+		pinctrl-names = "default";
+		pinctrl-0 = <&fan_tach_pin>; /* for the pull-up on the tacho input */
 		pulses-per-revolution = <2>;
 		interrupt-parent = <&gpio3>;  /* GPIO GPIO3_B1/PWM2_M1 */
 		interrupts = <RK_PB1 IRQ_TYPE_EDGE_FALLING>; // On 4-pin fan header
@@ -47,6 +49,18 @@
 		regulator-boot-on;
 		regulator-min-microvolt = <12000000>;
 		regulator-max-microvolt = <12000000>;
+	};
+
+	vcc5v0_fan: regulator-vcc5v0-fan {
+		compatible = "regulator-fixed";
+		regulator-name = "vcc5v0_fan";
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+		enable-active-high;
+		gpio = <&gpio3 RK_PC0 GPIO_ACTIVE_HIGH>;
+		pinctrl-names = "default";
+		pinctrl-0 = <&fan_en_pin>;
+		vin-supply = <&vcc5v0_sys>;
 	};
 
 	vcc5v0_sys: vcc5v0-sys-regulator {
@@ -505,22 +519,72 @@
 	status = "okay";
 };
 
-/* Temperature sensor near the center of the SoC */
+/*
+ * Temperature sensor near the center of the SoC; drives the 4-pin fan header.
+ * Mirrors the vendor DT's rockchip,temp-trips ladder (30/45/50/55/60 degC ->
+ * cooling levels 1..5). Each map pins min == max so the governor jumps
+ * straight to that discrete level instead of ramping within a range, which
+ * reproduces the vendor's step behaviour.
+ */
 &package_thermal {
 	polling-delay = <1000>;
 
 	trips {
-		package_hot: package_hot {
+		package_fan0: package-fan0 {
 			hysteresis = <2000>;
-			temperature = <40000>; /* 40 celsius */
+			temperature = <30000>;
+			type = "active";
+		};
+
+		package_fan1: package-fan1 {
+			hysteresis = <2000>;
+			temperature = <45000>;
+			type = "active";
+		};
+
+		package_fan2: package-fan2 {
+			hysteresis = <2000>;
+			temperature = <50000>;
+			type = "active";
+		};
+
+		package_fan3: package-fan3 {
+			hysteresis = <2000>;
+			temperature = <55000>;
+			type = "active";
+		};
+
+		package_fan4: package-fan4 {
+			hysteresis = <2000>;
+			temperature = <60000>;
 			type = "active";
 		};
 	};
 
 	cooling-maps {
 		map0 {
-			cooling-device = <&fan THERMAL_NO_LIMIT THERMAL_NO_LIMIT>;
-			trip = <&package_hot>;
+			cooling-device = <&fan 1 1>;
+			trip = <&package_fan0>;
+		};
+
+		map1 {
+			cooling-device = <&fan 2 2>;
+			trip = <&package_fan1>;
+		};
+
+		map2 {
+			cooling-device = <&fan 3 3>;
+			trip = <&package_fan2>;
+		};
+
+		map3 {
+			cooling-device = <&fan 4 4>;
+			trip = <&package_fan3>;
+		};
+
+		map4 {
+			cooling-device = <&fan 5 THERMAL_NO_LIMIT>;
+			trip = <&package_fan4>;
 		};
 	};
 };
@@ -617,6 +681,16 @@
 };
 
 &pinctrl {
+	fan {
+		fan_tach_pin: fan-tach-pin {
+			rockchip,pins = <3 RK_PB1 RK_FUNC_GPIO &pcfg_pull_up>;
+		};
+
+		fan_en_pin: fan-en-pin {
+			rockchip,pins = <3 RK_PC0 RK_FUNC_GPIO &pcfg_pull_none>;
+		};
+	};
+
 	sdmmc {
 		sdmmc_pwr: sdmmc-pwr {
 			rockchip,pins = <0 RK_PB7 RK_FUNC_GPIO &pcfg_pull_up>;


### PR DESCRIPTION
- 🌱 adapt levels similar to vendor (never spins down, spins up to about half duty)
- 🍀 use fan-recommended frequency
- 🌿 introduce proper regulator vcc5v0_fan, drive it instead of vcc5v0_sys
- 🌵 pull the tacho pin up so RPM values are not garbage

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved fan control with multi-step temperature-based cooling levels.
  * Added dedicated fan power control and fan speed monitoring support.
  * Tuned PWM behavior for improved compatibility with Noctua fans.
* **Bug Fixes**
  * Replaced the single high-temperature fan trigger with graduated thresholds from 30°C to 60°C for more responsive cooling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->