### PR TITLE
rtl8852bs: bump pin to 643a4990 (no_printk log stubs)

### DIFF
--- a/lib/functions/compilation/patch/drivers_network.sh
+++ b/lib/functions/compilation/patch/drivers_network.sh
@@ -430,7 +430,7 @@ driver_rtl8852bs() {
 	if linux-version compare "${version}" ge 6.1 && [[ "${LINUXFAMILY}" == spacemit || "${LINUXFAMILY}" == rk35xx || "${LINUXFAMILY}" == rockchip64 ]]; then
 
 		# Attach to specific commit
-		local rtl8852bs_ver='commit:9dc6d671bc64127efee60937701f73691c8fdda8' # Commit date: Sep 4, 2026 (please update when updating commit ref)
+		local rtl8852bs_ver='commit:643a4990752ad4761c2ad216901257adfd4fd8db' # Commit date: Sep 10, 2026 (please update when updating commit ref)
 
 		display_alert "Adding" "Wireless drivers for Realtek 8852BS SDIO chipset ${rtl8852bs_ver}" "info"
 


### PR DESCRIPTION
wifi-rtl8852bs#27 merged: with CONFIG_RTW_DEBUG=n the log stubs now expand to no_printk() instead of do {} while (0), so locals used only in log calls stay referenced. Armbian config: -Wunused-variable 45 -> 0, warnings 105 -> 49 on 7.2.4. Verified out-of-tree against 7.2.4 rockchip64 with CONFIG_RTW_DEBUG=n (no new warnings) and =y (builds).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the RTL8852BS wireless driver revision included in kernel builds, incorporating a newer upstream version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->