### PR TITLE
fix sunxi edge build and patch maint

### DIFF
--- a/patch/kernel/archive/rockchip64-6.18/board-firefly-rk3399-dts.patch
+++ b/patch/kernel/archive/rockchip64-6.18/board-firefly-rk3399-dts.patch
@@ -29,7 +29,7 @@ Subject: [ARCHEOLOGY] firefly-rk3399: move to rockchip64 family
 > X-Git-Archeology:   Subject: rockchip64: bump edge kernel to 6.10
 > X-Git-Archeology:
 ---
- arch/arm64/boot/dts/rockchip/rk3399-firefly.dts | 133 +++++++---
+ arch/arm64/boot/dts/rockchip/rk3399-firefly.dts | 111 ++++++++--
  1 file changed, 91 insertions(+), 20 deletions(-)
 
 diff --git a/arch/arm64/boot/dts/rockchip/rk3399-firefly.dts b/arch/arm64/boot/dts/rockchip/rk3399-firefly.dts
@@ -261,3 +261,6 @@ index 111111111111..222222222222 100644
  };
  
  &uart2 {
+-- 
+Armbian
+

--- a/patch/kernel/archive/rockchip64-6.18/general-cryptov1-trng.patch
+++ b/patch/kernel/archive/rockchip64-6.18/general-cryptov1-trng.patch
@@ -18,7 +18,7 @@ diff --git a/drivers/crypto/Kconfig b/drivers/crypto/Kconfig
 index 111111111111..222222222222 100644
 --- a/drivers/crypto/Kconfig
 +++ b/drivers/crypto/Kconfig
-@@ -707,6 +707,14 @@ config CRYPTO_DEV_ROCKCHIP
+@@ -706,6 +706,14 @@ config CRYPTO_DEV_ROCKCHIP
  	  This driver interfaces with the hardware crypto accelerator.
  	  Supporting cbc/ecb chainmode, and aes/des/des3_ede cipher mode.
  

--- a/patch/kernel/archive/rockchip64-6.18/rk3588-1211-arm64-dts-rk3588s-roc-pc-Enable-HDMI-audio.patch
+++ b/patch/kernel/archive/rockchip64-6.18/rk3588-1211-arm64-dts-rk3588s-roc-pc-Enable-HDMI-audio.patch
@@ -12,7 +12,7 @@ diff --git a/arch/arm64/boot/dts/rockchip/rk3588s-roc-pc.dts b/arch/arm64/boot/d
 index 111111111111..222222222222 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3588s-roc-pc.dts
 +++ b/arch/arm64/boot/dts/rockchip/rk3588s-roc-pc.dts
-@@ -243,6 +243,10 @@ &hdptxphy0 {
+@@ -252,6 +252,10 @@ &hdptxphy0 {
  	status = "okay";
  };
  
@@ -23,7 +23,7 @@ index 111111111111..222222222222 100644
  &i2c0 {
  	pinctrl-names = "default";
  	pinctrl-0 = <&i2c0m2_xfer>;
-@@ -344,6 +348,10 @@ &i2s0_sdi0
+@@ -353,6 +357,10 @@ &i2s0_sdi0
  	status = "okay";
  };
  

--- a/patch/kernel/archive/rockchip64-6.18/rk3588-1212-arm64-dts-Automatic-fan-speed-and-USB-3.0-Type-A-por.patch
+++ b/patch/kernel/archive/rockchip64-6.18/rk3588-1212-arm64-dts-Automatic-fan-speed-and-USB-3.0-Type-A-por.patch
@@ -12,7 +12,7 @@ diff --git a/arch/arm64/boot/dts/rockchip/rk3588s-roc-pc.dts b/arch/arm64/boot/d
 index 111111111111..222222222222 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3588s-roc-pc.dts
 +++ b/arch/arm64/boot/dts/rockchip/rk3588s-roc-pc.dts
-@@ -364,7 +364,35 @@ rgmii_phy1: ethernet-phy@1 {
+@@ -373,7 +373,35 @@ rgmii_phy1: ethernet-phy@1 {
  	};
  };
  
@@ -49,7 +49,7 @@ index 111111111111..222222222222 100644
  	reset-gpios = <&gpio3 RK_PD1 GPIO_ACTIVE_HIGH>;
  	vpcie3v3-supply = <&vcc3v3_pcie20>;
  	status = "okay";
-@@ -832,6 +860,11 @@ &usb_host1_ohci {
+@@ -841,6 +869,11 @@ &usb_host1_ohci {
  	status = "okay";
  };
  

--- a/patch/kernel/archive/rockchip64-6.18/rk3588-1213-arm64-dts-rk3588s-roc-pc-Enable-USB-type-C-port.patch
+++ b/patch/kernel/archive/rockchip64-6.18/rk3588-1213-arm64-dts-rk3588s-roc-pc-Enable-USB-type-C-port.patch
@@ -12,7 +12,7 @@ diff --git a/arch/arm64/boot/dts/rockchip/rk3588s-roc-pc.dts b/arch/arm64/boot/d
 index 111111111111..222222222222 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3588s-roc-pc.dts
 +++ b/arch/arm64/boot/dts/rockchip/rk3588s-roc-pc.dts
-@@ -319,6 +319,57 @@ hym8563: rtc@51 {
+@@ -328,6 +328,57 @@ hym8563: rtc@51 {
  		pinctrl-names = "default";
  		pinctrl-0 = <&hym8563_int>;
  	};
@@ -70,7 +70,7 @@ index 111111111111..222222222222 100644
  };
  
  &i2c3 {
-@@ -434,6 +485,16 @@ typec5v_pwren: typec5v-pwren {
+@@ -443,6 +494,16 @@ typec5v_pwren: typec5v-pwren {
  			rockchip,pins = <1 RK_PB1 RK_FUNC_GPIO &pcfg_pull_none>;
  		};
  
@@ -87,7 +87,7 @@ index 111111111111..222222222222 100644
  		vcc5v0_host_en: vcc5v0-host-en {
  			rockchip,pins = <1 RK_PB6 RK_FUNC_GPIO &pcfg_pull_none>;
  		};
-@@ -848,8 +909,17 @@ &usb_host0_ohci {
+@@ -857,8 +918,17 @@ &usb_host0_ohci {
  };
  
  &usb_host0_xhci {
@@ -106,7 +106,7 @@ index 111111111111..222222222222 100644
  };
  
  &usb_host1_ehci {
-@@ -865,6 +935,32 @@ &usb_host2_xhci {
+@@ -874,6 +944,32 @@ &usb_host2_xhci {
  	dr_mode = "host";
  };
  

--- a/patch/kernel/archive/rockchip64-6.18/rk35xx-montjoie-crypto-v2-rk35xx.patch
+++ b/patch/kernel/archive/rockchip64-6.18/rk35xx-montjoie-crypto-v2-rk35xx.patch
@@ -345,7 +345,7 @@ diff --git a/drivers/crypto/Kconfig b/drivers/crypto/Kconfig
 index 111111111111..222222222222 100644
 --- a/drivers/crypto/Kconfig
 +++ b/drivers/crypto/Kconfig
-@@ -744,6 +744,35 @@ config CRYPTO_DEV_XILINX_TRNG
+@@ -743,6 +743,35 @@ config CRYPTO_DEV_XILINX_TRNG
  	  To compile this driver as a module, choose M here: the module
  	  will be called xilinx-trng.
  

--- a/patch/kernel/archive/rockchip64-7.2/board-firefly-rk3399-dts.patch
+++ b/patch/kernel/archive/rockchip64-7.2/board-firefly-rk3399-dts.patch
@@ -29,7 +29,7 @@ Subject: [ARCHEOLOGY] firefly-rk3399: move to rockchip64 family
 > X-Git-Archeology:   Subject: rockchip64: bump edge kernel to 6.10
 > X-Git-Archeology:
 ---
- arch/arm64/boot/dts/rockchip/rk3399-firefly.dts | 133 +++++++---
+ arch/arm64/boot/dts/rockchip/rk3399-firefly.dts | 111 ++++++++--
  1 file changed, 91 insertions(+), 20 deletions(-)
 
 diff --git a/arch/arm64/boot/dts/rockchip/rk3399-firefly.dts b/arch/arm64/boot/dts/rockchip/rk3399-firefly.dts
@@ -261,3 +261,6 @@ index 111111111111..222222222222 100644
  };
  
  &uart2 {
+-- 
+Armbian
+

--- a/patch/kernel/archive/rockchip64-7.2/board-orangepi-5-es8388-route-mclk-to-io.patch
+++ b/patch/kernel/archive/rockchip64-7.2/board-orangepi-5-es8388-route-mclk-to-io.patch
@@ -1,8 +1,8 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: defcom5-rockchip <defcom5rockchip@proton.me>
 Date: Fri, 21 Aug 2026 21:43:53 -0700
-Subject: [PATCH] arm64: dts: rockchip: rk3588s-orangepi-5: route ES8388 MCLK
- to the IO pin
+Subject: arm64: dts: rockchip: rk3588s-orangepi-5: route ES8388 MCLK to the IO
+ pin
 
 Analog audio through the on-board ES8388 codec is silent on the Orange Pi 5
 and 5B: the codec's master clock (MCLK) never reaches its pin.
@@ -38,10 +38,10 @@ Signed-off-by: defcom5-rockchip <defcom5rockchip@proton.me>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/arch/arm64/boot/dts/rockchip/rk3588s-orangepi-5.dtsi b/arch/arm64/boot/dts/rockchip/rk3588s-orangepi-5.dtsi
-index 1111111111111..2222222222222 100644
+index 111111111111..222222222222 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3588s-orangepi-5.dtsi
 +++ b/arch/arm64/boot/dts/rockchip/rk3588s-orangepi-5.dtsi
-@@ -273,7 +273,7 @@
+@@ -277,7 +277,7 @@ &i2c6 {
  	es8388: audio-codec@10 {
  		compatible = "everest,es8388", "everest,es8328";
  		reg = <0x10>;
@@ -52,3 +52,4 @@ index 1111111111111..2222222222222 100644
  		HPVDD-supply = <&vcc_3v3_s0>;
 -- 
 Armbian
+

--- a/patch/kernel/archive/rockchip64-7.2/general-can-1-skb-make-echo-skb-freeing-safe-in-any-IRQ-contex.patch
+++ b/patch/kernel/archive/rockchip64-7.2/general-can-1-skb-make-echo-skb-freeing-safe-in-any-IRQ-contex.patch
@@ -1,7 +1,7 @@
-From 22bc38b1ea127f19276e188f6dbcd15ff774b583 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Cunhao Lu <1579567540@qq.com>
 Date: Fri, 31 Jul 2026 17:14:24 +0800
-Subject: [PATCH 1/3] can: skb: make echo skb freeing safe in any IRQ context
+Subject: can: skb: make echo skb freeing safe in any IRQ context
 
 can_put_echo_skb() can be called with hardware interrupts disabled. Its
 direct drop paths use kfree_skb(), while can_create_echo_skb() uses
@@ -23,7 +23,7 @@ Changes in v3:
  2 files changed, 4 insertions(+), 4 deletions(-)
 
 diff --git a/drivers/net/can/dev/skb.c b/drivers/net/can/dev/skb.c
-index 95fcdc1026f8..d7b5a5d17ff2 100644
+index 111111111111..222222222222 100644
 --- a/drivers/net/can/dev/skb.c
 +++ b/drivers/net/can/dev/skb.c
 @@ -62,7 +62,7 @@ int can_put_echo_skb(struct sk_buff *skb, struct net_device *dev,
@@ -45,7 +45,7 @@ index 95fcdc1026f8..d7b5a5d17ff2 100644
  	}
  
 diff --git a/include/linux/can/skb.h b/include/linux/can/skb.h
-index a70a02967071..78c5870e2f9a 100644
+index 111111111111..222222222222 100644
 --- a/include/linux/can/skb.h
 +++ b/include/linux/can/skb.h
 @@ -76,12 +76,12 @@ static inline struct sk_buff *can_create_echo_skb(struct sk_buff *skb)
@@ -64,5 +64,5 @@ index a70a02967071..78c5870e2f9a 100644
  }
  
 -- 
-2.34.1
+Armbian
 

--- a/patch/kernel/archive/rockchip64-7.2/general-can-2-skb-make-CAN-skb-allocation-failure-paths-IRQ-sa.patch
+++ b/patch/kernel/archive/rockchip64-7.2/general-can-2-skb-make-CAN-skb-allocation-failure-paths-IRQ-sa.patch
@@ -1,7 +1,7 @@
-From 56aae92b2a29364793e98d06e64b9eda731706b6 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Cunhao Lu <1579567540@qq.com>
 Date: Fri, 31 Jul 2026 17:14:38 +0800
-Subject: [PATCH 2/3] can: skb: make CAN skb allocation failure paths IRQ-safe
+Subject: can: skb: make CAN skb allocation failure paths IRQ-safe
 
 The CAN skb allocation helpers are used from hardware interrupt receive
 handlers. If can_skb_ext_add() fails, they release the newly allocated skb
@@ -18,7 +18,7 @@ Signed-off-by: Cunhao Lu <1579567540@qq.com>
  1 file changed, 3 insertions(+), 3 deletions(-)
 
 diff --git a/drivers/net/can/dev/skb.c b/drivers/net/can/dev/skb.c
-index d7b5a5d17ff2..d34d3e7d4c9f 100644
+index 111111111111..222222222222 100644
 --- a/drivers/net/can/dev/skb.c
 +++ b/drivers/net/can/dev/skb.c
 @@ -223,7 +223,7 @@ struct sk_buff *alloc_can_skb(struct net_device *dev, struct can_frame **cf)
@@ -49,5 +49,5 @@ index d7b5a5d17ff2..d34d3e7d4c9f 100644
  	}
  
 -- 
-2.34.1
+Armbian
 

--- a/patch/kernel/archive/rockchip64-7.2/general-can-3-dev-can_put_echo_skb-free-skb-on-invalid-echo-in.patch
+++ b/patch/kernel/archive/rockchip64-7.2/general-can-3-dev-can_put_echo_skb-free-skb-on-invalid-echo-in.patch
@@ -1,8 +1,7 @@
-From fefeeb8d95a0dedf8050612c04771ee37ea20dc4 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Cunhao Lu <1579567540@qq.com>
 Date: Fri, 31 Jul 2026 17:14:56 +0800
-Subject: [PATCH 3/3] can: dev: can_put_echo_skb(): free skb on invalid echo
- index
+Subject: can: dev: can_put_echo_skb(): free skb on invalid echo index
 
 can_put_echo_skb() consumes the skb on all paths except when the echo
 index is out of bounds. This leaves ownership with the caller on -EINVAL,
@@ -24,7 +23,7 @@ Changes in v2:
  1 file changed, 1 insertion(+)
 
 diff --git a/drivers/net/can/dev/skb.c b/drivers/net/can/dev/skb.c
-index d34d3e7d4c9f..e985616c062c 100644
+index 111111111111..222222222222 100644
 --- a/drivers/net/can/dev/skb.c
 +++ b/drivers/net/can/dev/skb.c
 @@ -54,6 +54,7 @@ int can_put_echo_skb(struct sk_buff *skb, struct net_device *dev,
@@ -36,5 +35,5 @@ index d34d3e7d4c9f..e985616c062c 100644
  	}
  
 -- 
-2.34.1
+Armbian
 

--- a/patch/kernel/archive/rockchip64-7.2/general-can-4-rockchip_canfd-prevent-TX-stall-on-echo-skb-fail.patch
+++ b/patch/kernel/archive/rockchip64-7.2/general-can-4-rockchip_canfd-prevent-TX-stall-on-echo-skb-fail.patch
@@ -1,7 +1,7 @@
-From 08956ae250aabf15d728a7502ff86986f540be55 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Cunhao Lu <1579567540@qq.com>
 Date: Thu, 30 Jul 2026 23:16:17 +0800
-Subject: [PATCH 1/3] can: rockchip_canfd: prevent TX stall on echo skb failure
+Subject: can: rockchip_canfd: prevent TX stall on echo skb failure
 
 rkcanfd_start_xmit() advances tx_head and requests transmission even when
 can_put_echo_skb() fails. This creates a pending TX entry without the echo
@@ -22,11 +22,11 @@ Fixes: b6661d73290c ("can: rockchip_canfd: add TX PATH")
 Cc: stable@vger.kernel.org
 Signed-off-by: Cunhao Lu <1579567540@qq.com>
 ---
- drivers/net/can/rockchip/rockchip_canfd-tx.c | 17 +++++++++++------
+ drivers/net/can/rockchip/rockchip_canfd-tx.c | 17 ++++++----
  1 file changed, 11 insertions(+), 6 deletions(-)
 
 diff --git a/drivers/net/can/rockchip/rockchip_canfd-tx.c b/drivers/net/can/rockchip/rockchip_canfd-tx.c
-index 12200dcfd338..86fa8f2e1c8b 100644
+index 111111111111..222222222222 100644
 --- a/drivers/net/can/rockchip/rockchip_canfd-tx.c
 +++ b/drivers/net/can/rockchip/rockchip_canfd-tx.c
 @@ -88,7 +88,16 @@ netdev_tx_t rkcanfd_start_xmit(struct sk_buff *skb, struct net_device *ndev)
@@ -68,5 +68,5 @@ index 12200dcfd338..86fa8f2e1c8b 100644
  	WRITE_ONCE(priv->tx_head, priv->tx_head + 1);
  
 -- 
-2.34.1
+Armbian
 

--- a/patch/kernel/archive/rockchip64-7.2/general-can-5-rockchip_canfd-retry-the-outstanding-TX-buffer.patch
+++ b/patch/kernel/archive/rockchip64-7.2/general-can-5-rockchip_canfd-retry-the-outstanding-TX-buffer.patch
@@ -1,7 +1,7 @@
-From 20fc9c7818d49faa1d6587ac2da6cfdb1f4b94b3 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Cunhao Lu <1579567540@qq.com>
 Date: Fri, 31 Jul 2026 17:16:27 +0800
-Subject: [PATCH 2/3] can: rockchip_canfd: retry the outstanding TX buffer
+Subject: can: rockchip_canfd: retry the outstanding TX buffer
 
 rkcanfd_xmit_retry() originally operated with a TX FIFO depth of one. At
 that depth, the masked head and tail indices both select buffer 0, so using
@@ -22,7 +22,7 @@ Signed-off-by: Cunhao Lu <1579567540@qq.com>
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/net/can/rockchip/rockchip_canfd-tx.c b/drivers/net/can/rockchip/rockchip_canfd-tx.c
-index 86fa8f2e1c8b..fc338ea865fe 100644
+index 111111111111..222222222222 100644
 --- a/drivers/net/can/rockchip/rockchip_canfd-tx.c
 +++ b/drivers/net/can/rockchip/rockchip_canfd-tx.c
 @@ -57,8 +57,8 @@ static void rkcanfd_start_xmit_write_cmd(const struct rkcanfd_priv *priv,
@@ -37,5 +37,5 @@ index 86fa8f2e1c8b..fc338ea865fe 100644
  	rkcanfd_start_xmit_write_cmd(priv, reg_cmd);
  }
 -- 
-2.34.1
+Armbian
 

--- a/patch/kernel/archive/rockchip64-7.2/general-can-6-rockchip_canfd-serialize-TX-state-and-command-wr.patch
+++ b/patch/kernel/archive/rockchip64-7.2/general-can-6-rockchip_canfd-serialize-TX-state-and-command-wr.patch
@@ -1,8 +1,7 @@
-From d88c17cb3aa0b055cf7d652e95f5696864e60e75 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Cunhao Lu <1579567540@qq.com>
 Date: Fri, 31 Jul 2026 17:17:29 +0800
-Subject: [PATCH 3/3] can: rockchip_canfd: serialize TX state and command
- writes
+Subject: can: rockchip_canfd: serialize TX state and command writes
 
 The TX completion path removes an echo skb before advancing tx_tail. In
 parallel, the transmit path reads tx_head, tx_tail and the tail echo slot
@@ -41,14 +40,14 @@ Fixes: 83f9bd6bf39d ("can: rockchip_canfd: implement workaround for erratum 12")
 Cc: stable@vger.kernel.org
 Signed-off-by: Cunhao Lu <1579567540@qq.com>
 ---
- .../net/can/rockchip/rockchip_canfd-core.c    |  1 +
- drivers/net/can/rockchip/rockchip_canfd-rx.c  | 31 ++++++++++++++-----
- drivers/net/can/rockchip/rockchip_canfd-tx.c  | 26 ++++++++++++++--
- drivers/net/can/rockchip/rockchip_canfd.h     |  4 ++-
+ drivers/net/can/rockchip/rockchip_canfd-core.c |  1 +
+ drivers/net/can/rockchip/rockchip_canfd-rx.c   | 31 +++++++---
+ drivers/net/can/rockchip/rockchip_canfd-tx.c   | 26 +++++++-
+ drivers/net/can/rockchip/rockchip_canfd.h      |  4 +-
  4 files changed, 50 insertions(+), 12 deletions(-)
 
 diff --git a/drivers/net/can/rockchip/rockchip_canfd-core.c b/drivers/net/can/rockchip/rockchip_canfd-core.c
-index 29de0c01e4ed..c8257858b452 100644
+index 111111111111..222222222222 100644
 --- a/drivers/net/can/rockchip/rockchip_canfd-core.c
 +++ b/drivers/net/can/rockchip/rockchip_canfd-core.c
 @@ -904,6 +904,7 @@ static int rkcanfd_probe(struct platform_device *pdev)
@@ -60,7 +59,7 @@ index 29de0c01e4ed..c8257858b452 100644
  	match = device_get_match_data(&pdev->dev);
  	if (match) {
 diff --git a/drivers/net/can/rockchip/rockchip_canfd-rx.c b/drivers/net/can/rockchip/rockchip_canfd-rx.c
-index 475c0409e215..02efc8c0cddc 100644
+index 111111111111..222222222222 100644
 --- a/drivers/net/can/rockchip/rockchip_canfd-rx.c
 +++ b/drivers/net/can/rockchip/rockchip_canfd-rx.c
 @@ -100,14 +100,25 @@ static int rkcanfd_rxstx_filter(struct rkcanfd_priv *priv,
@@ -156,7 +155,7 @@ index 475c0409e215..02efc8c0cddc 100644
  }
  
 diff --git a/drivers/net/can/rockchip/rockchip_canfd-tx.c b/drivers/net/can/rockchip/rockchip_canfd-tx.c
-index fc338ea865fe..b367341dd0ae 100644
+index 111111111111..222222222222 100644
 --- a/drivers/net/can/rockchip/rockchip_canfd-tx.c
 +++ b/drivers/net/can/rockchip/rockchip_canfd-tx.c
 @@ -14,6 +14,8 @@ static bool rkcanfd_tx_tail_is_eff(const struct rkcanfd_priv *priv)
@@ -243,7 +242,7 @@ index fc338ea865fe..b367341dd0ae 100644
  	skb = priv->can.echo_skb[tx_tail];
  
 diff --git a/drivers/net/can/rockchip/rockchip_canfd.h b/drivers/net/can/rockchip/rockchip_canfd.h
-index 93131c7d7f54..3cf283a7b380 100644
+index 111111111111..222222222222 100644
 --- a/drivers/net/can/rockchip/rockchip_canfd.h
 +++ b/drivers/net/can/rockchip/rockchip_canfd.h
 @@ -15,6 +15,7 @@
@@ -272,5 +271,5 @@ index 93131c7d7f54..3cf283a7b380 100644
  netdev_tx_t rkcanfd_start_xmit(struct sk_buff *skb, struct net_device *ndev);
  void rkcanfd_handle_tx_done_one(struct rkcanfd_priv *priv, const u32 ts,
 -- 
-2.34.1
+Armbian
 

--- a/patch/kernel/archive/rockchip64-7.2/general-cryptov1-trng.patch
+++ b/patch/kernel/archive/rockchip64-7.2/general-cryptov1-trng.patch
@@ -18,7 +18,7 @@ diff --git a/drivers/crypto/Kconfig b/drivers/crypto/Kconfig
 index 111111111111..222222222222 100644
 --- a/drivers/crypto/Kconfig
 +++ b/drivers/crypto/Kconfig
-@@ -681,6 +681,14 @@ config CRYPTO_DEV_ROCKCHIP
+@@ -680,6 +680,14 @@ config CRYPTO_DEV_ROCKCHIP
  	  This driver interfaces with the hardware crypto accelerator.
  	  Supporting cbc/ecb chainmode, and aes/des/des3_ede cipher mode.
  

--- a/patch/kernel/archive/rockchip64-7.2/general-disable-mtu-validation.patch
+++ b/patch/kernel/archive/rockchip64-7.2/general-disable-mtu-validation.patch
@@ -18,7 +18,7 @@ diff --git a/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c b/drivers/net/eth
 index 111111111111..222222222222 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
-@@ -6092,27 +6092,15 @@ static void stmmac_set_rx_mode(struct net_device *dev)
+@@ -6101,27 +6101,15 @@ static void stmmac_set_rx_mode(struct net_device *dev)
  static int stmmac_change_mtu(struct net_device *dev, int new_mtu)
  {
  	struct stmmac_priv *priv = netdev_priv(dev);

--- a/patch/kernel/archive/rockchip64-7.2/rk3528-pmdomain-rockchip-fixes-for-working-usb-rk3528.patch
+++ b/patch/kernel/archive/rockchip64-7.2/rk3528-pmdomain-rockchip-fixes-for-working-usb-rk3528.patch
@@ -1,8 +1,7 @@
-From eb926f51aa584732803ebaf668440cb336875d0f Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Daniel Bozeman <daniel@orb.net>
 Date: Thu, 13 Aug 2026 11:05:07 +0200
-Subject: [PATCH 1/2] pmdomain/rockchip: skip QoS operations for idle-only
- domains
+Subject: pmdomain/rockchip: skip QoS operations for idle-only domains
 
 Idle-only power domains (pwr_mask == 0) cannot actually be powered
 on or off. rockchip_do_pmu_set_power_domain() already returns early
@@ -25,7 +24,7 @@ Signed-off-by: Ricardo Pardini <ricardo@pardini.net>
  1 file changed, 3 insertions(+)
 
 diff --git a/drivers/pmdomain/rockchip/pm-domains.c b/drivers/pmdomain/rockchip/pm-domains.c
-index 490bbb1d1d8e8..2eecae092a132 100644
+index 111111111111..222222222222 100644
 --- a/drivers/pmdomain/rockchip/pm-domains.c
 +++ b/drivers/pmdomain/rockchip/pm-domains.c
 @@ -640,6 +640,9 @@ static int rockchip_pd_power(struct rockchip_pm_domain *pd, bool power_on)
@@ -39,13 +38,12 @@ index 490bbb1d1d8e8..2eecae092a132 100644
  	if (ret < 0) {
  		dev_err(pmu->dev, "failed to enable clocks\n");
 -- 
-2.55.0
+Armbian
 
-
-From 7f7dbaba1ae860247c0fc9f19b63e1f753332840 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Daniel Bozeman <daniel@orb.net>
 Date: Thu, 13 Aug 2026 11:06:20 +0200
-Subject: [PATCH 2/2] pmdomain/rockchip: skip domains returning -EPROBE_DEFER
+Subject: pmdomain/rockchip: skip domains returning -EPROBE_DEFER
 
 When iterating child nodes during probe, a single domain returning
 -EPROBE_DEFER (e.g. due to clock dependencies not yet available)
@@ -72,7 +70,7 @@ Signed-off-by: Ricardo Pardini <ricardo@pardini.net>
  1 file changed, 5 insertions(+)
 
 diff --git a/drivers/pmdomain/rockchip/pm-domains.c b/drivers/pmdomain/rockchip/pm-domains.c
-index 2eecae092a132..f42880c94f468 100644
+index 111111111111..222222222222 100644
 --- a/drivers/pmdomain/rockchip/pm-domains.c
 +++ b/drivers/pmdomain/rockchip/pm-domains.c
 @@ -1077,6 +1077,11 @@ static int rockchip_pm_domain_probe(struct platform_device *pdev)
@@ -88,5 +86,5 @@ index 2eecae092a132..f42880c94f468 100644
  				node, error);
  			goto err_out;
 -- 
-2.55.0
+Armbian
 

--- a/patch/kernel/archive/rockchip64-7.2/rk3576-0013-mmc-sdhci-dwcmshc-rk3576-dll-tap-calibration.patch
+++ b/patch/kernel/archive/rockchip64-7.2/rk3576-0013-mmc-sdhci-dwcmshc-rk3576-dll-tap-calibration.patch
@@ -1,35 +1,47 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: crackerjacques <jack@supremeoverlordjabs.co>
-Subject: [PATCH] mmc: sdhci-of-dwcmshc: rk3576: calibrate the HS400 DLL taps
+Date: Wed, 29 Jul 2026 19:19:21 +0200
+Subject: [ARCHEOLOGY] board: anbernic-rg-vita-pro - fix eMMC HS400 timeouts
+ (rk3576 DLL calibration)
 
-On dwcmshc revision 1 the HS400 path programs fixed DLL taps (TX and
-CMDOUT at 90 degrees, STRBIN at the generic default) and never feeds the
-measured DLL lock value back into the tap-value select. The rk3576
-vendor driver does both: it reads the locked DLL value out of
-DLL_STATUS0 and supplies it as the tap-value select on every DLL clock
-line, and it uses different HS400 taps (TX 7, CMDOUT 7, STRBIN 5) plus
-BOTH_CLK_EDGE rather than EN_SRC_CLK_NEG on CMDOUT.
-
-Without that calibration the HS400 timing has very little margin on
-rk3576. On an Anbernic RG Vita Pro (rk3576, Micron eMMC in HS400-ES at
-200MHz) sustained I/O stalls with
-
-  mmc0: Timeout waiting for hardware interrupt.
-
-for CMD13/CMD18/CMD24 alike - the command or its data phase never
-completes, the block layer stalls for seconds, and a kernel compile or
-a large apt transaction grinds to a halt. Forcing the card down to
-HS200 (by dropping mmc-hs400-1_8v/mmc-hs400-enhanced-strobe from the DT)
-makes the stalls disappear entirely, which points at the HS400 timing
-rather than at the card or the filesystem: the eMMC reports a pristine
-PRE_EOL/LIFE_TIME and fsck finds nothing.
-
-revision == 1 is shared by every non-rk356x SoC (rk3576, rk3588, ...),
-so gate the calibration on a dedicated needs_hs400_dll_calibration flag
-set only for rk3576. rk3588 and the other revision-1 SoCs keep their
-existing 90-degree CMDOUT taps and STRBIN default untouched.
-
-Signed-off-by: crackerjacques <jack@supremeoverlordjabs.co>
+> X-Git-Archeology: > recovered message: > Add a dwcmshc patch that ports the vendor rk3576 HS400 DLL tap
+> X-Git-Archeology: > recovered message: > calibration (revision 1 only): read the locked DLL value from
+> X-Git-Archeology: > recovered message: > DLL_STATUS0 and feed it back as the tap-value select on every DLL clock
+> X-Git-Archeology: > recovered message: > line, use taps 7/7/5 and BOTH_CLK_EDGE on CMDOUT.
+> X-Git-Archeology: > recovered message: > Without it the mainline HS400 timing has almost no margin on this board.
+> X-Git-Archeology: > recovered message: > Under sustained I/O (kernel compile, large apt transaction) the eMMC
+> X-Git-Archeology: > recovered message: > stalls with "mmc0: Timeout waiting for hardware interrupt" on
+> X-Git-Archeology: > recovered message: > CMD13/CMD18/CMD24 and grinds to a halt. Forcing HS200 makes it vanish,
+> X-Git-Archeology: > recovered message: > which pins it on the HS400 timing rather than the card (pristine
+> X-Git-Archeology: > recovered message: > PRE_EOL/LIFE_TIME, clean fsck). With the calibration the card stays in
+> X-Git-Archeology: > recovered message: > HS400-ES at 200MHz and the timeouts are gone.
+> X-Git-Archeology: > recovered message: > Signed-off-by: crackerjacques <jack@supremeoverlordjabs.co>
+> X-Git-Archeology: - Revision 2cfa897ddbb543b22945951ede51d64e5808ff9e: https://github.com/armbian/build/commit/2cfa897ddbb543b22945951ede51d64e5808ff9e
+> X-Git-Archeology:   Date: Wed, 29 Jul 2026 19:19:21 +0200
+> X-Git-Archeology:   From: crackerjacques <jack@supremeoverlordjabs.co>
+> X-Git-Archeology:   Subject: board: anbernic-rg-vita-pro - fix eMMC HS400 timeouts (rk3576 DLL calibration)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 1095031573cb2fd6f65f2b681ebeef9f618fcffe: https://github.com/armbian/build/commit/1095031573cb2fd6f65f2b681ebeef9f618fcffe
+> X-Git-Archeology:   Date: Sat, 08 Aug 2026 18:07:08 +0200
+> X-Git-Archeology:   From: EvilOlaf <werner@armbian.com>
+> X-Git-Archeology:   Subject: rockchip64-7.2: (2/2): fix magic marker and rewrite kernel patches against 7.2
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision c1e5062ff76af81a5a32be46d897d25eb7429275: https://github.com/armbian/build/commit/c1e5062ff76af81a5a32be46d897d25eb7429275
+> X-Git-Archeology:   Date: Sat, 08 Aug 2026 18:07:08 +0200
+> X-Git-Archeology:   From: EvilOlaf <werner@armbian.com>
+> X-Git-Archeology:   Subject: rockchip64-7.2: (2/2): heavy x-git-archeology
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 6e1c7552d55f8c331a5ba9acedb3a243bcb96975: https://github.com/armbian/build/commit/6e1c7552d55f8c331a5ba9acedb3a243bcb96975
+> X-Git-Archeology:   Date: Sun, 09 Aug 2026 16:41:54 +0200
+> X-Git-Archeology:   From: crackerjacques <jack@supremeoverlordjabs.co>
+> X-Git-Archeology:   Subject: rockchip64: sdhci-dwcmshc: scope the rk3576 HS400 DLL calibration to rk3576
+> X-Git-Archeology:
 ---
+ drivers/mmc/host/sdhci-of-dwcmshc.c | 74 ++++++++--
+ 1 file changed, 65 insertions(+), 9 deletions(-)
+
+diff --git a/drivers/mmc/host/sdhci-of-dwcmshc.c b/drivers/mmc/host/sdhci-of-dwcmshc.c
+index 111111111111..222222222222 100644
 --- a/drivers/mmc/host/sdhci-of-dwcmshc.c
 +++ b/drivers/mmc/host/sdhci-of-dwcmshc.c
 @@ -117,6 +117,13 @@
@@ -162,3 +174,6 @@ Signed-off-by: crackerjacques <jack@supremeoverlordjabs.co>
  };
  
  static const struct rockchip_pltfm_data sdhci_dwcmshc_rk3588_pdata = {
+-- 
+Armbian
+

--- a/patch/kernel/archive/rockchip64-7.2/rk3588-1211-arm64-dts-rk3588s-roc-pc-Enable-HDMI-audio.patch
+++ b/patch/kernel/archive/rockchip64-7.2/rk3588-1211-arm64-dts-rk3588s-roc-pc-Enable-HDMI-audio.patch
@@ -12,7 +12,7 @@ diff --git a/arch/arm64/boot/dts/rockchip/rk3588s-roc-pc.dts b/arch/arm64/boot/d
 index 111111111111..222222222222 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3588s-roc-pc.dts
 +++ b/arch/arm64/boot/dts/rockchip/rk3588s-roc-pc.dts
-@@ -247,6 +247,10 @@ &hdptxphy0 {
+@@ -256,6 +256,10 @@ &hdptxphy0 {
  	status = "okay";
  };
  
@@ -23,7 +23,7 @@ index 111111111111..222222222222 100644
  &i2c0 {
  	pinctrl-names = "default";
  	pinctrl-0 = <&i2c0m2_xfer>;
-@@ -348,6 +352,10 @@ &i2s0_sdi0
+@@ -357,6 +361,10 @@ &i2s0_sdi0
  	status = "okay";
  };
  

--- a/patch/kernel/archive/rockchip64-7.2/rk3588-1212-arm64-dts-Automatic-fan-speed-and-USB-3.0-Type-A-por.patch
+++ b/patch/kernel/archive/rockchip64-7.2/rk3588-1212-arm64-dts-Automatic-fan-speed-and-USB-3.0-Type-A-por.patch
@@ -12,7 +12,7 @@ diff --git a/arch/arm64/boot/dts/rockchip/rk3588s-roc-pc.dts b/arch/arm64/boot/d
 index 111111111111..222222222222 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3588s-roc-pc.dts
 +++ b/arch/arm64/boot/dts/rockchip/rk3588s-roc-pc.dts
-@@ -368,7 +368,35 @@ rgmii_phy1: ethernet-phy@1 {
+@@ -377,7 +377,35 @@ rgmii_phy1: ethernet-phy@1 {
  	};
  };
  
@@ -49,7 +49,7 @@ index 111111111111..222222222222 100644
  	reset-gpios = <&gpio3 RK_PD1 GPIO_ACTIVE_HIGH>;
  	vpcie3v3-supply = <&vcc3v3_pcie20>;
  	status = "okay";
-@@ -843,6 +871,11 @@ &usb_host1_ohci {
+@@ -852,6 +880,11 @@ &usb_host1_ohci {
  	status = "okay";
  };
  

--- a/patch/kernel/archive/rockchip64-7.2/rk3588-1213-arm64-dts-rk3588s-roc-pc-Enable-USB-type-C-port.patch
+++ b/patch/kernel/archive/rockchip64-7.2/rk3588-1213-arm64-dts-rk3588s-roc-pc-Enable-USB-type-C-port.patch
@@ -12,7 +12,7 @@ diff --git a/arch/arm64/boot/dts/rockchip/rk3588s-roc-pc.dts b/arch/arm64/boot/d
 index 111111111111..222222222222 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3588s-roc-pc.dts
 +++ b/arch/arm64/boot/dts/rockchip/rk3588s-roc-pc.dts
-@@ -323,6 +323,57 @@ hym8563: rtc@51 {
+@@ -332,6 +332,57 @@ hym8563: rtc@51 {
  		pinctrl-names = "default";
  		pinctrl-0 = <&hym8563_int>;
  	};
@@ -70,7 +70,7 @@ index 111111111111..222222222222 100644
  };
  
  &i2c3 {
-@@ -444,6 +495,16 @@ typec5v_pwren: typec5v-pwren {
+@@ -453,6 +504,16 @@ typec5v_pwren: typec5v-pwren {
  			rockchip,pins = <1 RK_PB1 RK_FUNC_GPIO &pcfg_pull_none>;
  		};
  
@@ -87,7 +87,7 @@ index 111111111111..222222222222 100644
  		vcc5v0_host_en: vcc5v0-host-en {
  			rockchip,pins = <1 RK_PB6 RK_FUNC_GPIO &pcfg_pull_none>;
  		};
-@@ -859,8 +920,17 @@ &usb_host0_ohci {
+@@ -868,8 +929,17 @@ &usb_host0_ohci {
  };
  
  &usb_host0_xhci {
@@ -106,7 +106,7 @@ index 111111111111..222222222222 100644
  };
  
  &usb_host1_ehci {
-@@ -876,6 +946,32 @@ &usb_host2_xhci {
+@@ -885,6 +955,32 @@ &usb_host2_xhci {
  	dr_mode = "host";
  };
  

--- a/patch/kernel/archive/rockchip64-7.2/rk3588-1230-can-rockchip-add-rk3588-can-support.patch
+++ b/patch/kernel/archive/rockchip64-7.2/rk3588-1230-can-rockchip-add-rk3588-can-support.patch
@@ -162,7 +162,7 @@ diff --git a/drivers/net/can/rockchip/rockchip_canfd-rx.c b/drivers/net/can/rock
 index 111111111111..222222222222 100644
 --- a/drivers/net/can/rockchip/rockchip_canfd-rx.c
 +++ b/drivers/net/can/rockchip/rockchip_canfd-rx.c
-@@ -281,7 +281,10 @@ rkcanfd_rx_fifo_get_len(const struct rkcanfd_priv *priv)
+@@ -296,7 +296,10 @@ rkcanfd_rx_fifo_get_len(const struct rkcanfd_priv *priv)
  {
  	const u32 reg = rkcanfd_read(priv, RKCANFD_REG_RX_FIFO_CTRL);
  
@@ -178,7 +178,7 @@ diff --git a/drivers/net/can/rockchip/rockchip_canfd.h b/drivers/net/can/rockchi
 index 111111111111..222222222222 100644
 --- a/drivers/net/can/rockchip/rockchip_canfd.h
 +++ b/drivers/net/can/rockchip/rockchip_canfd.h
-@@ -214,7 +214,8 @@
+@@ -215,7 +215,8 @@
  #define RKCANFD_REG_TXEVENT_FIFO_CTRL_TXE_FIFO_ENABLE BIT(0)
  
  #define RKCANFD_REG_RX_FIFO_CTRL 0x118
@@ -188,7 +188,7 @@ index 111111111111..222222222222 100644
  #define RKCANFD_REG_RX_FIFO_CTRL_RX_FIFO_FULL_WATERMARK GENMASK(3, 1)
  #define RKCANFD_REG_RX_FIFO_CTRL_RX_FIFO_ENABLE BIT(0)
  
-@@ -331,6 +332,11 @@
+@@ -332,6 +333,11 @@
   * rarely with the standard clock of 300 MHz, but almost immediately
   * at 80 MHz.
   *
@@ -200,7 +200,7 @@ index 111111111111..222222222222 100644
   * To workaround this problem, check for empty FIFO with
   * rkcanfd_fifo_header_empty() in rkcanfd_handle_rx_int_one() and exit
   * early.
-@@ -344,6 +350,8 @@
+@@ -345,6 +351,8 @@
  /* Erratum 6: The CAN controller's transmission of extended frames may
   * intermittently change into standard frames
   *
@@ -209,7 +209,7 @@ index 111111111111..222222222222 100644
   * Work around this issue by activating self reception (RXSTX). If we
   * have pending TX CAN frames, check all RX'ed CAN frames in
   * rkcanfd_rxstx_filter().
-@@ -424,6 +432,9 @@
+@@ -425,6 +433,9 @@
   *     cansequence -rv -i 1
   *
   * - TX starvation after repeated Bus-Off
@@ -219,7 +219,7 @@ index 111111111111..222222222222 100644
   *   To reproduce:
   *   host:
   *     sleep 3 && cangen can0 -I2 -Li -Di -p10 -g 0.0
-@@ -434,6 +445,7 @@
+@@ -435,6 +446,7 @@
  enum rkcanfd_model {
  	RKCANFD_MODEL_RK3568V2 = 0x35682,
  	RKCANFD_MODEL_RK3568V3 = 0x35683,

--- a/patch/kernel/archive/rockchip64-7.2/rk35xx-montjoie-crypto-v2-rk35xx.patch
+++ b/patch/kernel/archive/rockchip64-7.2/rk35xx-montjoie-crypto-v2-rk35xx.patch
@@ -345,7 +345,7 @@ diff --git a/drivers/crypto/Kconfig b/drivers/crypto/Kconfig
 index 111111111111..222222222222 100644
 --- a/drivers/crypto/Kconfig
 +++ b/drivers/crypto/Kconfig
-@@ -707,6 +707,35 @@ config CRYPTO_DEV_TEGRA
+@@ -706,6 +706,35 @@ config CRYPTO_DEV_TEGRA
  	  Select this to enable Tegra Security Engine which accelerates various
  	  AES encryption/decryption and HASH algorithms.
  

--- a/patch/kernel/archive/sunxi-7.2/patches.armbian/drv-net-stmmac-dwmac-sun8i-reset-emac-on-open.patch
+++ b/patch/kernel/archive/sunxi-7.2/patches.armbian/drv-net-stmmac-dwmac-sun8i-reset-emac-on-open.patch
@@ -3,52 +3,9 @@ From: Pedro Santos <hartmnn.p@gmail.com>
 Date: Sat, 22 Aug 2026 02:00:00 -0300
 Subject: drv:net:stmmac:dwmac-sun8i: reset the EMAC when opening, not probing
 
-Orange Pi Zero 3 and other H616/H618 boards with an external PHY lose
-Ethernet after every warm reboot: "EMAC reset timeout", probe fails with
--110, and eth0 never appears. A cold boot always works.
-
-sun8i_dwmac_reset() asserts EMAC_BASIC_CTL1.SOFT_RST and polls for it to
-clear. That bit only clears once the MAC has a running receive clock,
-which on these boards is driven by the PHY.
-
-Bringing the interface down powers the PHY down: phy_detach() calls
-phy_suspend(), which for a PHY without wake-on-LAN ends in BMCR_PDOWN.
-The Zero 3 wires no reset line to its YT8531 -- the reset is an RC
-circuit, per the board's DT author -- and phy-supply is a
-regulator-always-on rail shared with four GPIO banks and the SD card. So
-nothing powers the PHY back up, and after a warm reboot it comes back
-still off.
-
-Measured on an affected board at boot, before anything touched the PHY:
-BMCR 0x1800 (PDOWN set), EMAC_BASIC_CTL1 0x08000001, still set after
-polling for ten seconds -- so raising the 100 ms timeout does not help.
-
-The driver already has the right place for the reset.
-sun8i_dwmac_dma_reset() is registered as stmmac_dma_ops->reset and is
-documented as "reset the EMAC", but only zeroes a few registers. stmmac
-calls it from stmmac_init_dma_engine(), under stmmac_hw_setup(), whose
-only two callers are __stmmac_open() and stmmac_resume() -- both of which
-run after stmmac_init_phy() has attached and resumed the PHY. Doing the
-soft reset there means the receive clock is running by construction.
-
-sun8i_dwmac_reset() is kept: Armbian's h616-internal-phy patch calls it
-from sun8i_dwmac_init(), and the mdio-mux switch callback needs a reset
-after changing the syscon.
-
-Submitted upstream:
-https://lore.kernel.org/netdev/20260822045641.19282-1-hartmnn.p@gmail.com/
-
-Tested on Orange Pi Zero 3 (H618, YT8531, rgmii-rxid), DietPi/Debian 13,
-6.18.41-current-sunxi64: five warm reboots with no EMAC reset timeout and
-the link up at 1Gbps each time, plus one cold boot with power physically
-cycled. 20000 and 5000 1472-byte frames respectively, no loss, every MAC
-error counter at zero.
-
-Not tested on internal-PHY boards (H3/H5/V3s/H616 emac1): those take the
-other branch of the probe and keep their existing reset in
-sun8i_dwmac_init(), but they now also get one in the dma reset hook.
-
-Signed-off-by: Pedro Santos <hartmnn.p@gmail.com>
+---
+ drivers/net/ethernet/stmicro/stmmac/dwmac-sun8i.c | 49 ++++++----
+ 1 file changed, 30 insertions(+), 19 deletions(-)
 
 diff --git a/drivers/net/ethernet/stmicro/stmmac/dwmac-sun8i.c b/drivers/net/ethernet/stmicro/stmmac/dwmac-sun8i.c
 index 111111111111..222222222222 100644

--- a/patch/kernel/archive/sunxi-7.2/patches.megous/fixes-7.2/0005-usb-gadget-f_fs-Init-reset_work-at-alloc-to-avoid-ki.patch
+++ b/patch/kernel/archive/sunxi-7.2/patches.megous/fixes-7.2/0005-usb-gadget-f_fs-Init-reset_work-at-alloc-to-avoid-ki.patch
@@ -30,7 +30,7 @@ index 111111111111..222222222222 100644
  /* Creates new ffs_data object. */
  static struct ffs_data *__must_check ffs_data_new(const char *dev_name)
  	__attribute__((malloc));
-@@ -2224,6 +2227,8 @@ static struct ffs_data *ffs_data_new(const char *dev_name)
+@@ -2230,6 +2233,8 @@ static struct ffs_data *ffs_data_new(const char *dev_name)
  	init_completion(&ffs->ep0req_completion);
  	INIT_WORK(&ffs->reset_work, ffs_reset_work);
  

--- a/patch/kernel/archive/sunxi-7.2/patches.megous/fixes-7.2/0009-Revert-usb-dwc3-Abort-suspend-on-soft-disconnect-fai.patch
+++ b/patch/kernel/archive/sunxi-7.2/patches.megous/fixes-7.2/0009-Revert-usb-dwc3-Abort-suspend-on-soft-disconnect-fai.patch
@@ -48,7 +48,7 @@ diff --git a/drivers/usb/dwc3/gadget.c b/drivers/usb/dwc3/gadget.c
 index 111111111111..222222222222 100644
 --- a/drivers/usb/dwc3/gadget.c
 +++ b/drivers/usb/dwc3/gadget.c
-@@ -4874,19 +4874,23 @@ int dwc3_gadget_suspend(struct dwc3 *dwc)
+@@ -4875,19 +4875,23 @@ int dwc3_gadget_suspend(struct dwc3 *dwc)
  	int ret;
  
  	ret = dwc3_gadget_soft_disconnect(dwc);

--- a/patch/kernel/archive/sunxi-7.2/patches.megous/fixes-7.2/0026-clocksource-drivers-sun4i-Never-program-a-zero-inter.patch
+++ b/patch/kernel/archive/sunxi-7.2/patches.megous/fixes-7.2/0026-clocksource-drivers-sun4i-Never-program-a-zero-inter.patch
@@ -43,15 +43,6 @@ index 111111111111..222222222222 100644
  	sun4i_clkevt_time_start(timer_of_base(to), 0, false);
  
  	ret = sun4i_clkevt_check_armed(timer_of_base(to), 0);
-@@ -341,7 +345,7 @@ static int __init sun4i_timer_init(struct device_node *node)
- 	sun4i_timer_clear_interrupt(timer_of_base(&to));
- 
- 	clockevents_config_and_register(&to.clkevt, timer_of_rate(&to),
--					TIMER_SYNC_TICKS, 0xffffffff);
-+					TIMER_SYNC_TICKS + 1, 0xffffffff);
- 
- 	/* Enable timer0 interrupt */
- 	val = readl(timer_of_base(&to) + TIMER_IRQ_EN_REG);
 -- 
 Armbian
 

--- a/patch/kernel/archive/sunxi-7.2/patches.megous/misc-7.2/0019-Bluetooth-bcm-Restore-drive_rts_on_open-true-behavio.patch
+++ b/patch/kernel/archive/sunxi-7.2/patches.megous/misc-7.2/0019-Bluetooth-bcm-Restore-drive_rts_on_open-true-behavio.patch
@@ -15,7 +15,7 @@ diff --git a/drivers/bluetooth/hci_bcm.c b/drivers/bluetooth/hci_bcm.c
 index 111111111111..222222222222 100644
 --- a/drivers/bluetooth/hci_bcm.c
 +++ b/drivers/bluetooth/hci_bcm.c
-@@ -1580,8 +1580,13 @@ static struct bcm_device_data cyw55572_device_data = {
+@@ -1581,8 +1581,13 @@ static struct bcm_device_data cyw55572_device_data = {
  	.max_autobaud_speed = 921600,
  };
  

--- a/patch/kernel/archive/sunxi-7.2/patches.megous/misc-7.2/0048-net-usb-qmi_wwan-Re-assert-DTR-after-a-bus-reset.patch
+++ b/patch/kernel/archive/sunxi-7.2/patches.megous/misc-7.2/0048-net-usb-qmi_wwan-Re-assert-DTR-after-a-bus-reset.patch
@@ -132,7 +132,7 @@ index 111111111111..222222222222 100644
  static const struct driver_info	qmi_wwan_info = {
  	.description	= "WWAN/QMI device",
  	.flags		= FLAG_WWAN | FLAG_NOMAXMTU | FLAG_SEND_ZLP,
-@@ -1610,7 +1652,7 @@ static struct usb_driver qmi_wwan_driver = {
+@@ -1611,7 +1653,7 @@ static struct usb_driver qmi_wwan_driver = {
  	.disconnect	      = qmi_wwan_disconnect,
  	.suspend	      = qmi_wwan_suspend,
  	.resume		      =	qmi_wwan_resume,


### PR DESCRIPTION
# Description

rewrite various patches against upstream
fix build for sunxi-7.2 by dropping upstreamed hunk

# How Has This Been Tested?

- [x] Build test


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added HDMI audio, USB 3.0 host, and USB-C dual-role support on the RK3588S ROC-PC.
  - Added automatic fan-speed control based on temperature.
  - Added RK3588 CAN-FD controller support and hardware random-number generation on supported Rockchip devices.
  - Added cryptographic acceleration for supported Rockchip platforms.

- **Bug Fixes**
  - Improved Orange Pi 5 audio output.
  - Improved CAN-FD reliability and transmission recovery.
  - Improved SDHCI performance on RK3576.
  - Fixed USB gadget, Bluetooth, Ethernet, timer, and modem recovery issues.
  - Improved Firefly RK3399 power, Bluetooth, Wi-Fi, and PCIe configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->