### PR TITLE
Ayn Odin 2: add SDL gamepad mappings

### DIFF
--- a/config/boards/ayn-odin2.csc
+++ b/config/boards/ayn-odin2.csc
@@ -97,6 +97,9 @@ function post_family_tweaks__ayn-odin2_enable_services() {
 
 	# Add Gamepad udev rule
 	echo 'SUBSYSTEM=="input", ATTRS{name}=="AYN Odin2 Gamepad", MODE="0666", ENV{ID_INPUT_JOYSTICK}="1"' > "${SDCARD}"/etc/udev/rules.d/99-ignore-gamepad.rules
+	# Add Gamepad SDL mapping
+	mkdir -p "${SDCARD}"/etc/environment.d
+	echo 'SDL_GAMECONTROLLERCONFIG="03000000202000000130000001000000,AYN Odin2 Gamepad,platform:Linux,crc:05b6,a:b0,b:b1,x:b3,y:b2,back:b6,guide:b8,start:b7,leftstick:b9,rightstick:b10,leftshoulder:b4,rightshoulder:b5,dpup:b11,dpdown:b12,dpleft:b13,dpright:b14,misc1:b15,leftx:a0,lefty:a1,rightx:a3,righty:a4,lefttrigger:a2,righttrigger:a5,"' > "${SDCARD}"/etc/environment.d/99-sdl-gamepad.conf
 	# Not Any driver support suspend mode
 	chroot_sdcard systemctl mask suspend.target
 


### PR DESCRIPTION
# Description

Without this, SDL-based programs assume an incorrect gamepad layout, with the X and Y buttons being swapped.

I would assume that this is a problem with the `rsinput` kernel driver, but online gamepad testers map the gamepad perfectly, suggesting that it is not the root problem.

This was tested on an Odin 2 Mini; I do not have access to an Odin 2 Portal or regular Odin 2.

# How Has This Been Tested?

By running RetroArch (with its 'sdl2' controller driver), Sonic Unleashed Recompiled, and ClownMDEmu; all use SDL as a controller backend, so they benefit from this change.

For instance, in ClownMDEmu, the menu bar is accessed by pressing the X button, as is normal for a Dear ImGui UI; previously, it was accessed by the Y button instead, which is incorrect.

[hardwaretester.com](hardwaretester.com) still reports a correct controller layout, so browser support has not been broken by this change.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved AYN Odin2 gamepad support with additional SDL mapping configuration for more reliable controller recognition.
  * Preserved existing device permission handling and joystick identification behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->