### PR TITLE
u-boot/filogic: fix two defects in the Airoha PHY driver

### DIFF
--- a/patch/u-boot/u-boot-filogic/160-net-phy-add-support-for-Airoha-ethernet-PHY-driver.patch
+++ b/patch/u-boot/u-boot-filogic/160-net-phy-add-support-for-Airoha-ethernet-PHY-driver.patch
@@ -1015,7 +1015,7 @@ Signed-off-by: Weijie Gao <weijie.gao@mediatek.com>
 +#endif /* __EN8801S_H */
 --- a/drivers/net/phy/air_en8811h.c
 +++ b/drivers/net/phy/air_en8811h.c
-@@ -0,0 +1,725 @@
+@@ -0,0 +1,732 @@
 +// SPDX-License-Identifier: GPL-2.0
 +/*************************************************
 + * FILE NAME:  air_en8811h.c
@@ -1456,12 +1456,19 @@ Signed-off-by: Weijie Gao <weijie.gao@mediatek.com>
 +            return ret;
 +        }
 +        ret = blk_dread(mmc_get_blk_desc(mmc), 0, 0x120, firmware_buf);
-+        mmc_set_part_conf(mmc, 1, 1, 0);
++        int restore = mmc_set_part_conf(mmc, 1, 1, 0);
++        if (restore)
++            printf("[Airoha] cannot restore eMMC boot config, board may not boot.\n");
 +        if (ret != 0x120) {
 +            printf("[Airoha] cannot read firmware from eMMC.\n");
 +            free(firmware_buf);
 +            firmware_buf = NULL;
 +            return -EIO;
++        }
++        if (restore) {
++            free(firmware_buf);
++            firmware_buf = NULL;
++            return restore;
 +        }
 +#else
 +#warning EN8811H firmware loading not implemented
@@ -1566,7 +1573,7 @@ Signed-off-by: Weijie Gao <weijie.gao@mediatek.com>
 +        pbus_value = air_buckpbus_reg_read(phydev, 0x3b3c);
 +        printf("Check MD32 FW Version(0x3b3c) : %08x\n", pbus_value);
 +        printf("EN8811H initialize fail!\n");
-+        return 0;
++        return -ETIMEDOUT;
 +    }
 +    /* Mode selection*/
 +    printf("EN8811H Mode 1 !\n");
@@ -1657,8 +1664,8 @@ Signed-off-by: Weijie Gao <weijie.gao@mediatek.com>
 +                if (lpagb < 0 )
 +                    return lpagb;
 +                advgb = phy_read(phydev, MDIO_DEVAD_NONE, MII_CTRL1000);
-+                if (adv < 0 )
-+                    return adv;
++                if (advgb < 0 )
++                    return advgb;
 +                common_adv_gb = (lpagb & (advgb << 2));
 +
 +                lpa = phy_read(phydev, MDIO_DEVAD_NONE, MII_LPA);


### PR DESCRIPTION
# Description

Two defects in the Airoha PHY driver carried by the filogic U-Boot patch. The speed path tests `adv` after reading `MII_CTRL1000` into `advgb`, so a failed MDIO read gets shifted into the advertisement mask and can report a link the PHY never negotiated. The eMMC firmware loader ignores the result of the boot config restore, and a board left pointing at boot1 finds the PHY firmware there instead of BL2 on the next power cycle.

Both were found by CodeRabbit while reviewing #10678 and verified by hand.

# How Has This Been Tested?

- [x] `bananapir4` U-Boot builds clean
- [ ] Not exercised at runtime. `CONFIG_PHY_AIROHA` is off on every board in this family today, so the driver is not compiled by any of them. The same two fixes are applied to the copy in #10678, where the driver is compiled and the object links without warnings

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added U-Boot support for Airoha EN8801S and EN8811H Ethernet PHYs.
  - Added configuration options for compatible PHY hardware and firmware loading from supported UBI, eMMC boot, and raw MTD sources.
  - Added PHY initialization, link-status detection, reset support, LED and polarity configuration, and firmware handling for compatible devices.
  - Unsupported firmware sources now report an error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->