### PR TITLE
mainline: bump to 7.3-rc2

### DIFF
--- a/config/sources/mainline-kernel.conf.sh
+++ b/config/sources/mainline-kernel.conf.sh
@@ -8,7 +8,7 @@
 function mainline_kernel_decide_version__upstream_release_candidate_number() {
 	[[ -n "${KERNELBRANCH}" ]] && return 0          # if already set, don't touch it; that way other hooks can run in any order
 	if [[ "${KERNEL_MAJOR_MINOR}" == "7.3" ]]; then # @TODO: roll over to next MAJOR.MINOR and MAJOR.MINOR-rc1 when it is released
-		declare -g KERNELBRANCH="tag:v7.3-rc1"
+		declare -g KERNELBRANCH="tag:v7.3-rc2"
 		display_alert "mainline-kernel: upstream release candidate" "Using KERNELBRANCH='${KERNELBRANCH}' for KERNEL_MAJOR_MINOR='${KERNEL_MAJOR_MINOR}'" "info"
 	fi
 }
@@ -27,10 +27,10 @@ function mainline_kernel_decide_version__upstream_release_candidate_number() {
 # Example: 6.7-rc7 was released by Linus, but kernel.org git and google git mirrors took a while to catch up; change the source to pull directly from Linus.
 # This was necessary for a few days in late December 2023, but no longer; tag was pushed on 28/Dec/2023.
 function mainline_kernel_decide_version__750_use_torvalds_for_rc_kernel() {
-	if [[ "${KERNELBRANCH}" == 'tag:v7.3-rc1' ]]; then
-		display_alert "Using Linus kernel repo for 7.3-rc1" "${KERNELBRANCH}" "warn"
+	if [[ "${KERNELBRANCH}" == 'tag:v7.3-rc2' ]]; then
+		display_alert "Using Linus kernel repo for 7.3-rc2" "${KERNELBRANCH}" "warn"
 		declare -g KERNELSOURCE="https://github.com/torvalds/linux.git"
-		display_alert "mainline-kernel: missing torvalds tag on 7.3-rc1" "Using KERNELSOURCE='${KERNELSOURCE}' for KERNELBRANCH='${KERNELBRANCH}'" "info"
+		display_alert "mainline-kernel: missing torvalds tag on 7.3-rc2" "Using KERNELSOURCE='${KERNELSOURCE}' for KERNELBRANCH='${KERNELBRANCH}'" "info"
 	fi
 }
 

--- a/lib/functions/compilation/patch/drivers_network.sh
+++ b/lib/functions/compilation/patch/drivers_network.sh
@@ -82,7 +82,9 @@ driver_rtl8189ES() {
 
 		# cfg80211 set_monitor_channel gained a net_device arg (6.13 mainline; backported to 6.12.101)
 		process_patch_file "${SRC}/patch/misc/wireless-rtl8189es-set-monitor-channel-6.12.101.patch" "applying"
-
+		display_alert "Done adding" "Wireless drivers for Realtek 8189ES chipsets ${rtl8189esver}" "info"
+	else
+		display_alert "Skipping" "Wireless drivers for Realtek 8189ES chipsets" "info"
 	fi
 }
 
@@ -124,7 +126,9 @@ driver_rtl8189FS() {
 
 		# cfg80211 set_monitor_channel gained a net_device arg (6.13 mainline; backported to 6.12.101)
 		process_patch_file "${SRC}/patch/misc/wireless-rtl8189fs-set-monitor-channel-6.12.101.patch" "applying"
-
+		display_alert "Done adding" "Wireless drivers for Realtek 8189FS chipsets ${rtl8189fsver}" "info"
+	else
+		display_alert "Skipping" "Wireless drivers for Realtek 8189FS chipsets" "info"
 	fi
 }
 
@@ -162,7 +166,9 @@ driver_rtl8192EU() {
 
 		# cfg80211 set_monitor_channel gained a net_device arg (6.13 mainline; backported to 6.12.101)
 		process_patch_file "${SRC}/patch/misc/wireless-rtl8192eu-set-monitor-channel-6.12.101.patch" "applying"
-
+		display_alert "Done adding" "Wireless drivers for Realtek 8192EU chipsets ${rtl8192euver}" "info"
+	else
+		display_alert "Skipping" "Wireless drivers for Realtek 8192EU chipsets" "info"
 	fi
 }
 
@@ -212,6 +218,9 @@ driver_rtl8811_rtl8812_rtl8814_rtl8821() {
 		# fix compilation for kernels >= 6.16
 		process_patch_file "${SRC}/patch/misc/wireless-rtl8812au-Fix-6.16.patch" "applying"
 		process_patch_file "${SRC}/patch/misc/wireless-rtl8812au-set-monitor-channel-6.12.101.patch" "applying"
+		display_alert "Done adding" "Wireless drivers for Realtek 8811, 8812, 8814 and 8821 chipsets ${rtl8812auver}" "info"
+	else
+		display_alert "Skipping" "Wireless drivers for Realtek 8811, 8812, 8814 and 8821 chipsets" "info"
 	fi
 }
 
@@ -257,6 +266,9 @@ driver_rtl8812EU_rtl8822EU() {
 		echo "obj-\$(CONFIG_RTL8822EU) += rtl8822eu/" >> "$kerneldir/drivers/net/wireless/Makefile"
 		sed -i '/source "drivers\/net\/wireless\/ti\/Kconfig"/a source "drivers\/net\/wireless\/rtl8822eu\/Kconfig"' \
 			"$kerneldir/drivers/net/wireless/Kconfig"
+		display_alert "Done adding" "Wireless drivers for Realtek 8812EU and 8822EU chipsets ${rtl8822euver}" "info"
+	else
+		display_alert "Skipping" "Wireless drivers for Realtek 8812EU and 8822EU chipsets" "info"
 	fi
 }
 
@@ -269,7 +281,7 @@ driver_xradio_xr819() {
 		# Attach to specific commit (is branch:master)
 		local xradio_xr819_ver="commit:3ce657ae533e2213f6fda2297da1598fa11d7a03" # Commit date: Sep 1, 2026 (please update when updating commit ref)
 
-		display_alert "Adding" "Wireless drivers for Xradio XR819 chipsets" "info"
+		display_alert "Adding" "Wireless drivers for Xradio XR819 ${xradio_xr819_ver}" "info"
 
 		fetch_from_repo "$GITHUB_SOURCE/fifteenhex/xradio" "xradio" "${xradio_xr819_ver}" "yes"
 		cd "$kerneldir" || exit
@@ -294,6 +306,9 @@ driver_xradio_xr819() {
 			"$kerneldir/drivers/net/wireless/Kconfig"
 
 		process_patch_file "${SRC}/patch/misc/xradio-Switching-from-del_timer_sync-to-timer_delete_sync.patch" "applying"
+		display_alert "Done adding" "Wireless drivers for Xradio XR819 ${xradio_xr819_ver}" "info"
+	else
+		display_alert "Skipping" "Wireless drivers for Xradio XR819 ${xradio_xr819_ver}" "info"
 	fi
 }
 
@@ -339,6 +354,9 @@ driver_rtl8811CU_rtl8821C() {
 		# fix compilation for kernels >= 6.16
 		process_patch_file "${SRC}/patch/misc/wireless-rtl8811cu-Fix-6.16.patch" "applying"
 		process_patch_file "${SRC}/patch/misc/wireless-rtl8811cu-set-monitor-channel-6.12.101.patch" "applying"
+		display_alert "Done adding" "Wireless drivers for Realtek RTL8811CU and RTL8821C chipsets ${rtl8811cuver}" "info"
+	else
+		display_alert "Skipping" "Wireless drivers for Realtek RTL8811CU and RTL8821C chipsets" "info"
 	fi
 }
 
@@ -382,7 +400,9 @@ driver_rtl88x2bu() {
 		# fix compilation for kernels >= 6.16
 		process_patch_file "${SRC}/patch/misc/wireless-rtl88x2bu-Fix-6.16.patch" "applying"
 		process_patch_file "${SRC}/patch/misc/wireless-rtl88x2bu-set-monitor-channel-6.12.101.patch" "applying"
-
+		display_alert "Done adding" "Wireless drivers for Realtek 88x2bu chipsets ${rtl88x2buver}" "info"
+	else
+		display_alert "Skipping" "Wireless drivers for Realtek 88x2bu chipsets" "info"
 	fi
 }
 
@@ -397,6 +417,7 @@ driver_rtw88() {
 			process_patch_file "${SRC}/patch/misc/rtw88/${version}/001-drivers-net-wireless-realtek-rtw88-upstream-wireless.patch" "applying"
 			process_patch_file "${SRC}/patch/misc/rtw88/hack/003-rtw88-decrease-the-log-level-of-tx-report.patch" "applying"
 		fi
+		display_alert "Added" "Upstream wireless RTW88 drivers" "info"
 	fi
 
 	if linux-version compare "${version}" eq 6.1; then
@@ -454,6 +475,9 @@ driver_rtl8852bs() {
 				sed -i "s/CONFIG_PLATFORM_SPACEMIT = n/CONFIG_PLATFORM_SPACEMIT = y/g" "$kerneldir/drivers/net/wireless/realtek/rtl8852bs/Makefile"
 				;;
 		esac
+		display_alert "Done adding" "Wireless drivers for Realtek 8852BS SDIO chipset ${rtl8852bs_ver}" "info"
+	else
+		display_alert "Skipping" "Wireless drivers for Realtek 8852BS SDIO chipset" "info"
 	fi
 }
 
@@ -501,6 +525,9 @@ driver_rtl88x2cs() {
 
 		# fix compilation for kernels >= 5.4
 		process_patch_file "${SRC}/patch/misc/wireless-rtl88x2cs-Fix-VFS-import.patch" "applying"
+		display_alert "Done adding" "Wireless drivers for Realtek 88x2cs chipsets ${rtl88x2csver}" "info"
+	else
+		display_alert "Skipping" "Wireless drivers for Realtek 88x2cs chipsets" "info"
 	fi
 }
 
@@ -513,7 +540,7 @@ driver_uwe5622() {
 		# Attach to specific commit
 		local uwe5622ver='commit:b64c5d6c36015049bdc34aad5f7b307545bfa29c' # Commit date: Sep 1, 2026 (please update when updating commit ref)
 
-		display_alert "Adding" "Unisoc uwe5622 driver ${uwe5622ver}" "info"
+		display_alert "Adding" "Wireless drivers for Unisoc uwe5622 driver ${uwe5622ver}" "info"
 
 		fetch_from_repo "$GITHUB_SOURCE/armbian/uwe5622" "uwe5622" "${uwe5622ver}" "yes" # https://github.com/armbian/uwe5622
 		cd "$kerneldir" || exit
@@ -532,7 +559,9 @@ driver_uwe5622() {
 		sed -i '/source "drivers\/net\/wireless\/ti\/Kconfig"/a source "drivers\/net\/wireless\/uwe5622\/Kconfig"' \
 			"$kerneldir/drivers/net/wireless/Kconfig"
 
-		display_alert "Added" "uwe5622 driver with inline kernel version guards (5.15-7.1)" "info"
+		display_alert "Done adding" "Wireless drivers for Unisoc uwe5622 driver ${uwe5622ver}" "info"
+	else
+		display_alert "Skipping" "Wireless drivers for Unisoc uwe5622 driver" "info"
 	fi
 }
 
@@ -551,7 +580,6 @@ driver_rtl8723cs() {
 	# these few patches address some issues to let the rtl8723cs/rtl8703b chipsets to be used within the serdev framework
 	# Available only with kernels >= 6.1, because bt driver does not exist in older kernels
 	if linux-version compare "${version}" ge 6.1; then
-
 		if linux-version compare "${version}" ge 6.2 && linux-version compare "${version}" lt 6.3; then # landed in 6.1.30/6.3.4 # keep for 6.2
 			process_patch_file "${SRC}/patch/misc/bluetooth-rtl8723cs/bluetooth-btrtl-quirk-local-ext-features.patch" "applying"
 			process_patch_file "${SRC}/patch/misc/bluetooth-rtl8723cs/Bluetooth-btrtl-add-support-for-the-RTL8723CS.patch" "applying"
@@ -636,7 +664,6 @@ driver_rtl8723cs() {
 	if linux-version compare "${version}" ge 6.14; then
 		process_patch_file "${SRC}/patch/misc/wireless-rtl8723cs/8723cs-Port-to-6.14.patch" "applying"
 	fi
-
 }
 
 ###  The vendor's RTL8723DS driver is still required for RockPI-S support because
@@ -682,6 +709,9 @@ driver_rtl8723DS() {
 
 		# fix compilation for kernels >= 5.4
 		process_patch_file "${SRC}/patch/misc/wireless-rtl8723ds-Fix-VFS-import.patch" "applying"
+		display_alert "Done adding" "Wireless drivers for Realtek 8723DS chipsets ${rtl8723dsver}" "info"
+	else
+		display_alert "Skipping" "Wireless drivers for Realtek 8723DS chipsets" "info"
 	fi
 }
 


### PR DESCRIPTION
# Description

- bump `bleedingedge` to v7.3-rc2
- a bit out of scope but anyway
- - add some additional verbosity for out-of-tree wifi drivers if skipped or applied

# How Has This Been Tested?

- [x] build rockchip64-7.3
- [x] build meson64-7.3
- [x] build uefi-arm64-7.3
- [x] build uefi-x86-7.3

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * Updated the pinned upstream kernel release candidate to v7.3-rc2.
  * Updated emergency kernel-source routing and related alerts for the new release.

* **Bug Fixes**
  * Added clearer completion and skip-status notifications during Realtek, Xradio, and Unisoc wireless-driver setup.
  * Added a completion notification for RTW88 driver setup.
  * Improved Xradio and Unisoc driver progress messages with driver and version information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->