### PR TITLE
luckfox-rk3308b-nova: use bootph-all for the SPL console

### DIFF
--- a/patch/u-boot/v2026.07/board_luckfox-rk3308b-nova/add-board-luckfox-rk3308b-nova.patch
+++ b/patch/u-boot/v2026.07/board_luckfox-rk3308b-nova/add-board-luckfox-rk3308b-nova.patch
@@ -17,7 +17,7 @@ index 00000000000..c515003d25b
 +};
 +
 +&uart4 {
-+	u-boot,dm-pre-reloc;
++	bootph-all;
 +	clock-frequency = <24000000>;
 +	status = "okay";
 +};


### PR DESCRIPTION
# Description

The Luckfox Nova image (26.8.1 and current main) reset-loops in the SPL with `No serial driver found`.

U-Boot dropped the pre-schema `u-boot,dm-*` tags in [6d04828b4520](https://github.com/u-boot/u-boot/commit/6d04828b4520) ("dm: Remove pre-schema tag support", for v2026.01). The v2026.07 bump (2305d98df) left `&uart4` in `rk3308-luckfox-nova-u-boot.dtsi` on `u-boot,dm-pre-reloc`, so fdtgrep no longer keeps the node in the SPL device tree, `stdout-path = "serial4"` resolves to nothing, and the SPL panics before loading U-Boot proper.

Switch the node to `bootph-all`, as `rk3308-rock-pi-s-u-boot.dtsi` does for the same purpose. One line; no other board patch under `patch/u-boot/v2026.07/` for this board uses the old tags.

Fixes #10476

# How Has This Been Tested?

- [x] Diagnosis and the identical one-line fix verified on hardware by the reporter (extracted SPL DTB before/after, board boots to userspace) — see the issue.
- [x] `git cherry` against `upstream/main`: the branch is a single commit on top of current main.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added U-Boot support for the Luckfox Nova RK3308B board.
  * Enabled board initialization and boot support for storage, UART, USB, PWM, regulators, and analog input hardware.
  * Configured the board’s SPL boot order and UART4 for early boot communication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->