### PR TITLE
firstlogin: prefer the GNOME Flashback xmonad session when it can start

### DIFF
--- a/packages/bsp/common/usr/lib/armbian/armbian-firstlogin
+++ b/packages/bsp/common/usr/lib/armbian/armbian-firstlogin
@@ -1093,9 +1093,21 @@ if [[ -f /root/.not_logged_in_yet ]] && tty -s; then
 		[[ -x $(command -v sway) ]] && sed -i "s/user-session.*/user-session=sway/" /etc/lightdm/lightdm.conf.d/11-armbian.conf
 		[[ -x $(command -v sway) ]] && sed -i "s/user-session.*/user-session=sway/" /etc/lightdm/lightdm.conf.d/22-armbian-autologin.conf
 
-		# select xmonad session
-		[[ -x $(command -v xmonad) ]] && sed -i "s/user-session.*/user-session=xmonad/" /etc/lightdm/lightdm.conf.d/11-armbian.conf
-		[[ -x $(command -v xmonad) ]] && sed -i "s/user-session.*/user-session=xmonad/" /etc/lightdm/lightdm.conf.d/22-armbian-autologin.conf
+		# select xmonad session. The xmonad package ships two of them:
+		# xmonad.desktop runs the window manager bare, while
+		# gnome-flashback-xmonad.desktop runs it inside a GNOME Flashback
+		# session and so gets a session dbus, a polkit agent and session
+		# management. Prefer the latter when it can actually start -- its
+		# TryExec is gnome-flashback, which comes from gnome-session-flashback
+		# and is not always installed -- and fall back to the bare session.
+		if [[ -x $(command -v xmonad) ]]; then
+			xmonad_session="xmonad"
+			if [[ -f /usr/share/xsessions/gnome-flashback-xmonad.desktop && -x $(command -v gnome-flashback) ]]; then
+				xmonad_session="gnome-flashback-xmonad"
+			fi
+			sed -i "s/user-session.*/user-session=${xmonad_session}/" /etc/lightdm/lightdm.conf.d/11-armbian.conf
+			sed -i "s/user-session.*/user-session=${xmonad_session}/" /etc/lightdm/lightdm.conf.d/22-armbian-autologin.conf
+		fi
 
 		ln -sf /lib/systemd/system/lightdm.service /etc/systemd/system/display-manager.service
 


### PR DESCRIPTION
Companion to [configng#1019](https://github.com/armbian/configng/pull/1019), which installs `gnome-session-flashback` for xmonad. Without this, autologin keeps selecting the bare session and that change has no effect at first login.

## Why

The **xmonad package itself** ships two sessions — confirmed from the `.deb`:

```
/usr/share/xsessions/xmonad.desktop                  Exec=xmonad-session
/usr/share/xsessions/gnome-flashback-xmonad.desktop  Exec=gnome-flashback-xmonad
                                                     TryExec=gnome-flashback
```

Only the flashback one gets a session dbus, a polkit agent and session management. `armbian-firstlogin` hardcoded the bare one:

```bash
[[ -x $(command -v xmonad) ]] && sed -i "s/user-session.*/user-session=xmonad/" ...
```

so the better session was never selected, even where it was usable.

## What

Prefer `gnome-flashback-xmonad` when it can actually start, otherwise keep today's behaviour exactly.

Its `TryExec` is `gnome-flashback`, which comes from `gnome-session-flashback` and is **not** on every image, so both the `.desktop` and the binary are checked — selecting a session whose `TryExec` fails would leave the user at the greeter.

| `gnome-flashback-xmonad.desktop` | `gnome-flashback` binary | `user-session=` |
|---|---|---|
| present | present | `gnome-flashback-xmonad` |
| present | **missing** | `xmonad` |
| missing | present | `xmonad` |
| missing | missing | `xmonad` |

Verified by exercising the block against a stubbed `PATH` and `xsessions` directory for all four combinations.

**Existing images are unaffected** — without `gnome-session-flashback` installed the second column is always missing, so the result is `xmonad`, identical to today.

`bash -n` clean; `shellcheck -s bash -S warning` reports nothing new for this block (the file's one pre-existing SC2207 at line 339 is untouched).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automatic session selection for xmonad environments.
  * Prefers the GNOME Flashback xmonad session when available, with fallback to the standard xmonad session.
  * Prevents xmonad session configuration when xmonad is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->