### PR TITLE
uwe5622: bump pin to 6eb2184 (-Wvla-larger-than 2 -> 0)

### DIFF
--- a/lib/functions/compilation/patch/drivers_network.sh
+++ b/lib/functions/compilation/patch/drivers_network.sh
@@ -538,7 +538,7 @@ driver_uwe5622() {
 	if linux-version compare "${version}" ge 5.15 && [[ "$LINUXFAMILY" == sun* || "$LINUXFAMILY" == rockchip64 || "$LINUXFAMILY" == rk35xx ]]; then
 
 		# Attach to specific commit
-		local uwe5622ver='commit:b64c5d6c36015049bdc34aad5f7b307545bfa29c' # Commit date: Sep 1, 2026 (please update when updating commit ref)
+		local uwe5622ver='commit:6eb218457c35cc4862f43a694708f74cf03370eb' # Commit date: Sep 9, 2026 (please update when updating commit ref)
 
 		display_alert "Adding" "Wireless drivers for Unisoc uwe5622 driver ${uwe5622ver}" "info"
 


### PR DESCRIPTION
b64c5d6 (Sep 1) -> 6eb2184 (Sep 9), one commit: uwe5622#21 sizes the two reply buffers in
cmdevt.c with the constant expressions their lengths already held, so gcc no longer treats them
as variable-length arrays. The driver now builds without warnings in the Armbian configuration.

Build test: the driver repository CI built it inside Armbian kernel builds for orangepizero2
current/edge/legacy and orangepi4-lts edge, all green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the Unisoc uwe5622 wireless driver to a newer upstream revision, improving access to the latest available driver fixes and updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->