### PR TITLE
fix(rockchip64): remove conflicting rfkill node on orangepi-5-max

### DIFF
--- a/patch/kernel/archive/rockchip64-6.12/dt/rk3588-orangepi-5-max.dts
+++ b/patch/kernel/archive/rockchip64-6.12/dt/rk3588-orangepi-5-max.dts
@@ -4944,13 +4944,6 @@
 		};
 	};
 
-	rfkill {
-		compatible = "rfkill-gpio";
-		label = "rfkill-pcie-wlan";
-		radio-type = "wlan";
-		shutdown-gpios = <0x88 0x14 0x00>;
-	};
-
 	analog_sound: sound {
 		compatible = "simple-audio-card";
 		simple-audio-card,name = "Analog";


### PR DESCRIPTION
### Description
Fixes an unrecoverable Bluetooth freeze/timeout (`Opcode 0x0c03 failed: -110`) on the Orange Pi 5 Max caused by GPIO pin contention during boot.

### Context / Root Cause
In `rk3588-orangepi-5-max.dts`, a legacy top-level `rfkill` node labeled `rfkill-pcie-wlan` was assigned to `GPIO0_PC4` (pin 20) as an output. However, on the Orange Pi 5 Max, the onboard AP6611 module's Bluetooth reset line (`BT_REG_ON`) is physically wired to `GPIO0_PC4` and managed natively by the `serdev` node under `&uart7`:

```bash
fbernier@orangepi5-max ~> echo "=== Node Properties ===" && \
                              python3 -c '
                          import struct, os
                          p = "/proc/device-tree/serial@feba0000/bluetooth/"
                          for prop in ["compatible", "shutdown-gpios", "device-wakeup-gpios", "interrupts"]:
                              with open(p + prop, "rb") as f:
                                  data = f.read()
                              if prop == "compatible":
                                  print(f"{prop}: {data.decode().strip(chr(0))}")
                              elif prop == "interrupts":
                                  irq, flags = struct.unpack(">II", data)
                                  print(f"{prop}: pin index {irq}, flags 0x{flags:x}")
                              else:
                                  phandle, pin, flags = struct.unpack(">III", data)
                                  print(f"{prop}: phandle 0x{phandle:08x}, pin {pin} (RK_PC4 is pin 20), flags {flags}")
                          ' && \
                              echo -e "\n=== GPIO0 Pin Allocation in Kernel ===" && \
                              sudo cat /sys/kernel/debug/gpio | grep -E "gpio-20|gpio-21"
=== Node Properties ===
compatible: brcm,bcm43438-bt
shutdown-gpios: phandle 0x0000008f, pin 20 (RK_PC4 is pin 20), flags 0
device-wakeup-gpios: phandle 0x0000008f, pin 21 (RK_PC4 is pin 20), flags 0
interrupts: pin index 0, flags 0x2

=== GPIO0 Pin Allocation in Kernel ===
[sudo] password for fbernier:
 gpio-20  (                    |interrupt           ) in  hi IRQ
 gpio-20  (                    |shutdown            ) out hi
 gpio-21  (                    |device-wakeup       ) out hi
```

During boot, `rfkill_gpio` fails with `-EIO` (`-5`):
`gpio-532 (shutdown): gpiod_direction_output_nonotify: tried to set a GPIO tied to an IRQ as output`

This error leaves GPIO reference tracking broken, preventing the `hci_bcm` driver from hardware-toggling `BT_REG_ON`. When sleep-state framing errors or UART desyncs occur, the AP6611 hangs indefinitely in a dead state until board reboot.

Removing the redundant `rfkill` node gives `&uart7/bluetooth` exclusive ownership of the shutdown line and restores functional hardware reset recovery.

### Historical Context:

This node appears to be an artifact from bringing up the board DTS using rk3588-orangepi-5-plus.dts as a base template. On the Orange Pi 5 Plus, an M.2 E-Key slot is present where GPIO0_PC4 controls W_DISABLE1# (Wi-Fi disable) via rfkill-gpio.

On the Orange Pi 5 Max, the modular slot was replaced with the soldered AP6611 combo module, routing GPIO0_PC4 to BT_REG_ON instead. The modern &uart7/bluetooth serdev block was added for the AP6611, but the legacy top-level rfkill-pcie-wlan node was inadvertently left behind in the DTS.

### How Has This Been Tested?
- [x] Applied overlay disabling `/rfkill` on live hardware (Orange Pi 5 Max running `7.2.3-edge-rockchip64`).
- [x] Verified `rfkill_gpio: probe with driver rfkill_gpio failed with error -5` is gone from `dmesg`.
- [x] Validated that `bluetoothctl power off && bluetoothctl power on` cleanly cycles and re-enumerates the chip without `0x0c03` timeouts.

Note that I am running kernel 7.2.3 but it is my understanding that it still uses `patch/kernel/archive/rockchip64-6.12/dt/rk3588-orangepi-5-max.dts`. Let me know if I am wrong.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed the WLAN radio control device from the Orange Pi 5 Max hardware configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->