### PR TITLE
menu: draw dialog borders with Unicode box characters

### DIFF
--- a/lib/functions/configuration/menu.sh
+++ b/lib/functions/configuration/menu.sh
@@ -34,10 +34,12 @@ function dialog_if_terminal_set_vars() {
 	set +o errtrace # do not trap errors inside a subshell/function
 	set +o errexit  # disable
 
-	exec 3>&1                              # open fd 3...
-	DIALOG_RESULT=$(dialog "$@" 2>&1 1>&3) # juggle fds and capture.
-	DIALOG_EXIT_CODE=$?                    # get the exit code.
-	exec 3>&-                              # close fd 3...
+	# Draw borders with Unicode box characters rather than the VT100 alternate charset:
+	# PuTTY and other emulators that report TERM=xterm but ignore that charset switch in UTF-8 mode show letters.
+	exec 3>&1                                                    # open fd 3...
+	DIALOG_RESULT=$(NCURSES_NO_UTF8_ACS=1 dialog "$@" 2>&1 1>&3) # juggle fds and capture.
+	DIALOG_EXIT_CODE=$?                                          # get the exit code.
+	exec 3>&-                                                    # close fd 3...
 
 	set -e          # back to normal
 	set -o errtrace # back to normal


### PR DESCRIPTION
# Description

dialog (ncurses) draws its borders via the VT100 alternate charset (`ESC(0` + letters). Terminals that report `TERM=xterm` but ignore that switch in UTF-8 mode show the borders as letters. `NCURSES_NO_UTF8_ACS=1` makes ncurses emit U+2500 box-drawing characters directly; outside UTF-8 locales ncurses ignores the variable.

Expected to fix: PuTTY with default settings (UTF-8 + TERM=xterm, "Enable VT100 line drawing even in UTF-8 mode" off), mosh, Chrome Secure Shell (hterm). Basis: their terminfo entries carry `U8#1` in ncurses terminfo.src.

Expected no change: xterm, GNOME Terminal and other VTE terminals, Konsole, kitty, Alacritty, WezTerm, foot, iTerm2, macOS Terminal.app, Windows Terminal, tmux, Linux console, GNU screen. All of them render both forms as lines; the Linux console and screen already got Unicode through their own terminfo. Non-UTF-8 locales: unchanged.

Same issue exists in armbian-config; separate PR to configng.

# How Has This Been Tested?

Armbian (ncurses 6.4), `./compile.sh` in docker: the "Choose a board" dialog goes from 10× `ESC(0` to 0, borders come out as U+2500..U+2518.

Before / after (PuTTY behaviour emulated by dropping `ESC(0`/`ESC(B` from the output stream):

| before | after |
|---|---|
| ![before](https://github.com/user-attachments/assets/5e3d74ad-1518-4ca7-97d0-9361e236b105) | ![after](https://github.com/user-attachments/assets/c0e1a480-f231-4c39-b6fe-8d5d6134754a) |

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved terminal dialog border rendering in UTF-8 environments, including emulators that previously displayed borders incorrectly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->