### PR TITLE
fix(rockchip64): fix Bluetooth on Orange Pi 5 Max and Ultra

### DIFF
--- a/config/boards/orangepi5-max.csc
+++ b/config/boards/orangepi5-max.csc
@@ -53,37 +53,33 @@ function post_family_tweaks__orangepi5max_naming_audios() {
 }
 
 function post_family_tweaks_bsp__orangepi5max_bluetooth() {
+	[[ "$BRANCH" != "vendor" ]] && return 0
 	display_alert "$BOARD" "Installing ap6611s-bluetooth.service" "info"
 
-	# Bluetooth on this board is handled by a Broadcom (AP6611S) chip and requires
-	# a custom brcm_patchram_plus binary, plus a systemd service to run it at boot time
+	# Vendor kernels require the user-space patchram loader.
 	install -m 755 $SRC/packages/bsp/rk3399/brcm_patchram_plus_rk3399 $destination/usr/bin
 	cp $SRC/packages/bsp/rk3399/rk3399-bluetooth.service $destination/lib/systemd/system/ap6611s-bluetooth.service
 
-	# Reuse the service file, ttyS0 -> ttyS7; BCM4345C5.hcd -> SYN43711A0.hcd
+	# Adapt the shared service to the AP6611S on UART7.
 	sed -i 's/ttyS0/ttyS7/g' $destination/lib/systemd/system/ap6611s-bluetooth.service
 	sed -i 's/BCM4345C5.hcd/SYN43711A0.hcd/g' $destination/lib/systemd/system/ap6611s-bluetooth.service
 	return 0
 }
 
 function post_family_tweaks__orangepi5max_enable_bluetooth_service() {
-	# On the edge kernel, the mainline hci_bcm SerDev driver handles BT natively
-	# via the DT bluetooth node. The user-space patchram service would conflict
-	# with SerDev (both try to claim /dev/ttyS7), so we skip enabling it.
-	[[ "$BRANCH" == "edge" ]] && return 0
+	# Mainline kernels use the hci_bcm SerDev driver.
+	[[ "$BRANCH" != "vendor" ]] && return 0
 
 	display_alert "$BOARD" "Enabling ap6611s-bluetooth.service" "info"
 	chroot_sdcard systemctl enable ap6611s-bluetooth.service
 	return 0
 }
 
-# On the edge kernel, hci_bcm constructs the firmware filename from the board
-# compatible string (BCM.<board>.hcd), not from the chip name. Create a symlink
-# so the driver finds the SYN43711A0 patchram firmware.
-function post_family_tweaks__orangepi5max_bt_firmware_symlink() {
-	[[ "$BRANCH" != "edge" ]] && return 0
-	display_alert "$BOARD" "Creating BT firmware symlink for edge kernel" "info"
-	mkdir -p "$SDCARD/lib/firmware/brcm"
-	ln -sf SYN43711A0.hcd "$SDCARD/lib/firmware/brcm/BCM.xunlong,orangepi-5-max.hcd"
+# hci_bcm derives the firmware name from the board compatible string.
+function post_family_tweaks_bsp__orangepi5max_bt_firmware_symlink() {
+	[[ "$BRANCH" == "vendor" ]] && return 0
+	display_alert "$BOARD" "Creating BT firmware symlink for hci_bcm" "info"
+	mkdir -p "$destination/lib/firmware/brcm"
+	ln -sf SYN43711A0.hcd "$destination/lib/firmware/brcm/BCM.xunlong,orangepi-5-max.hcd"
 	return 0
 }

--- a/config/boards/orangepi5-ultra.csc
+++ b/config/boards/orangepi5-ultra.csc
@@ -30,37 +30,33 @@ function post_family_tweaks__orangepi5ultra_naming_audios() {
 }
 
 function post_family_tweaks_bsp__orangepi5ultra_bluetooth() {
+	[[ "$BRANCH" != "vendor" ]] && return 0
 	display_alert "$BOARD" "Installing ap6611s-bluetooth.service" "info"
 
-	# Bluetooth on this board is handled by a Broadcom (AP6611S) chip and requires
-	# a custom brcm_patchram_plus binary, plus a systemd service to run it at boot time
+	# Vendor kernels require the user-space patchram loader.
 	install -m 755 $SRC/packages/bsp/rk3399/brcm_patchram_plus_rk3399 $destination/usr/bin
 	cp $SRC/packages/bsp/rk3399/rk3399-bluetooth.service $destination/lib/systemd/system/ap6611s-bluetooth.service
 
-	# Reuse the service file, ttyS0 -> ttyS7; BCM4345C5.hcd -> SYN43711A0.hcd
+	# Adapt the shared service to the AP6611S on UART7.
 	sed -i 's/ttyS0/ttyS7/g' $destination/lib/systemd/system/ap6611s-bluetooth.service
 	sed -i 's/BCM4345C5.hcd/SYN43711A0.hcd/g' $destination/lib/systemd/system/ap6611s-bluetooth.service
 	return 0
 }
 
 function post_family_tweaks__orangepi5ultra_enable_bluetooth_service() {
-	# On the edge kernel, the mainline hci_bcm SerDev driver handles BT natively
-	# via the DT bluetooth node. The user-space patchram service would conflict
-	# with SerDev (both try to claim /dev/ttyS7), so we skip enabling it.
-	[[ "$BRANCH" == "edge" ]] && return 0
+	# Mainline kernels use the hci_bcm SerDev driver.
+	[[ "$BRANCH" != "vendor" ]] && return 0
 
 	display_alert "$BOARD" "Enabling ap6611s-bluetooth.service" "info"
 	chroot_sdcard systemctl enable ap6611s-bluetooth.service
 	return 0
 }
 
-# On the edge kernel, hci_bcm constructs the firmware filename from the board
-# compatible string (BCM.<board>.hcd), not from the chip name. Create a symlink
-# so the driver finds the SYN43711A0 patchram firmware.
-function post_family_tweaks__orangepi5ultra_bt_firmware_symlink() {
-	[[ "$BRANCH" != "edge" ]] && return 0
-	display_alert "$BOARD" "Creating BT firmware symlink for edge kernel" "info"
-	mkdir -p "$SDCARD/lib/firmware/brcm"
-	ln -sf SYN43711A0.hcd "$SDCARD/lib/firmware/brcm/BCM.xunlong,orangepi-5-ultra.hcd"
+# hci_bcm derives the firmware name from the board compatible string.
+function post_family_tweaks_bsp__orangepi5ultra_bt_firmware_symlink() {
+	[[ "$BRANCH" == "vendor" ]] && return 0
+	display_alert "$BOARD" "Creating BT firmware symlink for hci_bcm" "info"
+	mkdir -p "$destination/lib/firmware/brcm"
+	ln -sf SYN43711A0.hcd "$destination/lib/firmware/brcm/BCM.xunlong,orangepi-5-ultra.hcd"
 	return 0
 }

--- a/patch/kernel/archive/rockchip64-6.18/rk3588-1102-arm64-dts-rockchip-opi5-compact-fix-bluetooth.patch
+++ b/patch/kernel/archive/rockchip64-6.18/rk3588-1102-arm64-dts-rockchip-opi5-compact-fix-bluetooth.patch
@@ -1,0 +1,41 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Fran=C3=A7ois=20Bernier?= <frankbernier@gmail.com>
+Date: Wed, 9 Sep 2026 12:00:00 -0400
+Subject: Orange Pi 5 Max/Ultra: fix Bluetooth
+
+GPIO0_C4 is the hym8563 RTC interrupt on these boards. Disable the
+inherited WLAN rfkill node, which drives the same line as an output.
+Use the tested 1.5 Mbaud operating rate for the AP6611S on UART7.
+
+Tested on Max with Linux 7.2.4. Ultra wiring matches the official
+schematic but has not been runtime-tested.
+---
+ arch/arm64/boot/dts/rockchip/rk3588-orangepi-5-compact.dtsi | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3588-orangepi-5-compact.dtsi b/arch/arm64/boot/dts/rockchip/rk3588-orangepi-5-compact.dtsi
+index 111111111111..222222222222 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3588-orangepi-5-compact.dtsi
++++ b/arch/arm64/boot/dts/rockchip/rk3588-orangepi-5-compact.dtsi
+@@ -7,6 +7,11 @@
+ #include "rk3588-orangepi-5.dtsi"
+ 
+ / {
++	/* GPIO0_C4 is the hym8563 IRQ on compact boards. */
++	rfkill {
++		status = "disabled";
++	};
++
+ 	vcc5v0_usb30_otg: vcc5v0-usb30-otg-regulator {
+ 		compatible = "regulator-fixed";
+ 		enable-active-high;
+@@ -148,6 +153,7 @@
+ 		interrupt-parent = <&gpio0>;
+ 		interrupts = <RK_PA0 IRQ_TYPE_EDGE_FALLING>;
+ 		interrupt-names = "host-wakeup";
++		max-speed = <1500000>;
+ 		pinctrl-names = "default";
+ 		pinctrl-0 = <&bt_reg_on>, <&host_wake_bt>, <&bt_wake_host>;
+ 		shutdown-gpios = <&gpio4 RK_PC4 GPIO_ACTIVE_HIGH>;
+-- 
+Armbian

--- a/patch/kernel/archive/rockchip64-7.2/rk3588-1102-arm64-dts-rockchip-opi5-compact-fix-bluetooth.patch
+++ b/patch/kernel/archive/rockchip64-7.2/rk3588-1102-arm64-dts-rockchip-opi5-compact-fix-bluetooth.patch
@@ -1,0 +1,41 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Fran=C3=A7ois=20Bernier?= <frankbernier@gmail.com>
+Date: Wed, 9 Sep 2026 12:00:00 -0400
+Subject: Orange Pi 5 Max/Ultra: fix Bluetooth
+
+GPIO0_C4 is the hym8563 RTC interrupt on these boards. Disable the
+inherited WLAN rfkill node, which drives the same line as an output.
+Use the tested 1.5 Mbaud operating rate for the AP6611S on UART7.
+
+Tested on Max with Linux 7.2.4. Ultra wiring matches the official
+schematic but has not been runtime-tested.
+---
+ arch/arm64/boot/dts/rockchip/rk3588-orangepi-5-compact.dtsi | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3588-orangepi-5-compact.dtsi b/arch/arm64/boot/dts/rockchip/rk3588-orangepi-5-compact.dtsi
+index 111111111111..222222222222 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3588-orangepi-5-compact.dtsi
++++ b/arch/arm64/boot/dts/rockchip/rk3588-orangepi-5-compact.dtsi
+@@ -7,6 +7,11 @@
+ #include "rk3588-orangepi-5.dtsi"
+ 
+ / {
++	/* GPIO0_C4 is the hym8563 IRQ on compact boards. */
++	rfkill {
++		status = "disabled";
++	};
++
+ 	vcc5v0_usb30_otg: vcc5v0-usb30-otg-regulator {
+ 		compatible = "regulator-fixed";
+ 		enable-active-high;
+@@ -148,6 +153,7 @@
+ 		interrupt-parent = <&gpio0>;
+ 		interrupts = <RK_PA0 IRQ_TYPE_EDGE_FALLING>;
+ 		interrupt-names = "host-wakeup";
++		max-speed = <1500000>;
+ 		pinctrl-names = "default";
+ 		pinctrl-0 = <&bt_reg_on>, <&host_wake_bt>, <&bt_wake_host>;
+ 		shutdown-gpios = <&gpio4 RK_PC4 GPIO_ACTIVE_HIGH>;
+-- 
+Armbian

--- a/patch/kernel/archive/rockchip64-7.3/rk3588-1102-arm64-dts-rockchip-opi5-compact-fix-bluetooth.patch
+++ b/patch/kernel/archive/rockchip64-7.3/rk3588-1102-arm64-dts-rockchip-opi5-compact-fix-bluetooth.patch
@@ -1,0 +1,41 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Fran=C3=A7ois=20Bernier?= <frankbernier@gmail.com>
+Date: Wed, 9 Sep 2026 12:00:00 -0400
+Subject: Orange Pi 5 Max/Ultra: fix Bluetooth
+
+GPIO0_C4 is the hym8563 RTC interrupt on these boards. Disable the
+inherited WLAN rfkill node, which drives the same line as an output.
+Use the tested 1.5 Mbaud operating rate for the AP6611S on UART7.
+
+Tested on Max with Linux 7.2.4. Ultra wiring matches the official
+schematic but has not been runtime-tested.
+---
+ arch/arm64/boot/dts/rockchip/rk3588-orangepi-5-compact.dtsi | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3588-orangepi-5-compact.dtsi b/arch/arm64/boot/dts/rockchip/rk3588-orangepi-5-compact.dtsi
+index 111111111111..222222222222 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3588-orangepi-5-compact.dtsi
++++ b/arch/arm64/boot/dts/rockchip/rk3588-orangepi-5-compact.dtsi
+@@ -7,6 +7,11 @@
+ #include "rk3588-orangepi-5.dtsi"
+ 
+ / {
++	/* GPIO0_C4 is the hym8563 IRQ on compact boards. */
++	rfkill {
++		status = "disabled";
++	};
++
+ 	vcc5v0_usb30_otg: vcc5v0-usb30-otg-regulator {
+ 		compatible = "regulator-fixed";
+ 		enable-active-high;
+@@ -148,6 +153,7 @@
+ 		interrupt-parent = <&gpio0>;
+ 		interrupts = <RK_PA0 IRQ_TYPE_EDGE_FALLING>;
+ 		interrupt-names = "host-wakeup";
++		max-speed = <1500000>;
+ 		pinctrl-names = "default";
+ 		pinctrl-0 = <&bt_reg_on>, <&host_wake_bt>, <&bt_wake_host>;
+ 		shutdown-gpios = <&gpio4 RK_PC4 GPIO_ACTIVE_HIGH>;
+-- 
+Armbian


### PR DESCRIPTION
# Description

Follow-up to #10667.

Fix Bluetooth configuration for the onboard AP6611S/SYN43711 on the Orange Pi 5 Max and Orange Pi 5 Ultra.

This PR:

- disables an inherited `rfkill-gpio` node that conflicts with the RTC interrupt;
- sets the Bluetooth UART operating rate to the tested 1.5 Mbaud;
- adds one combined DTS patch to each of `rockchip64-6.18`, `rockchip64-7.2` and `rockchip64-7.3`;
- packages the mainline Bluetooth firmware aliases in the BSP, covering both new images and package upgrades;
- retains the userspace patchram loader and service for vendor kernels only.

The 6.12 DTS is unchanged by this PR.

## GPIO conflict

`rk3588-orangepi-5.dtsi` assigns GPIO0_C4 to a WLAN rfkill node:

```dts
rfkill {
   compatible = "rfkill-gpio";
   shutdown-gpios = <&gpio0 RK_PC4 GPIO_ACTIVE_HIGH>;
};
```

The shared `rk3588-orangepi-5-compact.dtsi` also assigns GPIO0_C4 to the hym8563 RTC interrupt:

```dts
&hym8563 {
   interrupt-parent = <&gpio0>;
   interrupts = <RK_PC4 IRQ_TYPE_LEVEL_LOW>;
};
```

The official schematics identify GPIO0_C4 as `RTC_INT_L`. The Bluetooth reset line is GPIO4_C4 (`BT_REG_ON`), not GPIO0_C4.

The inherited rfkill node therefore requests an output on a line the RTC needs as an interrupt input. Disable that node for the compact boards.

The RTC also supplies the Bluetooth module's 32.768 kHz LPO clock, so correct RTC initialization matters to Bluetooth.

## Bluetooth UART configuration

Set the AP6611S on UART7 to:

```dts
max-speed = <1500000>;
```

This is the operating rate used in the working configuration tested on the Max. Combined with the rfkill correction, it supports firmware loading,
controller power-on and device discovery.

The investigation encountered HCI initialization and command timeouts. However, it did not isolate a baud-rate-only failure mechanism, so this change
does not claim a fixed UART hardware ceiling or a proven clock-jitter cause.

The remaining Bluetooth resources are already correct in the upstream DTSI and are left unchanged:

- UART7 M0 RX/TX and RTS/CTS
- GPIO4_C4 active-high shutdown
- GPIO4_C5 active-high device wake
- GPIO0_A0 falling-edge host-wakeup interrupt

## Max and Ultra compatibility

The official schematics show matching relevant connections on both boards:

- Module: AP6611
- UART: UART7 M0
- RX/TX: GPIO2_B4/B5
- RTS/CTS: GPIO4_C2/C6
- Bluetooth reset: GPIO4_C4
- Host-to-Bluetooth wake: GPIO4_C5
- Bluetooth-to-host wake: GPIO0_A0
- Bluetooth LPO: RTC `32KOUT`
- RTC interrupt: GPIO0_C4

Mainline already describes both boards' Bluetooth hardware in the shared `rk3588-orangepi-5-compact.dtsi`.

The Max was runtime-tested. The Ultra wiring was checked against its official schematic, but this change has not been runtime-tested on an Ultra.

References:

- [Official Ultra schematic](https://drive.google.com/drive/folders/1fftZIgPlZFxuFWhwwb8Ma00PaSx2ugER)
- [Initial shared Max/Ultra DTSI](https://github.com/torvalds/linux/commit/c600d252dc52ffc29982ee6873b6eee064193752)
- [Upstream AP6611S Bluetooth support](https://github.com/torvalds/linux/commit/db1fefec31e79e59459c2c14fe4d42e303ef8ba3)

## BSP and branch handling

Mainline kernels use the native `hci_bcm` SerDev driver. On the tested Max, UART7 is consequently not exposed as `/dev/ttyS7` for the userspace patchram
service.

The board hooks now:

- install and enable the patchram loader/service only for `vendor`;
- package the board-specific firmware alias for non-vendor branches.

The aliases are:

```text
BCM.xunlong,orangepi-5-max.hcd -> SYN43711A0.hcd
BCM.xunlong,orangepi-5-ultra.hcd -> SYN43711A0.hcd
```

They are created under `$destination` by `post_family_tweaks_bsp`, rather than under `$SDCARD` during image creation. Existing installations therefore
receive them when upgrading the BSP package.

The target firmware is supplied by the regular Armbian firmware repository; `armbian-firmware-full` is not required.

## Relationship to #10667

#10667 changed the archived 6.12 Max DTS, based on an incorrect assumption that it was also used by the reported 7.2 system.

Armbian selects a version-specific patch directory; it does not fall back from 7.2 to 6.12. The relevant mappings in this tree are:

- `current`: `rockchip64-6.18`
- `edge`: `rockchip64-7.2`
- `bleedingedge`: `rockchip64-7.3`

This PR fixes those mainline patch sets. It leaves the previous 6.12 removal intact: that DTS also contains the RTC GPIO conflict, so restoring the node
would reintroduce it.

# How Has This Been Tested?

## Hardware

Orange Pi 5 Max running `7.2.4-edge-rockchip64`.

Applied the same two property changes directly to the installed DTB and rebooted with the user overlay disabled:

```text
user_overlays=
rfkill/status = disabled
bluetooth/max-speed = 0016e360
```

Observed on the successful boot:

- `rtc-hym8563` registered as `rtc0`; RTC reads worked.
- GPIO0_C4 was assigned to the RTC interrupt.
- `hci_bcm` detected SYN43711A0 and loaded the board-specific firmware alias.
- `hci0` reached `UP RUNNING`.
- Bluetooth discovery returned nearby devices.
- No HCI transmit timeouts or `-110` errors occurred during that boot and discovery test.

This verifies the DT changes on hardware, not a complete image built from this PR.

## Build-side checks

- [x] Combined patches parse and apply without fuzz or offsets against Linux 6.18, 7.2 and 7.3-rc2 sources.
- [x] Combined patches produce byte-identical DTSI output to the previously tested two-patch sequence.
- [x] Max and Ultra DTBs compile with the changes using the local kernel source snapshot.
- [x] Board configurations pass `bash -n`.
- [x] BSP hook/payload checks pass for both boards across vendor, current, edge and bleedingedge.
- [x] Firmware aliases survive payload archive/extraction; vendor service enablement was checked using `systemctl --root`.
- [ ] Full Armbian image/package build; `dpkg-deb` was unavailable locally.
- [ ] Orange Pi 5 Ultra runtime testing.
- [ ] Runtime testing on Linux 6.18 and 7.3.

# Checklist

- [x] Changes follow existing repository conventions.
- [x] Self-review completed.
- [x] Non-obvious GPIO conflict documented.
- [x] No additional firmware package or downstream change is required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved Bluetooth setup on Orange Pi 5 Max and Ultra boards for both vendor and mainline kernels.
  - Added mainline-kernel Bluetooth firmware support through the standard driver path.
  - Added Orange Pi 5 Compact support for simultaneous RTC and Bluetooth initialization.
  - Configured AP6611S Bluetooth communication for a maximum speed of 1.5 Mbaud across supported kernel versions.
  - Improved Bluetooth firmware handling for vendor-kernel configurations through the required system service.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->