### PR TITLE
rtl8189es/fs: bump pins to c204f13 / 1c2f168

### DIFF
--- a/lib/functions/compilation/patch/drivers_network.sh
+++ b/lib/functions/compilation/patch/drivers_network.sh
@@ -51,7 +51,7 @@ driver_rtl8189ES() {
 	if linux-version compare "${version}" ge 3.14; then
 
 		# Attach to specific commit (was "branch:master")
-		local rtl8189esver='commit:6fbc1014694944629c20d9e9dd504f1ea51ddd43' # Commit date: Sep 2nd 2026 (please update when updating commit ref)
+		local rtl8189esver='commit:c204f1311040d78732c04f25a507fb3fbbf08170' # Commit date: Sep 9th 2026 (please update when updating commit ref)
 
 		display_alert "Adding" "Wireless drivers for Realtek 8189ES chipsets ${rtl8189esver}" "info"
 
@@ -95,7 +95,7 @@ driver_rtl8189FS() {
 	if linux-version compare "${version}" ge 3.14; then
 
 		# Attach to specific commit (was "branch:rtl8189fs")
-		local rtl8189fsver='commit:be148d226d22214a173e5b2dfe4287e53685ceda' # Commit date: Sep 2nd 2026 (please update when updating commit ref)
+		local rtl8189fsver='commit:1c2f16802d094e8a316b4cdac7285a6fe00ecd4f' # Commit date: Sep 9th 2026 (please update when updating commit ref)
 
 		display_alert "Adding" "Wireless drivers for Realtek 8189FS chipsets ${rtl8189fsver}" "info"
 


### PR DESCRIPTION
es 6fbc101 -> c204f13 (master), fs be148d2 -> 1c2f168 (rtl8189fs), EvilOlaf/rtl8189ES_linux.
Two fixes per branch: #5/#6 restore the cookie output parameter of the mgmt_tx path on kernels
before 7.3; #3/#4 keep the byte-count semantics of the strncpy() calls that the 7.2 compat
rewrote to strscpy(), so copied strings are no longer truncated by one character.

Build test: both drivers compiled out-of-tree against Armbian rockchip64 7.2.4 (CONFIG_RTW_DEBUG=n,
the tree's set-monitor-channel patches applied): no errors, warning counts unchanged (es 412, fs 575).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the bundled Realtek 8189ES and 8189FS wireless driver sources to newer upstream revisions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->