### PR TITLE
gl-mt2500-v2: stop shipping Airoha firmware in the BSP

### DIFF
--- a/config/boards/gl-mt2500-v2.csc
+++ b/config/boards/gl-mt2500-v2.csc
@@ -13,37 +13,6 @@ SRC_EXTLINUX="yes"
 SRC_CMDLINE="console=ttyS0,115200n8 rootwait rootdelay=10 cgroup_enable cgroup_memory=1 init=/sbin/init"
 HAS_VIDEO_OUTPUT="no"
 
-function post_family_tweaks_bsp__gl_mt2500_v2_airoha_firmware() {
-	display_alert "Adding to bsp-cli" "${BOARD}: Airoha EN8811H firmware" "info"
-	local firmware_commit="458e40fdbb4dad5134ec230a42df21aea1b5baf8"
-	local firmware_base_url="https://gitlab.com/api/v4/projects/48890189/repository/files"
-	local firmware_destination="${destination}/lib/firmware/airoha"
-	local license_destination="${destination}/usr/share/doc/armbian-bsp-cli-gl-mt2500-v2"
-	local -a firmware_names=("EthMD32.dm.bin" "EthMD32.DSP.bin")
-	local -a firmware_sha256=(
-		"874982b88330112c376e484cdce114cf2e1476ccbb901c87f80882f127ffb90f"
-		"3e4699ec709c836d5fce7c91bc5d205beb54aea326c4b70c7050b355784cbebd"
-	)
-	local index firmware_file
-
-	run_host_command_logged mkdir -pv "${firmware_destination}" "${license_destination}"
-	for index in "${!firmware_names[@]}"; do
-		firmware_file="${firmware_destination}/${firmware_names[index]}"
-		run_host_command_logged curl -fLo "${firmware_file}" --retry 5 --retry-all-errors \
-			--retry-delay 2 --connect-timeout 30 --max-time 300 \
-			"${firmware_base_url}/airoha%2F${firmware_names[index]}/raw?ref=${firmware_commit}"
-		echo "${firmware_sha256[index]}  ${firmware_file}" | sha256sum -c - || \
-			exit_with_error "Checksum validation failed for ${firmware_names[index]}"
-	done
-
-	local license_file="${license_destination}/LICENSE.airoha"
-	run_host_command_logged curl -fLo "${license_file}" --retry 5 --retry-all-errors \
-		--retry-delay 2 --connect-timeout 30 --max-time 300 \
-		"${firmware_base_url}/LICENSES%2FLICENSE.airoha/raw?ref=${firmware_commit}"
-	echo "ad548ca0ffb91ec655de0f28e13089ef1cd4e0deabb2f15a9289194990e62252  ${license_file}" | \
-		sha256sum -c - || exit_with_error "Checksum validation failed for LICENSE.airoha"
-}
-
 function post_family_tweaks_bsp__gl_mt2500_v2_airoha_firmware_in_initrd() {
 	display_alert "Adding to bsp-cli" "${BOARD}: Airoha EN8811H firmware in initrd" "info"
 	declare file_added_to_bsp_destination


### PR DESCRIPTION
## What is broken

Every `Gl-mt2500-v2` image build fails when dpkg unpacks the BSP:

```
dpkg: error processing archive armbian-bsp-cli-gl-mt2500-v2-edge_26.11.0-trunk.44_arm64...deb (--unpack):
 trying to overwrite '/lib/firmware/airoha/EthMD32.dm.bin',
 which is also in package armbian-firmware (26.11.0-trunk.44)
```

Seen in [armbian/ci run 34548029496](https://github.com/armbian/ci/actions/runs/34548029496/job/103608649328) (`Gl-mt2500-v2_trixie_edge_6.16.y_minimal`).

## Why

Two packages started claiming the same paths, six days apart:

| date | event |
| --- | --- |
| 2026-09-04 | #10598 adds this board, whose config downloads `airoha/EthMD32.{dm,DSP}.bin` into the bsp-cli package |
| 2026-09-10 | armbian/firmware `2a9e1c19` — *"airoha: add EN8811H 2.5G PHY firmware"* — adds the same two files to `armbian-firmware` |

`armbian-firmware` is installed first, so the BSP unpack is the one that dies. dpkg will not let two packages own a path, and neither declares a `Replaces:`.

Nothing was wrong with the board config when it was written — the firmware simply moved into the shared package six days later.

## Fix

Drop the whole download hook: both the firmware and the licence text.

- `armbian-firmware` provides the firmware now.
- The licence belongs with whoever ships the blobs, not with a board package that no longer does.
- It also removes this board's build-time dependency on a GitLab API endpoint (two `curl` fetches plus sha256 checks that had to be kept in step with an external repo).

The **initramfs hook is unchanged** and still does `add_firmware "airoha/EthMD32.dm.bin"` / `.DSP.bin`; those files now come from `armbian-firmware`, which is installed before the BSP, so the hook still resolves them.

Net: 8 insertions, 30 deletions.

`gl-mt2500-v2` is the only board config that shipped airoha firmware (`grep -rln airoha config/boards/`), so nothing else needs the same treatment.

## Two follow-ups, deliberately not in here

1. `armbian/firmware` ships the EN8811H blobs **without** a `LICENSE.airoha` (it is not in that repo's `LICENSES/`). Since this board package no longer carries it either, the licence text is now absent from images. Adding it to armbian/firmware alongside the blobs would be the right home.
2. The initramfs hook calls `add_firmware` without `|| true`, whereas #10678 (BPi R3 Mini) uses `|| true` for the same two files. Now that the firmware comes from a separate package, a system without `armbian-firmware` would fail `update-initramfs` on every kernel upgrade rather than warn. Worth aligning.

Signed-off-by: Igor Pecovnik <igor@armbian.com>