### PR TITLE
SpacemiT K1: Disable CSI by default on BPI-F3 and MusePI Pro

### DIFF
--- a/patch/kernel/archive/spacemit-6.18/dt/k1-bananapi-f3.dts
+++ b/patch/kernel/archive/spacemit-6.18/dt/k1-bananapi-f3.dts
@@ -194,7 +194,7 @@
 	pwdn-gpios = <&gpio 113 0>;
 	reset-gpios = <&gpio 111 0>;
 
-	status = "okay";
+	status = "disabled";
 };
 
 &backsensor_aux {
@@ -206,44 +206,39 @@
 
 &ccic0 {
 	power-domains = <&power K1X_PMU_ISP_PWR_DOMAIN>;
-
-	status = "okay";
+	status = "disabled";
 };
 
 &ccic1 {
 	power-domains = <&power K1X_PMU_ISP_PWR_DOMAIN>;
-
-	status = "okay";
+	status = "disabled";
 };
 
 &ccic2 {
 	power-domains = <&power K1X_PMU_ISP_PWR_DOMAIN>;
-
-	status = "okay";
-};
-
-&csiphy0 {
-
-	status = "okay";
+	status = "disabled";
 };
 
 &combphy {
 	status = "okay";
 };
 
-&csiphy1 {
+&csiphy0 {
+	status = "disabled";
+};
 
+&csiphy1 {
 	status = "disabled";
 };
 
 &csiphy2 {
 	spacemit,bifmode-enable;
-
-	status = "okay";
+	status = "disabled";
 };
 
 &cpp {
 	power-domains = <&power K1X_PMU_ISP_PWR_DOMAIN>;
+	status = "disabled";
 };
 
 &dpu_online2_dsi {
@@ -725,6 +720,7 @@
 
 &isp {
 	power-domains = <&power K1X_PMU_ISP_PWR_DOMAIN>;
+	status = "disabled";
 };
 
 &lcds {
@@ -1174,4 +1170,5 @@
 
 &vi {
 	power-domains = <&power K1X_PMU_ISP_PWR_DOMAIN>;
+	status = "disabled";
 };

--- a/patch/kernel/archive/spacemit-6.18/dt/k1-musepi-pro.dts
+++ b/patch/kernel/archive/spacemit-6.18/dt/k1-musepi-pro.dts
@@ -185,7 +185,7 @@
 
 	mclk-disable;
 
-	status = "okay";
+	status = "disabled";
 };
 
 /* MIPI CSI3 data line2,3 clk lane2 */
@@ -210,20 +210,17 @@
 
 &ccic0 {
 	power-domains = <&power K1X_PMU_ISP_PWR_DOMAIN>;
-
-	status = "okay";
+	status = "disabled";
 };
 
 &ccic1 {
 	power-domains = <&power K1X_PMU_ISP_PWR_DOMAIN>;
-
-	status = "okay";
+	status = "disabled";
 };
 
 &ccic2 {
 	power-domains = <&power K1X_PMU_ISP_PWR_DOMAIN>;
-
-	status = "okay";
+	status = "disabled";
 };
 
 &combphy {
@@ -232,11 +229,12 @@
 
 &cpp {
 	power-domains = <&power K1X_PMU_ISP_PWR_DOMAIN>;
+	status = "disabled";
 };
 
 &csiphy0 {
 
-	status = "okay";
+	status = "disabled";
 };
 
 &csiphy1 {
@@ -246,7 +244,7 @@
 
 &csiphy2 {
 	spacemit,bifmode-enable;
-	status = "okay";
+	status = "disabled";
 };
 
 &dpu_online2_dsi {
@@ -370,7 +368,7 @@
 	pinctrl-names = "default";
 	pinctrl-0 = <&pinctrl_camera1>;
 
-	status = "okay";
+	status = "disabled";
 };
 
 &gpio{
@@ -770,6 +768,7 @@
 
 &isp {
 	power-domains = <&power K1X_PMU_ISP_PWR_DOMAIN>;
+	status = "disabled";
 };
 
 &otg {
@@ -1188,4 +1187,5 @@
 
 &vi {
 	power-domains = <&power K1X_PMU_ISP_PWR_DOMAIN>;
+	status = "disabled";
 };

--- a/patch/kernel/archive/spacemit-6.18/overlay/Makefile
+++ b/patch/kernel/archive/spacemit-6.18/overlay/Makefile
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: GPL-2.0
 dtbo-$(CONFIG_SOC_SPACEMIT_K1X) += \
 	k1-can0.dtbo \
+	k1-csi.dtbo \
 	k1-i2c3.dtbo \
 	k1-i2c4.dtbo \
 	k1-lcd.dtbo \

--- a/patch/kernel/archive/spacemit-6.18/overlay/k1-csi.dts
+++ b/patch/kernel/archive/spacemit-6.18/overlay/k1-csi.dts
@@ -1,0 +1,76 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "spacemit,k1-x";
+
+	fragment@0 {
+		target = <&backsensor>;
+		__overlay__ {
+			status = "okay";
+		};
+	};
+
+	fragment@1 {
+		target = <&ccic0>;
+		__overlay__ {
+			status = "okay";
+		};
+	};
+
+	fragment@2 {
+		target = <&ccic1>;
+		__overlay__ {
+			status = "okay";
+		};
+	};
+
+	fragment@3 {
+		target = <&ccic2>;
+		__overlay__ {
+			status = "okay";
+		};
+	};
+
+	fragment@4 {
+		target = <&cpp>;
+		__overlay__ {
+			status = "okay";
+		};
+	};
+
+	fragment@5 {
+		target = <&csiphy0>;
+		__overlay__ {
+			status = "okay";
+		};
+	};
+
+	fragment@6 {
+		target = <&csiphy2>;
+		__overlay__ {
+			status = "okay";
+		};
+	};
+
+	fragment@7 {
+		target = <&frontsensor>;
+		__overlay__ {
+			status = "okay";
+		};
+	};
+
+	fragment@8 {
+		target = <&isp>;
+		__overlay__ {
+			status = "okay";
+		};
+	};
+
+	fragment@9 {
+		target = <&vi>;
+		__overlay__ {
+			status = "okay";
+		};
+	};
+};

--- a/patch/kernel/archive/spacemit-6.6/dt/k1-bananapi-f3.dts
+++ b/patch/kernel/archive/spacemit-6.6/dt/k1-bananapi-f3.dts
@@ -169,7 +169,7 @@
 
 		bt_pwrseq: bt-pwrseq {
 			compatible = "spacemit,bt-pwrseq";
-			reset-gpios = <&gpio 63 GPIO_ACTIVE_LOW>;
+			reset-gpios = <&gpio 63 GPIO_ACTIVE_HIGH>;
 		};
 	};
 

--- a/patch/kernel/archive/spacemit-6.6/dt/k1-bananapi-f3.dts
+++ b/patch/kernel/archive/spacemit-6.6/dt/k1-bananapi-f3.dts
@@ -169,7 +169,7 @@
 
 		bt_pwrseq: bt-pwrseq {
 			compatible = "spacemit,bt-pwrseq";
-			reset-gpios = <&gpio 63 GPIO_ACTIVE_HIGH>;
+			reset-gpios = <&gpio 63 GPIO_ACTIVE_LOW>;
 		};
 	};
 
@@ -194,7 +194,7 @@
 	pwdn-gpios = <&gpio 113 0>;
 	reset-gpios = <&gpio 111 0>;
 
-	status = "okay";
+	status = "disabled";
 };
 
 &backsensor_aux {
@@ -206,44 +206,39 @@
 
 &ccic0 {
 	power-domains = <&power K1X_PMU_ISP_PWR_DOMAIN>;
-
-	status = "okay";
+	status = "disabled";
 };
 
 &ccic1 {
 	power-domains = <&power K1X_PMU_ISP_PWR_DOMAIN>;
-
-	status = "okay";
+	status = "disabled";
 };
 
 &ccic2 {
 	power-domains = <&power K1X_PMU_ISP_PWR_DOMAIN>;
-
-	status = "okay";
-};
-
-&csiphy0 {
-
-	status = "okay";
+	status = "disabled";
 };
 
 &combphy {
 	status = "okay";
 };
 
-&csiphy1 {
+&csiphy0 {
+	status = "disabled";
+};
 
+&csiphy1 {
 	status = "disabled";
 };
 
 &csiphy2 {
 	spacemit,bifmode-enable;
-
-	status = "okay";
+	status = "disabled";
 };
 
 &cpp {
 	power-domains = <&power K1X_PMU_ISP_PWR_DOMAIN>;
+	status = "disabled";
 };
 
 &dpu_online2_dsi {
@@ -725,6 +720,7 @@
 
 &isp {
 	power-domains = <&power K1X_PMU_ISP_PWR_DOMAIN>;
+	status = "disabled";
 };
 
 &lcds {
@@ -1174,4 +1170,5 @@
 
 &vi {
 	power-domains = <&power K1X_PMU_ISP_PWR_DOMAIN>;
+	status = "disabled";
 };

--- a/patch/kernel/archive/spacemit-6.6/dt/k1-musepi-pro.dts
+++ b/patch/kernel/archive/spacemit-6.6/dt/k1-musepi-pro.dts
@@ -185,7 +185,7 @@
 
 	mclk-disable;
 
-	status = "okay";
+	status = "disabled";
 };
 
 /* MIPI CSI3 data line2,3 clk lane2 */
@@ -210,20 +210,17 @@
 
 &ccic0 {
 	power-domains = <&power K1X_PMU_ISP_PWR_DOMAIN>;
-
-	status = "okay";
+	status = "disabled";
 };
 
 &ccic1 {
 	power-domains = <&power K1X_PMU_ISP_PWR_DOMAIN>;
-
-	status = "okay";
+	status = "disabled";
 };
 
 &ccic2 {
 	power-domains = <&power K1X_PMU_ISP_PWR_DOMAIN>;
-
-	status = "okay";
+	status = "disabled";
 };
 
 &combphy {
@@ -232,11 +229,12 @@
 
 &cpp {
 	power-domains = <&power K1X_PMU_ISP_PWR_DOMAIN>;
+	status = "disabled";
 };
 
 &csiphy0 {
 
-	status = "okay";
+	status = "disabled";
 };
 
 &csiphy1 {
@@ -246,7 +244,7 @@
 
 &csiphy2 {
 	spacemit,bifmode-enable;
-	status = "okay";
+	status = "disabled";
 };
 
 &dpu_online2_dsi {
@@ -370,7 +368,7 @@
 	pinctrl-names = "default";
 	pinctrl-0 = <&pinctrl_camera1>;
 
-	status = "okay";
+	status = "disabled";
 };
 
 &gpio{
@@ -770,6 +768,7 @@
 
 &isp {
 	power-domains = <&power K1X_PMU_ISP_PWR_DOMAIN>;
+	status = "disabled";
 };
 
 &otg {
@@ -1188,4 +1187,5 @@
 
 &vi {
 	power-domains = <&power K1X_PMU_ISP_PWR_DOMAIN>;
+	status = "disabled";
 };

--- a/patch/kernel/archive/spacemit-6.6/overlay/Makefile
+++ b/patch/kernel/archive/spacemit-6.6/overlay/Makefile
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: GPL-2.0
 dtbo-$(CONFIG_ARCH_RV64I) += \
 	k1-can0.dtbo \
+	k1-csi.dtbo \
 	k1-i2c3.dtbo \
 	k1-i2c4.dtbo \
 	k1-lcd.dtbo \

--- a/patch/kernel/archive/spacemit-6.6/overlay/k1-csi.dts
+++ b/patch/kernel/archive/spacemit-6.6/overlay/k1-csi.dts
@@ -1,0 +1,76 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "spacemit,k1-x";
+
+	fragment@0 {
+		target = <&backsensor>;
+		__overlay__ {
+			status = "okay";
+		};
+	};
+
+	fragment@1 {
+		target = <&ccic0>;
+		__overlay__ {
+			status = "okay";
+		};
+	};
+
+	fragment@2 {
+		target = <&ccic1>;
+		__overlay__ {
+			status = "okay";
+		};
+	};
+
+	fragment@3 {
+		target = <&ccic2>;
+		__overlay__ {
+			status = "okay";
+		};
+	};
+
+	fragment@4 {
+		target = <&cpp>;
+		__overlay__ {
+			status = "okay";
+		};
+	};
+
+	fragment@5 {
+		target = <&csiphy0>;
+		__overlay__ {
+			status = "okay";
+		};
+	};
+
+	fragment@6 {
+		target = <&csiphy2>;
+		__overlay__ {
+			status = "okay";
+		};
+	};
+
+	fragment@7 {
+		target = <&frontsensor>;
+		__overlay__ {
+			status = "okay";
+		};
+	};
+
+	fragment@8 {
+		target = <&isp>;
+		__overlay__ {
+			status = "okay";
+		};
+	};
+
+	fragment@9 {
+		target = <&vi>;
+		__overlay__ {
+			status = "okay";
+		};
+	};
+};


### PR DESCRIPTION
Camera Serial Interface
* Can be enabled via overlay k1-csi


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a camera/CSI device-tree overlay for K1-X platforms, allowing camera and image-processing hardware to be enabled when needed.
  * Included the new overlay in supported platform builds.

* **Bug Fixes**
  * Camera and image-processing components are now disabled by default on BananaPi F3 and MusePi Pro boards.
  * Corrected Bluetooth reset GPIO polarity in the 6.6 BananaPi F3 configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->