### PR TITLE
zram-config: don't write read-only max_comp_streams on modern kernels

### DIFF
--- a/packages/bsp/common/usr/lib/armbian/armbian-zram-config
+++ b/packages/bsp/common/usr/lib/armbian/armbian-zram-config
@@ -85,7 +85,12 @@ activate_zram_swap() {
 		if [ "X${ZRAM_BACKING_DEV}" != "X" ]; then
 			echo ${ZRAM_BACKING_DEV} >/sys/block/${swap_device}/backing_dev
 		fi
-		echo -n ${ZRAM_MAX_DEVICES:=4} > /sys/block/${swap_device}/max_comp_streams
+		# max_comp_streams is a no-op since Linux 4.7 (zram always uses per-CPU
+		# streams) and the attribute is read-only / removed on modern kernels, so
+		# writing it fails the service (SIGSEGV/EACCES) even though zram is fine.
+		# Only write it where it is actually writable (old 3.x kernels).
+		[ -w /sys/block/${swap_device}/max_comp_streams ] && \
+			echo -n ${ZRAM_MAX_DEVICES:=4} > /sys/block/${swap_device}/max_comp_streams
 		echo -n ${mem_per_zram_device} > /sys/block/${swap_device}/disksize
 		echo -n ${mem_limit_per_zram_device} > /sys/block/${swap_device}/mem_limit
 		mkswap /dev/${swap_device}


### PR DESCRIPTION
`max_comp_streams` has been a no-op since Linux 4.7 (zram always uses per-CPU compression streams) and the sysfs attribute is **read-only / removed** on modern kernels. `armbian-zram-config` unconditionally writes it:

```
echo -n ${ZRAM_MAX_DEVICES:=4} > /sys/block/${swap_device}/max_comp_streams
```

On recent kernels that write fails with EACCES, which fails `armbian-zram-config.service` even though the zram swap device is created correctly (`disksize`/`mkswap`/`swapon` all run after it).

Observed on a mainline 7.2 kernel: `armbian-zram-config[...]: /usr/lib/armbian/armbian-zram-config: line 88: /sys/block/zram0/max_comp_streams: Permission denied`, service marked failed, yet `zramctl`/`swapon` show `/dev/zram0` active as swap.

Fix: guard the write with `[ -w ... ]` so it only runs where the attribute is actually writable (old 3.x kernels). No functional change to zram swap; just stops the service from failing on modern kernels (affects any board on a >=4.7 kernel).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved zram swap activation compatibility with modern kernels by avoiding writes to unavailable or read-only configuration attributes.
  - Prevented zram setup failures on systems where the compression stream setting cannot be changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->